### PR TITLE
perf(pr-validation): reduce deterministic restore overhead

### DIFF
--- a/gamesymbol_snapshot_lib/operations.py
+++ b/gamesymbol_snapshot_lib/operations.py
@@ -271,7 +271,7 @@ def load_snapshot_context(snapshot_path, config_path, game_version, bindir, requ
     return SnapshotContext(document, raw, contract)
 
 
-def _atomic_write(path: Path, data: bytes) -> None:
+def _atomic_write(path: Path, data: bytes, *, durable: bool = True) -> None:
     path.parent.mkdir(parents=True, exist_ok=True)
     temporary = None
     try:
@@ -279,7 +279,8 @@ def _atomic_write(path: Path, data: bytes) -> None:
             temporary = Path(handle.name)
             handle.write(data)
             handle.flush()
-            os.fsync(handle.fileno())
+            if durable:
+                os.fsync(handle.fileno())
         os.replace(temporary, path)
     finally:
         if temporary and temporary.exists():
@@ -326,12 +327,12 @@ def _delete_yaml_tree(game_root: Path) -> None:
         path.unlink()
 
 
-def _write_document_files(contract, document: dict, overwrite: bool) -> None:
+def _write_document_files(contract, document: dict, overwrite: bool, *, durable: bool = True) -> None:
     for key, payload in document["files"].items():
         target = path_from_key(contract.game_root, key)
         if target.exists() and not overwrite:
             continue
-        _atomic_write(target, canonical_yaml_bytes(payload))
+        _atomic_write(target, canonical_yaml_bytes(payload), durable=durable)
 
 
 def _round_trip_document(document: dict, game_version: str, config_path) -> bytes:
@@ -340,7 +341,7 @@ def _round_trip_document(document: dict, game_version: str, config_path) -> byte
         bindir = Path(temp_dir) / "bin"
         contract = load_contract(config_path, game_version, bindir, digest_version)
         ensure_real_tree(bindir, contract.game_root)
-        _write_document_files(contract, document, overwrite=True)
+        _write_document_files(contract, document, overwrite=True, durable=False)
         actual = build_actual_document(
             contract,
             schema_version=document["schema_version"],

--- a/gamesymbol_snapshot_lib/pr_cli.py
+++ b/gamesymbol_snapshot_lib/pr_cli.py
@@ -11,7 +11,7 @@ from gamesymbol_snapshot_lib.config import LATEST_CONFIG_DIGEST_VERSION, load_co
 from gamesymbol_snapshot_lib.model import ChangedPath, SnapshotContext
 from gamesymbol_snapshot_lib.operations import load_snapshot_context
 from gamesymbol_snapshot_lib.paths import ensure_real_tree, path_from_key
-from gamesymbol_snapshot_lib.pr_validation import build_invalidation_plan
+from gamesymbol_snapshot_lib.pr_validation import build_invalidation_plan, required_source_index_sides
 
 
 def parse_args(argv=None):
@@ -83,7 +83,7 @@ def _changed_paths(base_ref: str, head_ref: str, repo_root: Path) -> list[Change
 
 def _revision_sources(ref: str, repo_root: Path) -> dict[str, str]:
     result = subprocess.run(
-        ["git", "archive", "--format=tar", ref, "--", "ida_preprocessor_scripts"],
+        ["git", "archive", "--format=tar", ref, "--", "ida_preprocessor_scripts/*.py"],
         cwd=repo_root,
         capture_output=True,
         check=False,
@@ -139,6 +139,9 @@ def _run(args) -> None:
     base = load_snapshot_context(args.basesnapshot, args.baseconfigyaml, args.gamever, args.bindir)
     head = _load_head_context(head_snapshot, args.headconfigyaml, args.gamever, args.bindir, base)
     changes = _changed_paths(args.baseref, args.headref, repo_root)
+    needs_base_sources, needs_head_sources = required_source_index_sides(changes)
+    base_sources = _revision_sources(args.baseref, repo_root) if needs_base_sources else {}
+    head_sources = _revision_sources(args.headref, repo_root) if needs_head_sources else {}
     plan = build_invalidation_plan(
         base.contract,
         head.contract,
@@ -146,8 +149,8 @@ def _run(args) -> None:
         head.document,
         changes,
         repo_root,
-        base_sources=_revision_sources(args.baseref, repo_root),
-        head_sources=_revision_sources(args.headref, repo_root),
+        base_sources=base_sources,
+        head_sources=head_sources,
     )
     deleted = _delete_paths(head.contract, plan.paths)
     for reason in plan.reasons:

--- a/gamesymbol_snapshot_lib/pr_validation.py
+++ b/gamesymbol_snapshot_lib/pr_validation.py
@@ -109,6 +109,13 @@ def _is_preprocessor(path: str | None) -> bool:
     return bool(path and path.startswith(PREPROCESSOR_PREFIX) and path.endswith(".py"))
 
 
+def required_source_index_sides(changed_files: list[str | ChangedPath]) -> tuple[bool, bool]:
+    changes = _normalize_changes(changed_files)
+    needs_base = any(_is_reference(_base_path(change)) or _is_preprocessor(_base_path(change)) for change in changes)
+    needs_head = any(_is_reference(_head_path(change)) or _is_preprocessor(_head_path(change)) for change in changes)
+    return needs_base, needs_head
+
+
 def _format_consumers(consumers: set[ReferenceConsumer]) -> str:
     return ",".join(sorted(consumer.label for consumer in consumers)) or "none"
 
@@ -202,16 +209,10 @@ def _source_changed_nodes(
     reasons = []
     base_by_skill = _skill_nodes(base_contract)
     head_by_skill = _skill_nodes(head_contract)
-    needs_source_index = any(
-        _is_reference(change.old_path)
-        or _is_reference(change.new_path)
-        or _is_preprocessor(change.old_path)
-        or _is_preprocessor(change.new_path)
-        for change in changes
-    )
+    needs_base_index, needs_head_index = required_source_index_sides(changes)
     empty_index = AnalysisSourceIndex((), {})
-    base_index = AnalysisSourceIndex.build(base_sources, "base") if needs_source_index else empty_index
-    head_index = AnalysisSourceIndex.build(head_sources, "HEAD") if needs_source_index else empty_index
+    base_index = AnalysisSourceIndex.build(base_sources, "base") if needs_base_index else empty_index
+    head_index = AnalysisSourceIndex.build(head_sources, "HEAD") if needs_head_index else empty_index
     for change in changes:
         broad_paths = {path for path in (change.old_path, change.new_path) if path in BROAD_ANALYSIS_FILES}
         if broad_paths:
@@ -298,10 +299,15 @@ def build_invalidation_plan(
 ) -> InvalidationPlan:
     repo_root = Path(repo_root)
     changes = _normalize_changes(changed_files)
-    if base_sources is None or head_sources is None:
+    needs_base_sources, needs_head_sources = required_source_index_sides(changes)
+    missing_base_sources = needs_base_sources and base_sources is None
+    missing_head_sources = needs_head_sources and head_sources is None
+    if missing_base_sources or missing_head_sources:
         workspace_sources = workspace_python_sources(repo_root)
-        base_sources = workspace_sources if base_sources is None else base_sources
-        head_sources = workspace_sources if head_sources is None else head_sources
+        base_sources = workspace_sources if missing_base_sources else base_sources
+        head_sources = workspace_sources if missing_head_sources else head_sources
+    base_sources = {} if base_sources is None else base_sources
+    head_sources = {} if head_sources is None else head_sources
     delta_paths = _snapshot_delta(base_snapshot, head_snapshot)
     seed_nodes = _owners_for_paths(base_contract, delta_paths)
     seed_nodes.update(_owners_for_paths(head_contract, delta_paths))

--- a/gamesymbols/14175.yaml
+++ b/gamesymbols/14175.yaml
@@ -44536,5 +44536,5 @@ files:
     vtable_symbol: ??_7CVPhys2World@@6B@
     vtable_va: '0x1803c57d0'
 game_version: '14175'
-last_publish_time: '2026-08-19T07:05:36Z'
+last_publish_time: '2026-08-20T16:24:42Z'
 schema_version: 5

--- a/tests/test_gamesymbol_pr_cli.py
+++ b/tests/test_gamesymbol_pr_cli.py
@@ -1,12 +1,14 @@
 import subprocess
 import unittest
 from pathlib import Path
+from types import SimpleNamespace
 from tempfile import TemporaryDirectory
 from unittest.mock import patch
 
 from gamesymbol_snapshot_lib.errors import SnapshotMismatchError
 from gamesymbol_snapshot_lib.model import SnapshotContext
-from gamesymbol_snapshot_lib.pr_cli import _load_head_context, _parse_changed_paths, _revision_sources
+from gamesymbol_snapshot_lib.model import ChangedPath
+from gamesymbol_snapshot_lib.pr_cli import _load_head_context, _parse_changed_paths, _revision_sources, _run
 
 
 class TestGitChangeCollection(unittest.TestCase):
@@ -80,8 +82,11 @@ class TestGitChangeCollection(unittest.TestCase):
                 ["git", "rev-parse", "HEAD"], cwd=root, check=True, capture_output=True, text=True
             ).stdout.strip()
 
-            base_sources = _revision_sources(base_ref, root)
-            head_sources = _revision_sources(head_ref, root)
+            native_run = subprocess.run
+            with patch("gamesymbol_snapshot_lib.pr_cli.subprocess.run", wraps=native_run) as run:
+                base_sources = _revision_sources(base_ref, root)
+                head_sources = _revision_sources(head_ref, root)
+            archive_commands = [item.args[0] for item in run.call_args_list]
             current_ref = subprocess.run(
                 ["git", "rev-parse", "HEAD"], cwd=root, check=True, capture_output=True, text=True
             ).stdout.strip()
@@ -90,6 +95,59 @@ class TestGitChangeCollection(unittest.TestCase):
         self.assertEqual("VALUE = 1\n", base_sources[path])
         self.assertEqual("VALUE = 2\n", head_sources[path])
         self.assertEqual(head_ref, current_ref)
+        self.assertEqual(
+            [
+                ["git", "archive", "--format=tar", base_ref, "--", "ida_preprocessor_scripts/*.py"],
+                ["git", "archive", "--format=tar", head_ref, "--", "ida_preprocessor_scripts/*.py"],
+            ],
+            archive_commands,
+        )
+
+    def test_run_loads_only_required_revision_source_sides(self) -> None:
+        reference = "ida_preprocessor_scripts/references/server/Input.windows.yaml"
+        preprocessor = "ida_preprocessor_scripts/find-target.py"
+        cases = (
+            ([ChangedPath("M", "README.md", "README.md")], []),
+            ([ChangedPath("D", reference, None)], ["BASE"]),
+            ([ChangedPath("A", None, preprocessor)], ["HEAD"]),
+            ([ChangedPath("C", reference, "ida_preprocessor_scripts/references/server/Copy.windows.yaml")], ["HEAD"]),
+            ([ChangedPath("R", preprocessor, "ida_preprocessor_scripts/find-renamed.py")], ["BASE", "HEAD"]),
+        )
+        base = SnapshotContext({"files": {}}, b"base", "base-contract")
+        head = SnapshotContext({"files": {}}, b"head", "head-contract")
+        plan = SimpleNamespace(paths=frozenset(), reasons=())
+
+        for changes, expected_refs in cases:
+            args = SimpleNamespace(
+                gamever="14175",
+                bindir="bin",
+                baseconfigyaml="base-config.yaml",
+                basesnapshot="base-snapshot.yaml",
+                headconfigyaml="head-config.yaml",
+                headsnapshot="head-snapshot.yaml",
+                baseref="BASE",
+                headref="HEAD",
+            )
+            with (
+                patch("gamesymbol_snapshot_lib.pr_cli.resolve_analysis_config", return_value="head-config.yaml"),
+                patch("gamesymbol_snapshot_lib.pr_cli.load_snapshot_context", side_effect=[base, head]),
+                patch("gamesymbol_snapshot_lib.pr_cli._changed_paths", return_value=changes),
+                patch(
+                    "gamesymbol_snapshot_lib.pr_cli._revision_sources",
+                    side_effect=lambda ref, _root: {ref: ref},
+                ) as revision_sources,
+                patch("gamesymbol_snapshot_lib.pr_cli.build_invalidation_plan", return_value=plan) as build_plan,
+                patch("gamesymbol_snapshot_lib.pr_cli._delete_paths", return_value=0),
+            ):
+                _run(args)
+
+            self.assertEqual(expected_refs, [item.args[0] for item in revision_sources.call_args_list])
+            self.assertEqual(
+                {ref: ref for ref in expected_refs if ref == "BASE"}, build_plan.call_args.kwargs["base_sources"]
+            )
+            self.assertEqual(
+                {ref: ref for ref in expected_refs if ref == "HEAD"}, build_plan.call_args.kwargs["head_sources"]
+            )
 
 
 if __name__ == "__main__":

--- a/tests/test_gamesymbol_pr_validation.py
+++ b/tests/test_gamesymbol_pr_validation.py
@@ -2,10 +2,11 @@ import unittest
 from dataclasses import replace
 from pathlib import Path
 from tempfile import TemporaryDirectory
+from unittest.mock import patch
 
 from gamesymbol_snapshot_lib.config import load_contract
 from gamesymbol_snapshot_lib.model import ChangedPath
-from gamesymbol_snapshot_lib.pr_validation import build_invalidation_plan
+from gamesymbol_snapshot_lib.pr_validation import build_invalidation_plan, required_source_index_sides
 from tests.gamesymbol_snapshot_test_support import module, skill, write_config
 
 
@@ -23,6 +24,44 @@ class TestInvalidationPlan(unittest.TestCase):
             load_contract(base_config, "1", root / "bin"),
             load_contract(head_config, "1", root / "bin"),
         )
+
+    def test_source_index_sides_follow_git_change_semantics(self) -> None:
+        reference = "ida_preprocessor_scripts/references/server/Input.windows.yaml"
+        preprocessor = "ida_preprocessor_scripts/find-target.py"
+        cases = (
+            (ChangedPath("M", reference, reference), (True, True)),
+            (ChangedPath("D", preprocessor, None), (True, False)),
+            (ChangedPath("A", None, reference), (False, True)),
+            (ChangedPath("R", preprocessor, "ida_preprocessor_scripts/find-renamed.py"), (True, True)),
+            (
+                ChangedPath("C", reference, "ida_preprocessor_scripts/references/server/Copy.windows.yaml"),
+                (False, True),
+            ),
+            (ChangedPath("M", "README.md", "README.md"), (False, False)),
+        )
+
+        for change, expected in cases:
+            with self.subTest(status=change.status, old_path=change.old_path, new_path=change.new_path):
+                self.assertEqual(expected, required_source_index_sides([change]))
+
+    def test_unrelated_change_does_not_scan_workspace_sources(self) -> None:
+        modules = [module("server", [skill("find-target", ["Target.{platform}.yaml"])], linux=False)]
+        with TemporaryDirectory() as temp_dir:
+            root = Path(temp_dir)
+            base, head = self._contracts(root, modules)
+            unchanged = snapshot({"server/Target.windows.yaml": {"value": 1}})
+            with patch("gamesymbol_snapshot_lib.pr_validation.workspace_python_sources") as workspace_sources:
+                plan = build_invalidation_plan(
+                    base,
+                    head,
+                    unchanged,
+                    unchanged,
+                    [ChangedPath("M", "README.md", "README.md")],
+                    root,
+                )
+
+        self.assertEqual(frozenset(), plan.paths)
+        workspace_sources.assert_not_called()
 
     def test_snapshot_change_invalidates_whole_owner_and_downstream_closure(self) -> None:
         modules = [

--- a/tests/test_gamesymbol_snapshot_ops.py
+++ b/tests/test_gamesymbol_snapshot_ops.py
@@ -10,6 +10,7 @@ from gamesymbol_snapshot_lib.config import load_contract
 from gamesymbol_snapshot_lib.errors import SnapshotMismatchError, SnapshotSchemaError
 from gamesymbol_snapshot_lib.operations import (
     build_actual_document,
+    check_snapshot_contract,
     load_snapshot_for_contract,
     pack_snapshot,
     restore_snapshot,
@@ -182,6 +183,37 @@ class TestRestoreAndVerify(unittest.TestCase):
         self.assertEqual("14168", document["game_version"])
         self.assertTrue(raw)
         canonical_snapshot_bytes.assert_not_called()
+
+    def test_contract_check_uses_non_durable_temporary_writes(self) -> None:
+        with TemporaryDirectory() as temp_dir:
+            workspace = SnapshotWorkspace(Path(temp_dir))
+            workspace.write_required()
+            expected = workspace.pack()
+
+            with patch("gamesymbol_snapshot_lib.operations.os.fsync") as fsync:
+                context = check_snapshot_contract(
+                    "14168",
+                    workspace.bindir,
+                    workspace.config,
+                    workspace.snapshot,
+                )
+
+        self.assertEqual(expected, context.raw_bytes)
+        fsync.assert_not_called()
+
+    def test_restore_keeps_durable_output_writes(self) -> None:
+        with TemporaryDirectory() as temp_dir:
+            workspace = SnapshotWorkspace(Path(temp_dir))
+            workspace.write_required()
+            workspace.pack()
+            game_root = workspace.bindir / "14168"
+            for symbol in (game_root / "server/A.windows.yaml", game_root / "server/A.linux.yaml"):
+                symbol.unlink()
+
+            with patch("gamesymbol_snapshot_lib.operations.os.fsync") as fsync:
+                restore_snapshot("14168", workspace.bindir, workspace.config, workspace.snapshot, replace=True)
+
+        self.assertEqual(2, fsync.call_count)
 
     def test_replace_restores_round_trip_and_preserves_non_yaml_files(self) -> None:
         with TemporaryDirectory() as temp_dir:


### PR DESCRIPTION
## Summary
- skip per-file `fsync` for disposable snapshot contract round-trip writes while preserving durable real output writes
- lazily load only the required base/HEAD analysis source indexes and archive Python sources instead of the full preprocessor tree
- add regression coverage for durability, Git A/M/D/R/C source-side semantics, and lazy revision loading

## Validation
- implementation-specific tests: targeted PR validation tests passed (29); unit suite passed (1049/1049); all suite passed (1197 passed, 3 skipped, 0 failures); repository-contract passed (101/101)
- performance benchmark: `check-contract` improved from 45.825s to 26.845s on the same Windows machine (~41% faster)
- independent code review: no findings
- candidate preparation: passed for `14175`
- C++ post-change validation: passed with 15 runnable tests and zero compile, invalid-item, vtable, or record-layout failures
- candidate publication: passed; published SHA-256 `c9e301fae957b066b226b61be87e1c1179f1c5d6778ee9f19630991d038e219d` matches the validated candidate