### PR TITLE
feat(pr-validation): route PRs to full or lightweight validation by changed paths

### DIFF
--- a/.github/workflows/pr-self-runner.yml
+++ b/.github/workflows/pr-self-runner.yml
@@ -690,17 +690,11 @@ jobs:
       - name: Set up uv
         id: setup-uv
         uses: astral-sh/setup-uv@v9.0.0
-      - name: Install formatters
-        id: install-formatters
-        shell: bash
-        run: |
-          uv tool install ruff yamlfix
-          echo "$HOME/.local/bin" >> "$GITHUB_PATH"
       - name: Check formatting
         id: format
         shell: bash
         run: |
-          python3 format_repo_files.py --check
+          uv run --locked --only-group dev python format_repo_files.py --check
       - name: Verify download config exists
         id: verify-download-config
         shell: pwsh
@@ -709,7 +703,7 @@ jobs:
           if ([string]::IsNullOrWhiteSpace($gamever)) {
             throw "Missing latest game version from preflight."
           }
-          $configPath = Join-Path $env:WORKSPACE "configs\$gamever.yaml"
+          $configPath = Join-Path (Join-Path $env:WORKSPACE "configs") "${gamever}.yaml"
           if (-not (Test-Path -LiteralPath $configPath -PathType Leaf)) {
             throw "Missing analysis config for ${gamever}: $configPath"
           }

--- a/.github/workflows/pr-self-runner.yml
+++ b/.github/workflows/pr-self-runner.yml
@@ -23,8 +23,10 @@ jobs:
       pull-requests: read
     runs-on: ubuntu-latest
     outputs:
-      validation_path: ${{ steps.pull-request.outputs.validation-path }}
-      requires_warmup: ${{ steps.pull-request.outputs.requires-warmup }}
+      validation_path: ${{ steps.classify-validation-mode.outputs.validation-mode || 'light' }}
+      requires_warmup: ${{ steps.classify-validation-mode.outputs.validation-mode == 'full' && 'true' || 'false' }}
+      latest_gamever: ${{ steps.classify-validation-mode.outputs.latest-gamever }}
+      is_bump: ${{ steps.pull-request.outputs.is-bump }}
       pr_number: ${{ steps.pull-request.outputs.pr-number }}
       gamever: ${{ steps.resolve-version.outputs.gamever }}
       pr_gamever: ${{ steps.resolve-version.outputs.pr_gamever }}
@@ -59,7 +61,7 @@ jobs:
           $headRef = $env:PR_HEAD_REF
           $title = $env:PR_TITLE
           $isBump = $isBot -and $headRef.StartsWith("bump-download/") -and $title.StartsWith("chore(download): Update manifest for ")
-          $requiresWarmup = if ($isBump) { "false" } else { "true" }
+          $isBumpLower = if ($isBump) { "true" } else { "false" }
           $sourceSha = (git rev-parse HEAD).Trim()
           if ($LASTEXITCODE -ne 0 -or $sourceSha -notmatch '^[0-9a-fA-F]{40}$') {
             throw "Unable to resolve the PR merge commit SHA."
@@ -76,22 +78,34 @@ jobs:
           if ($LASTEXITCODE -ne 0 -or $mergeHeadSha -ne $headSha) {
             throw "PR merge ref second parent does not match the immutable PR head SHA."
           }
-          "validation-path=full" | Out-File $env:GITHUB_OUTPUT -Encoding utf8 -Append
+          "is-bump=$isBumpLower" | Out-File $env:GITHUB_OUTPUT -Encoding utf8 -Append
           "pr-number=$env:PR_NUMBER" | Out-File $env:GITHUB_OUTPUT -Encoding utf8 -Append
-          "requires-warmup=$requiresWarmup" | Out-File $env:GITHUB_OUTPUT -Encoding utf8 -Append
           "source-sha=$($sourceSha.ToLowerInvariant())" | Out-File $env:GITHUB_OUTPUT -Encoding utf8 -Append
           "head-sha=$headSha" | Out-File $env:GITHUB_OUTPUT -Encoding utf8 -Append
           "head-ref=$headRef" | Out-File $env:GITHUB_OUTPUT -Encoding utf8 -Append
           "base-sha=$($baseSha.ToLowerInvariant())" | Out-File $env:GITHUB_OUTPUT -Encoding utf8 -Append
           "pr-title=$title" | Out-File $env:GITHUB_OUTPUT -Encoding utf8 -Append
           "pr-user-login=$env:PR_USER_LOGIN" | Out-File $env:GITHUB_OUTPUT -Encoding utf8 -Append
-      - name: Set up uv for validation version resolution
+      - name: Set up uv for validation classification
         id: setup-preflight-uv
-        if: github.event_name == 'pull_request' && steps.pull-request.outputs.requires-warmup == 'true'
         uses: astral-sh/setup-uv@v9.0.0
+      - name: Classify PR validation mode from changed paths
+        id: classify-validation-mode
+        shell: pwsh
+        env:
+          PR_BASE_SHA: ${{ steps.pull-request.outputs.base-sha }}
+          PR_IS_BUMP: ${{ steps.pull-request.outputs.is-bump }}
+        run: |
+          $forceArgs = @()
+          if ($env:PR_IS_BUMP -eq "true") { $forceArgs += "--force-light" }
+          uv run python pr_validation_mode.py `
+            --repo-root "${{ github.workspace }}" `
+            --base-ref "$env:PR_BASE_SHA" `
+            --github-output "$env:GITHUB_OUTPUT" @forceArgs
+          if ($LASTEXITCODE -ne 0) { throw "Failed to classify PR validation mode." }
       - name: Resolve exact PR validation GAMEVER
         id: resolve-version
-        if: github.event_name == 'pull_request' && steps.pull-request.outputs.requires-warmup == 'true'
+        if: github.event_name == 'pull_request' && steps.classify-validation-mode.outputs.validation-mode == 'full'
         shell: pwsh
         env:
           PR_BASE_SHA: ${{ steps.pull-request.outputs.base-sha }}
@@ -117,8 +131,7 @@ jobs:
       always() &&
       needs.pr-preflight.result == 'success' &&
       needs.pr-preflight.outputs.validation_path == 'full' &&
-      (needs.pr-preflight.outputs.requires_warmup != 'true' ||
-       needs.pr-warmup-idb.result == 'success')
+      needs.pr-warmup-idb.result == 'success'
     permissions:
       pull-requests: read
     environment: win64
@@ -167,22 +180,8 @@ jobs:
           if ($LASTEXITCODE -ne 0 -or $actualSourceSha -ne $env:PR_SOURCE_SHA) {
             throw "PR source checkout drifted: expected=$env:PR_SOURCE_SHA actual=$actualSourceSha"
           }
-      - name: Detect bump-download PR
-        id: detect-bump
-        shell: pwsh
-        run: |
-          $isBot = $env:PR_USER_LOGIN -eq "github-actions[bot]"
-          $headRef = $env:PR_HEAD_REF
-          $title = $env:PR_TITLE
-          $isBump = $isBot -and $headRef.StartsWith("bump-download/") -and $title.StartsWith("chore(download): Update manifest for ")
-          # PowerShell bool ToString() yields capitalized True/False; emit lowercase
-          # so the downstream string comparisons against 'true' are case-exact.
-          $isBumpLower = if ($isBump) { "true" } else { "false" }
-          "is-bump=$isBumpLower" | Out-File -FilePath $env:GITHUB_OUTPUT -Encoding utf8 -Append
-          Write-Host "Detected bump-download PR: $isBumpLower"
       - name: Compute submodule cache key
         id: submodule-cache-key
-        if: steps.detect-bump.outputs.is-bump != 'true'
         shell: pwsh
         run: |
           Set-Location $env:WORKSPACE
@@ -200,7 +199,6 @@ jobs:
           "hash=$hash" | Out-File -FilePath $env:GITHUB_OUTPUT -Encoding utf8 -Append
       - name: Restore submodule cache
         id: restore-submodule-cache
-        if: steps.detect-bump.outputs.is-bump != 'true'
         uses: actions/cache@v5
         with:
           path: |
@@ -211,7 +209,6 @@ jobs:
             ${{ runner.os }}-submodules-${{ env.SUBMODULE_CACHE_VERSION }}-
       - name: Sync and update submodules
         id: sync-submodules
-        if: steps.detect-bump.outputs.is-bump != 'true'
         shell: pwsh
         run: |
           Set-Location $env:WORKSPACE
@@ -225,24 +222,8 @@ jobs:
         run: |
           Set-Location $env:WORKSPACE
           uv run python format_repo_files.py --check
-      - name: Bump-download lightweight validation
-        id: bump-light
-        if: steps.detect-bump.outputs.is-bump == 'true'
-        shell: pwsh
-        run: |
-          Set-Location $env:WORKSPACE
-          $gamever = (uv run python -c "import yaml; d=yaml.safe_load(open('download.yaml', encoding='utf-8')); print(d['downloads'][-1]['tag'])").Trim()
-          if ($LASTEXITCODE -ne 0 -or [string]::IsNullOrWhiteSpace($gamever)) {
-            throw "Failed to read latest game version from download.yaml."
-          }
-          $configPath = Join-Path $env:WORKSPACE "configs\$gamever.yaml"
-          if (-not (Test-Path -LiteralPath $configPath -PathType Leaf)) {
-            throw "Missing analysis config for bump tag ${gamever}: $configPath"
-          }
-          Write-Host "Bump-download validation OK: GAMEVER=$gamever config=$configPath"
       - name: Determine release version from PR download config
         id: select-version
-        if: steps.detect-bump.outputs.is-bump != 'true'
         shell: pwsh
         run: |
           Set-Location $env:WORKSPACE
@@ -261,7 +242,6 @@ jobs:
           Write-Host "PR release GAMEVER=$gamever"
       - name: Extract deterministic base snapshot
         id: base-snapshot
-        if: steps.detect-bump.outputs.is-bump != 'true'
         shell: pwsh
         run: |
           Set-Location $env:WORKSPACE
@@ -344,7 +324,6 @@ jobs:
           Write-Host "PR validation GAMEVER=$validationGamever (release GAMEVER=$env:PR_GAMEVER)"
       - name: Resolve consumer IDA identity
         id: resolve-consumer-ida
-        if: steps.detect-bump.outputs.is-bump != 'true'
         shell: pwsh
         run: |
           $pythonExe = (Get-Command python -ErrorAction SilentlyContinue).Source
@@ -368,7 +347,6 @@ jobs:
           "IDA_VERSION=$idaVersion" | Out-File $env:GITHUB_ENV -Encoding utf8 -Append
       - name: Restore required published warm IDB cache
         id: restore-idb-cache
-        if: steps.detect-bump.outputs.is-bump != 'true'
         shell: pwsh
         run: |
           Set-Location $env:WORKSPACE
@@ -382,7 +360,6 @@ jobs:
           if ($LASTEXITCODE -ne 0) { throw "Required published IDB cache restore failed." }
       - name: Restore deterministic base and invalidate affected outputs
         id: restore-base
-        if: steps.detect-bump.outputs.is-bump != 'true'
         shell: pwsh
         run: |
           Set-Location $env:WORKSPACE
@@ -488,7 +465,6 @@ jobs:
           ) | Out-File -FilePath $env:GITHUB_STEP_SUMMARY -Encoding utf8 -Append
       - name: Run Python test suites
         id: test-suites
-        if: steps.detect-bump.outputs.is-bump != 'true'
         shell: pwsh
         run: |
           Set-Location $env:WORKSPACE
@@ -498,7 +474,6 @@ jobs:
           }
       - name: Analyze binaries
         id: analyze
-        if: steps.detect-bump.outputs.is-bump != 'true'
         shell: pwsh
         run: |
           Set-Location $env:WORKSPACE
@@ -508,7 +483,6 @@ jobs:
           }
       - name: Build actual candidate snapshot
         id: build-snapshot
-        if: steps.detect-bump.outputs.is-bump != 'true'
         shell: pwsh
         run: |
           Set-Location $env:WORKSPACE
@@ -536,7 +510,6 @@ jobs:
           "SNAPSHOT_SHA256=$snapshotSha256" | Out-File -FilePath $env:GITHUB_ENV -Encoding utf8 -Append
       - name: Build isolated versioned gamedata candidate
         id: build-gamedata
-        if: steps.detect-bump.outputs.is-bump != 'true'
         shell: pwsh
         run: |
           Set-Location $env:WORKSPACE
@@ -566,7 +539,6 @@ jobs:
           if ($LASTEXITCODE -ne 0) { throw "failed to mark gamedata validation" }
       - name: Select versioned SDK for C++ ABI validation
         id: select-sdk
-        if: steps.detect-bump.outputs.is-bump != 'true'
         shell: pwsh
         run: |
           $sdkPath = Join-Path $env:WORKSPACE "hl2sdk_cs2"
@@ -610,7 +582,6 @@ jobs:
           }
       - name: Run C++ tests
         id: cpp-tests
-        if: steps.detect-bump.outputs.is-bump != 'true'
         shell: pwsh
         run: |
           Set-Location $env:WORKSPACE
@@ -646,14 +617,12 @@ jobs:
           Write-Host "C++ ABI SDK restore: restored pinned SHA=$restoredSha"
       - name: Mark snapshot validation success
         id: mark-success
-        if: steps.detect-bump.outputs.is-bump != 'true'
         shell: pwsh
         run: |
           Set-Location $env:WORKSPACE
           "validated" | Out-File -LiteralPath (Join-Path $env:RUNNER_TEMP "snapshot-validation-success") -Encoding ascii
       - name: Stage analyzed YAML for merge promotion
         id: stage-yaml
-        if: steps.detect-bump.outputs.is-bump != 'true'
         shell: pwsh
         run: |
           Set-Location $env:WORKSPACE
@@ -692,9 +661,62 @@ jobs:
           if (-not [string]::IsNullOrWhiteSpace($env:CANDIDATE_ROOT) -and (Test-Path -LiteralPath $env:CANDIDATE_ROOT)) {
             Remove-Item -LiteralPath $env:CANDIDATE_ROOT -Recurse -Force
           }
+  pr-validate-light:
+    name: pr-validate-light
+    needs: pr-preflight
+    if: >-
+      always() &&
+      github.event_name == 'pull_request' &&
+      github.event.action != 'closed' &&
+      (github.repository == 'HLND2T/CS2_VibeSignatures' ||
+       github.repository == 'hzqst/CS2_VibeSignatures') &&
+      github.event.pull_request.head.repo.full_name == github.repository &&
+      !(github.event.pull_request.user.login == 'github-actions[bot]' &&
+         startsWith(github.event.pull_request.head.ref, 'gamesymbols/build/') &&
+         startsWith(github.event.pull_request.title, 'chore(gamesymbols): publish ')) &&
+      needs.pr-preflight.result == 'success' &&
+      needs.pr-preflight.outputs.validation_path == 'light'
+    runs-on: ubuntu-latest
+    env:
+      WORKSPACE: ${{ github.workspace }}
+    steps:
+      - name: Checkout PR merge ref
+        id: checkout-merge
+        uses: actions/checkout@v5
+        with:
+          ref: ${{ needs.pr-preflight.outputs.source_sha }}
+          fetch-depth: 0
+          submodules: false
+      - name: Set up uv
+        id: setup-uv
+        uses: astral-sh/setup-uv@v9.0.0
+      - name: Install formatters
+        id: install-formatters
+        shell: bash
+        run: |
+          uv tool install ruff yamlfix
+          echo "$HOME/.local/bin" >> "$GITHUB_PATH"
+      - name: Check formatting
+        id: format
+        shell: bash
+        run: |
+          python3 format_repo_files.py --check
+      - name: Verify download config exists
+        id: verify-download-config
+        shell: pwsh
+        run: |
+          $gamever = "${{ needs.pr-preflight.outputs.latest_gamever }}".Trim()
+          if ([string]::IsNullOrWhiteSpace($gamever)) {
+            throw "Missing latest game version from preflight."
+          }
+          $configPath = Join-Path $env:WORKSPACE "configs\$gamever.yaml"
+          if (-not (Test-Path -LiteralPath $configPath -PathType Leaf)) {
+            throw "Missing analysis config for ${gamever}: $configPath"
+          }
+          Write-Host "Download config validation OK: GAMEVER=$gamever config=$configPath"
   pr-validate:
     name: pr-validate
-    needs: [pr-preflight, pr-validate-full]
+    needs: [pr-preflight, pr-validate-full, pr-validate-light]
     if: >-
       always() &&
       github.event_name == 'pull_request' &&
@@ -707,16 +729,22 @@ jobs:
          startsWith(github.event.pull_request.title, 'chore(gamesymbols): publish '))
     runs-on: ubuntu-latest
     steps:
-      - name: Require successful full validation
+      - name: Require successful validation
         id: terminal
         shell: bash
         env:
           PREFLIGHT_RESULT: ${{ needs.pr-preflight.result }}
           FULL_RESULT: ${{ needs.pr-validate-full.result }}
+          LIGHT_RESULT: ${{ needs.pr-validate-light.result }}
+          VALIDATION_PATH: ${{ needs.pr-preflight.outputs.validation_path }}
         run: |
           set -euo pipefail
           [[ "$PREFLIGHT_RESULT" == "success" ]]
-          [[ "$FULL_RESULT" == "success" ]]
+          if [[ "$VALIDATION_PATH" == "full" ]]; then
+            [[ "$FULL_RESULT" == "success" ]]
+          else
+            [[ "$LIGHT_RESULT" == "success" ]]
+          fi
   finalize-pr-workspace:
     if: >-
       github.event.action == 'closed' &&

--- a/pr_validation_mode.py
+++ b/pr_validation_mode.py
@@ -1,0 +1,294 @@
+#!/usr/bin/env python3
+"""Classify a PR into full or lightweight validation from its changed paths."""
+
+from __future__ import annotations
+
+import argparse
+import fnmatch
+import re
+import subprocess
+import sys
+from dataclasses import dataclass
+from pathlib import Path
+
+from gamesymbol_snapshot_lib.model import ChangedPath
+from trusted_yaml import load_yaml, load_yaml_file
+
+CONFIG_REPO_PATH = "pr_validation_mode.yaml"
+SHA_PATTERN = re.compile(r"^[0-9a-fA-F]{40}$")
+_RULE_KEYS = frozenset({"paths", "regexes", "reason"})
+
+
+class PrValidationModeError(RuntimeError):
+    pass
+
+
+@dataclass(frozen=True)
+class ImpactRule:
+    glob_patterns: tuple[str, ...]
+    regex_patterns: tuple[re.Pattern[str], ...]
+    reason: str
+
+
+@dataclass(frozen=True)
+class Classification:
+    mode: str
+    matched_rules: tuple[str, ...]
+    force_light: bool
+
+
+@dataclass(frozen=True)
+class ValidationResult:
+    mode: str
+    latest_gamever: str
+    matched_rules: tuple[str, ...]
+    changed_paths: tuple[str, ...]
+
+
+def _git_lines(repo_root: Path, arguments: list[str]) -> list[str]:
+    result = subprocess.run(
+        ["git", "-C", str(repo_root), *arguments],
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    if result.returncode != 0:
+        raise PrValidationModeError(result.stderr.strip() or f"git {' '.join(arguments)} failed")
+    return [line.strip() for line in result.stdout.splitlines() if line.strip()]
+
+
+def _read_tracked_file(repo_root: Path, ref: str, path: str) -> bytes:
+    result = subprocess.run(
+        ["git", "-C", str(repo_root), "show", f"{ref}:{path}"],
+        capture_output=True,
+        check=False,
+    )
+    if result.returncode != 0:
+        raise PrValidationModeError(
+            result.stderr.decode("utf-8", errors="replace").strip() or f"git show {ref}:{path} failed"
+        )
+    return result.stdout
+
+
+def _decode_git_field(value: bytes) -> str:
+    try:
+        return value.decode("utf-8")
+    except UnicodeDecodeError as exc:
+        raise PrValidationModeError(f"git returned a non-UTF-8 path: {exc}") from exc
+
+
+def parse_changed_paths(raw: bytes) -> list[ChangedPath]:
+    fields = raw.split(b"\0")
+    if fields and fields[-1] == b"":
+        fields.pop()
+    changes = []
+    index = 0
+    while index < len(fields):
+        status_token = _decode_git_field(fields[index])
+        index += 1
+        status = status_token[:1]
+        if status not in {"A", "M", "D", "R", "C"}:
+            raise PrValidationModeError(f"unsupported git change status: {status_token}")
+        required_paths = 2 if status in {"R", "C"} else 1
+        if index + required_paths > len(fields):
+            raise PrValidationModeError(f"malformed git diff --name-status record for {status_token}")
+        paths = [_decode_git_field(value) for value in fields[index : index + required_paths]]
+        index += required_paths
+        if status == "A":
+            changes.append(ChangedPath(status, None, paths[0]))
+        elif status == "D":
+            changes.append(ChangedPath(status, paths[0], None))
+        elif status == "M":
+            changes.append(ChangedPath(status, paths[0], paths[0]))
+        else:
+            changes.append(ChangedPath(status, paths[0], paths[1]))
+    return changes
+
+
+def changed_paths(repo_root: Path, base_ref: str, head_ref: str) -> list[ChangedPath]:
+    result = subprocess.run(
+        ["git", "diff", "--name-status", "-M", "-z", base_ref, head_ref, "--"],
+        cwd=repo_root,
+        capture_output=True,
+        check=False,
+    )
+    if result.returncode != 0:
+        stderr = result.stderr.decode("utf-8", errors="replace").strip()
+        raise PrValidationModeError(stderr or "git diff --name-status failed")
+    return parse_changed_paths(result.stdout)
+
+
+def normalize_path(path: str) -> str:
+    normalized = str(path).strip().replace("\\", "/")
+    normalized = normalized.removeprefix("./")
+    if not normalized:
+        raise PrValidationModeError(f"changed path must not be empty: {path!r}")
+    return normalized
+
+
+def _string_list(value, context: str) -> list[str]:
+    if value is None:
+        return []
+    if not isinstance(value, list) or any(not isinstance(item, str) or not item.strip() for item in value):
+        raise PrValidationModeError(f"{context} must be a list of non-empty strings")
+    return [item.strip() for item in value]
+
+
+def _validate_glob_pattern(pattern: str) -> None:
+    if "\\" in pattern:
+        raise PrValidationModeError(f"rule glob pattern must use forward slashes: {pattern!r}")
+    if pattern.startswith("/"):
+        raise PrValidationModeError(f"rule glob pattern must be repo-relative: {pattern!r}")
+    if any(char in pattern for char in "[ ] { }"):
+        raise PrValidationModeError(f"rule glob pattern must not use bracket or brace metacharacters: {pattern!r}")
+    if any(component in {"", ".", ".."} for component in pattern.split("/")):
+        raise PrValidationModeError(f"rule glob pattern must not contain empty or dot components: {pattern!r}")
+
+
+def _parse_rule(rule, index: int) -> ImpactRule:
+    context = f"rules[{index}]"
+    if not isinstance(rule, dict):
+        raise PrValidationModeError(f"{context} must be a mapping")
+    unknown = set(rule) - _RULE_KEYS
+    if unknown:
+        raise PrValidationModeError(f"{context} has unknown keys: {', '.join(sorted(unknown))}")
+    globs = _string_list(rule.get("paths"), f"{context}.paths")
+    regexes = _string_list(rule.get("regexes"), f"{context}.regexes")
+    if not globs and not regexes:
+        raise PrValidationModeError(f"{context} must declare at least one of paths or regexes")
+    for pattern in globs:
+        _validate_glob_pattern(pattern)
+    compiled = []
+    for pattern in regexes:
+        try:
+            compiled.append(re.compile(pattern))
+        except re.error as exc:
+            raise PrValidationModeError(f"{context}.regexes contains an invalid pattern {pattern!r}: {exc}")
+    reason = rule.get("reason")
+    if reason is not None and (not isinstance(reason, str) or not reason.strip()):
+        raise PrValidationModeError(f"{context}.reason must be a non-empty string")
+    return ImpactRule(tuple(globs), tuple(compiled), reason or "")
+
+
+def parse_rules(document) -> tuple[ImpactRule, ...]:
+    if not isinstance(document, dict):
+        raise PrValidationModeError("pr_validation_mode.yaml must be a mapping")
+    unknown = set(document) - {"schema_version", "rules"}
+    if unknown:
+        raise PrValidationModeError(f"unknown pr_validation_mode.yaml top-level keys: {', '.join(sorted(unknown))}")
+    if document.get("schema_version") != 1:
+        raise PrValidationModeError("pr_validation_mode.yaml schema_version must be 1")
+    rules = document.get("rules")
+    if not isinstance(rules, list) or not rules:
+        raise PrValidationModeError("pr_validation_mode.yaml rules must be a non-empty list")
+    return tuple(_parse_rule(rule, index) for index, rule in enumerate(rules))
+
+
+def load_rules_from_ref(repo_root: Path, base_ref: str) -> tuple[ImpactRule, ...]:
+    payload = _read_tracked_file(repo_root, base_ref, CONFIG_REPO_PATH)
+    return parse_rules(load_yaml(payload.decode("utf-8")))
+
+
+def load_rules_from_file(path) -> tuple[ImpactRule, ...]:
+    return parse_rules(load_yaml_file(Path(path)))
+
+
+def rule_matches(rule: ImpactRule, path: str) -> bool:
+    for pattern in rule.glob_patterns:
+        if fnmatch.fnmatchcase(path, pattern):
+            return True
+    for regex in rule.regex_patterns:
+        if regex.search(path):
+            return True
+    return False
+
+
+def classify_paths(
+    changed_paths: list[str], rules: tuple[ImpactRule, ...], *, force_light: bool = False
+) -> Classification:
+    normalized = {normalize_path(path) for path in changed_paths}
+    matched = tuple(rule.reason for rule in rules if any(rule_matches(rule, path) for path in normalized))
+    mode = "light" if force_light else ("full" if matched else "light")
+    return Classification(mode, matched, force_light)
+
+
+def latest_gamever(repo_root: Path) -> str:
+    document = load_yaml_file(repo_root / "download.yaml")
+    downloads = document.get("downloads") if isinstance(document, dict) else None
+    if not isinstance(downloads, list) or not downloads or not isinstance(downloads[-1], dict):
+        raise PrValidationModeError("download.yaml has no latest download entry")
+    tag = str(downloads[-1].get("tag", "")).strip()
+    if not tag:
+        raise PrValidationModeError("download.yaml latest download has no tag")
+    return tag
+
+
+def resolve_validation_mode(
+    repo_root: Path,
+    base_ref: str,
+    head_ref: str,
+    *,
+    config_path: str | None = None,
+    force_light: bool = False,
+) -> ValidationResult:
+    repo_root = Path(repo_root).resolve()
+    base_ref = str(base_ref).strip()
+    if not SHA_PATTERN.fullmatch(base_ref):
+        raise PrValidationModeError(f"base ref must be a full commit SHA: {base_ref}")
+    rules = load_rules_from_file(config_path) if config_path else load_rules_from_ref(repo_root, base_ref)
+    changed = changed_paths(repo_root, base_ref, head_ref)
+    paths = tuple(sorted({path for change in changed for path in (change.old_path, change.new_path) if path}))
+    classification = classify_paths(list(paths), rules, force_light=force_light)
+    return ValidationResult(
+        mode=classification.mode,
+        latest_gamever=latest_gamever(repo_root),
+        matched_rules=classification.matched_rules,
+        changed_paths=paths,
+    )
+
+
+def parse_args(argv=None) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--repo-root", default=".")
+    parser.add_argument("--base-ref", required=True)
+    parser.add_argument("--head-ref", default="HEAD")
+    parser.add_argument(
+        "--config",
+        default=None,
+        help=f"override the trusted config file (default: read {CONFIG_REPO_PATH} from --base-ref)",
+    )
+    parser.add_argument(
+        "--force-light", action="store_true", help="force lightweight validation regardless of changed paths"
+    )
+    parser.add_argument("--github-output")
+    return parser.parse_args(argv)
+
+
+def main(argv=None) -> int:
+    args = parse_args(argv)
+    try:
+        result = resolve_validation_mode(
+            Path(args.repo_root),
+            args.base_ref,
+            args.head_ref,
+            config_path=args.config,
+            force_light=args.force_light,
+        )
+    except (OSError, PrValidationModeError) as exc:
+        print(f"Error: {exc}", file=sys.stderr)
+        return 1
+    if args.github_output:
+        with Path(args.github_output).open("a", encoding="utf-8") as handle:
+            handle.write(f"validation-mode={result.mode}\n")
+            handle.write(f"latest-gamever={result.latest_gamever}\n")
+    print(f"validation-mode={result.mode}")
+    print(f"latest-gamever={result.latest_gamever}")
+    for reason in result.matched_rules:
+        print(f"  matched rule: {reason}")
+    for path in result.changed_paths:
+        print(f"  changed: {path}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/pr_validation_mode.py
+++ b/pr_validation_mode.py
@@ -17,9 +17,14 @@ from trusted_yaml import load_yaml, load_yaml_file
 CONFIG_REPO_PATH = "pr_validation_mode.yaml"
 SHA_PATTERN = re.compile(r"^[0-9a-fA-F]{40}$")
 _RULE_KEYS = frozenset({"paths", "regexes", "reason"})
+TRUSTED_CONFIG_MISSING_REASON = "Trusted validation config missing; fail-closed to full validation"
 
 
 class PrValidationModeError(RuntimeError):
+    pass
+
+
+class TrustedConfigMissingError(PrValidationModeError):
     pass
 
 
@@ -64,6 +69,13 @@ def _read_tracked_file(repo_root: Path, ref: str, path: str) -> bytes:
         check=False,
     )
     if result.returncode != 0:
+        commit_check = subprocess.run(
+            ["git", "-C", str(repo_root), "cat-file", "-e", f"{ref}^{{commit}}"],
+            capture_output=True,
+            check=False,
+        )
+        if commit_check.returncode == 0:
+            raise TrustedConfigMissingError(f"trusted config {path!r} is missing from base commit {ref}")
         raise PrValidationModeError(
             result.stderr.decode("utf-8", errors="replace").strip() or f"git show {ref}:{path} failed"
         )
@@ -235,10 +247,21 @@ def resolve_validation_mode(
     base_ref = str(base_ref).strip()
     if not SHA_PATTERN.fullmatch(base_ref):
         raise PrValidationModeError(f"base ref must be a full commit SHA: {base_ref}")
-    rules = load_rules_from_file(config_path) if config_path else load_rules_from_ref(repo_root, base_ref)
+    trusted_config_missing = False
+    if config_path:
+        rules = load_rules_from_file(config_path)
+    else:
+        try:
+            rules = load_rules_from_ref(repo_root, base_ref)
+        except TrustedConfigMissingError:
+            rules = ()
+            trusted_config_missing = True
     changed = changed_paths(repo_root, base_ref, head_ref)
     paths = tuple(sorted({path for change in changed for path in (change.old_path, change.new_path) if path}))
-    classification = classify_paths(list(paths), rules, force_light=force_light)
+    if trusted_config_missing:
+        classification = Classification("full", (TRUSTED_CONFIG_MISSING_REASON,), False)
+    else:
+        classification = classify_paths(list(paths), rules, force_light=force_light)
     return ValidationResult(
         mode=classification.mode,
         latest_gamever=latest_gamever(repo_root),

--- a/pr_validation_mode.yaml
+++ b/pr_validation_mode.yaml
@@ -1,0 +1,82 @@
+# PR validation routing rules: a PR whose changed paths match any rule runs full
+# validation; otherwise it runs lightweight validation.
+# Glob patterns use fnmatch semantics: `*` also matches `/`. Patterns are
+# repo-relative POSIX paths (e.g. configs/14176.yaml). Regexes match with re.search.
+schema_version: 1
+rules:
+  - paths:
+      - download.yaml
+      - configs/*.yaml
+      - gamesymbols/**
+      - pr_validation_version.py
+    reason: Game version registry and per-version analysis config
+  - paths:
+      - analysis_config.py
+      - analysis_output_contract.py
+      - trusted_yaml.py
+      - ida_analyze_bin.py
+      - ida_analyze_util.py
+      - ida_llm_decompile.py
+      - ida_llm_utils.py
+      - ida_mcp_session.py
+      - ida_vcall_finder.py
+      - ida_skill_preprocessor.py
+      - ida_preprocessor_scripts/**
+      - vcall_finder/**
+    reason: IDA analysis pipeline
+  - regexes:
+      - ^\.claude/skills/find-.*
+      - ^\.claude/skills/convert-finder-skill-to-preprocessor-scripts/.*
+      - ^\.claude/skills/create-preprocessor-scripts/.*
+      - ^\.claude/skills/rename-preprocessor-scripts/.*
+    reason: find-* and preprocessor-generation skills
+  - paths:
+      - binary_hashing.py
+      - idb_cache.py
+      - warmup_idb.py
+      - warmup_idb_worker.py
+      - warmup_memory.py
+      - gamesymbol_snapshot.py
+      - gamesymbol_snapshot_lib/**
+      - gamesymbol_candidate.py
+      - gamesymbol_pr_validation.py
+      - gamesymbol_store.py
+    reason: Snapshot and warm IDB cache machinery
+  - paths:
+      - gamedata_candidate.py
+      - gamedata_config_validation.py
+      - gamedata_contract.py
+      - gamedata_diagnostics.py
+      - gamedata_symbol_config.py
+      - gamedata_symbol_data.py
+      - gamedata_utils.py
+      - gamedata-generators/**
+      - update_gamedata.py
+    reason: Gamedata generation and validation
+  - paths:
+      - run_cpp_tests.py
+      - cpp_tests/**
+      - cpp_tests_util.py
+      - hl2sdk_cs2
+      - .gitmodules
+    reason: C++ ABI validation and SDK submodule
+  - paths:
+      - process_*.py
+      - release_workflow.py
+      - release_workflow_lib/**
+      - agent_runner.py
+      - bump_download.py
+      - push_binsync_symbols.py
+      - headless_force_push.py
+      - release-manifests/**
+    reason: Subsystems covered by full-run redis/release integration tests
+  - paths:
+      - pyproject.toml
+      - uv.lock
+      - .github/workflows/**
+      - format_repo_files.py
+    reason: Dependencies, CI pipeline, and repository formatter
+  - paths:
+      - pr_validation_mode.py
+      - pr_validation_mode.yaml
+    reason: PR validation router itself (self-neutralization)

--- a/tests/run_test_suite.py
+++ b/tests/run_test_suite.py
@@ -37,6 +37,7 @@ REPOSITORY_CONTRACT_PREFIXES = (
     "test_bump_download.TestBumpDownload.test_bump_workflow_prunes_local_only_tags_before_bump",
     "test_ida_mcp_session.TestMcpSessionBoundary.test_only_adapter_creates_raw_mcp_sessions",
     "test_llm_decompile_dependencies.TestRepositoryLlmDecompileDependencyPolicy",
+    "test_pr_validation_mode.PrValidationModeRepositoryContractTests",
     "test_test_suite_runner.TestSuiteAssignmentContract",
     "test_trusted_yaml.TestRepositoryYamlCompatibility",
 )
@@ -101,6 +102,7 @@ UNIT_MODULES = frozenset(
         "test_process_scheduler_redis",
         "test_process_status_reader_redis",
         "test_prune_pr_expected_output_bin",
+        "test_pr_validation_mode",
         "test_pr_validation_version",
         "test_push_binsync_symbols",
         "test_ordinal_vtable_common",

--- a/tests/test_pr_self_runner_workflow.py
+++ b/tests/test_pr_self_runner_workflow.py
@@ -9,6 +9,7 @@ class TestPrSelfRunnerWorkflow(unittest.TestCase):
         self.preflight = workflow_job(self.workflow, "pr-preflight")
         self.warmup = workflow_job(self.workflow, "pr-warmup-idb")
         self.full = workflow_job(self.workflow, "pr-validate-full")
+        self.light = workflow_job(self.workflow, "pr-validate-light")
         self.terminal = workflow_job(self.workflow, "pr-validate")
         self.steps = steps_by_id(self.full)
 
@@ -21,11 +22,16 @@ class TestPrSelfRunnerWorkflow(unittest.TestCase):
         self.assertEqual({"contents": "read"}, self.workflow["permissions"])
         self.assertEqual({"pull-requests": "read"}, self.full["permissions"])
         self.assertEqual("pr-validate", self.terminal["name"])
-        self.assertEqual(["pr-preflight", "pr-validate-full"], self.terminal["needs"])
+        self.assertEqual(
+            ["pr-preflight", "pr-validate-full", "pr-validate-light"],
+            self.terminal["needs"],
+        )
         self.assertNotIn("pr-published-recheck", self.workflow["jobs"])
         terminal_run = steps_by_id(self.terminal)["terminal"]["run"]
         self.assertIn('PREFLIGHT_RESULT" == "success', terminal_run)
         self.assertIn('FULL_RESULT" == "success', terminal_run)
+        self.assertIn('LIGHT_RESULT" == "success', terminal_run)
+        self.assertIn("VALIDATION_PATH", terminal_run)
         self.assertNotIn("published-recheck", terminal_run)
         self.assertNotIn("RECHECK_RESULT", terminal_run)
 
@@ -53,6 +59,47 @@ class TestPrSelfRunnerWorkflow(unittest.TestCase):
         self.assertEqual(["pr-preflight", "pr-warmup-idb"], self.full["needs"])
         self.assertIn("needs.pr-preflight.outputs.validation_path == 'full'", self.full["if"])
         self.assertIn("needs.pr-warmup-idb.result == 'success'", self.full["if"])
+
+    def test_preflight_classifies_validation_mode_from_trusted_base_config(self) -> None:
+        classify = steps_by_id(self.preflight)["classify-validation-mode"]
+        run = classify["run"]
+        self.assertIn("pr_validation_mode.py", run)
+        self.assertIn("--base-ref", run)
+        self.assertIn("$env:PR_BASE_SHA", run)
+        self.assertEqual("${{ steps.pull-request.outputs.base-sha }}", classify["env"]["PR_BASE_SHA"])
+        self.assertEqual("${{ steps.pull-request.outputs.is-bump }}", classify["env"]["PR_IS_BUMP"])
+        outputs = self.preflight["outputs"]
+        self.assertEqual(
+            "${{ steps.classify-validation-mode.outputs.validation-mode || 'light' }}",
+            outputs["validation_path"],
+        )
+        self.assertEqual(
+            "${{ steps.classify-validation-mode.outputs.validation-mode == 'full' && 'true' || 'false' }}",
+            outputs["requires_warmup"],
+        )
+        self.assertEqual("${{ steps.classify-validation-mode.outputs.latest-gamever }}", outputs["latest_gamever"])
+        self.assertEqual("${{ steps.pull-request.outputs.is-bump }}", outputs["is_bump"])
+
+    def test_light_job_runs_only_for_light_path_on_ubuntu(self) -> None:
+        self.assertEqual("pr-preflight", self.light["needs"])
+        self.assertEqual("ubuntu-latest", self.light["runs-on"])
+        self.assertIn("needs.pr-preflight.outputs.validation_path == 'light'", self.light["if"])
+        light_steps = steps_by_id(self.light)
+        self.assertIn("install-formatters", light_steps)
+        self.assertIn("format", light_steps)
+        self.assertIn("verify-download-config", light_steps)
+        verify = light_steps["verify-download-config"]["run"]
+        self.assertIn("latest_gamever", verify)
+        self.assertIn("configs\\$gamever.yaml", verify)
+        self.assertNotIn("test-suites", light_steps)
+        self.assertNotIn("analyze", light_steps)
+        self.assertNotIn("build-snapshot", light_steps)
+
+    def test_full_job_dropped_bump_partition_machinery(self) -> None:
+        self.assertNotIn("detect-bump", self.steps)
+        self.assertNotIn("bump-light", self.steps)
+        for step_id in ("submodule-cache-key", "restore-submodule-cache", "sync-submodules"):
+            self.assertNotIn("is-bump", self.steps[step_id].get("if", ""))
 
     def test_full_validation_build_test_stage_order(self) -> None:
         test_run = self.steps["test-suites"]["run"]
@@ -93,7 +140,7 @@ class TestPrSelfRunnerWorkflow(unittest.TestCase):
         self.assertNotIn("gamesymbol_candidate.py publish", build)
         self.assertNotIn("gamedata_candidate.py publish", gamedata)
 
-    def test_submodule_cache_and_bump_partition_are_preserved(self) -> None:
+    def test_submodule_cache_is_preserved_without_bump_partition(self) -> None:
         self.assertEqual("actions/cache@v5", self.steps["restore-submodule-cache"]["uses"])
         self.assertIn(
             "git submodule update --init --recursive --depth 1 --jobs 8",
@@ -101,19 +148,14 @@ class TestPrSelfRunnerWorkflow(unittest.TestCase):
         )
         self.assertIn("git ls-tree HEAD", self.steps["submodule-cache-key"]["run"])
         self.assertNotIn("submodule status --recursive", self.steps["submodule-cache-key"]["run"])
-        condition = "steps.detect-bump.outputs.is-bump != 'true'"
-        for step_id in ("submodule-cache-key", "restore-submodule-cache", "sync-submodules"):
-            self.assertEqual(condition, self.steps[step_id]["if"])
         order = step_order(
             self.full,
             "checkout-merge",
             "verify-source",
-            "detect-bump",
             "submodule-cache-key",
             "restore-submodule-cache",
             "sync-submodules",
             "format",
-            "bump-light",
         )
         self.assertEqual(sorted(order), order)
 
@@ -154,13 +196,14 @@ class TestPrSelfRunnerWorkflow(unittest.TestCase):
 
     def test_untrusted_pr_fields_are_passed_via_environment(self) -> None:
         identify = steps_by_id(self.preflight)["pull-request"]
-        detect = self.steps["detect-bump"]
-        for step in (identify, detect):
-            run = step["run"]
-            self.assertIn("$env:PR_TITLE", run)
-            self.assertIn("$env:PR_HEAD_REF", run)
-            self.assertIn("$env:PR_USER_LOGIN", run)
-            self.assertNotIn("${{ github.event.pull_request.title }}", run)
+        run = identify["run"]
+        self.assertIn("$env:PR_TITLE", run)
+        self.assertIn("$env:PR_HEAD_REF", run)
+        self.assertIn("$env:PR_USER_LOGIN", run)
+        self.assertNotIn("${{ github.event.pull_request.title }}", run)
+        classify = steps_by_id(self.preflight)["classify-validation-mode"]
+        self.assertEqual("${{ steps.pull-request.outputs.base-sha }}", classify["env"]["PR_BASE_SHA"])
+        self.assertEqual("${{ steps.pull-request.outputs.is-bump }}", classify["env"]["PR_IS_BUMP"])
 
     def test_closed_event_still_promotes_staged_yaml_on_merge(self) -> None:
         finalize = workflow_job(self.workflow, "finalize-pr-workspace")

--- a/tests/test_pr_self_runner_workflow.py
+++ b/tests/test_pr_self_runner_workflow.py
@@ -85,12 +85,13 @@ class TestPrSelfRunnerWorkflow(unittest.TestCase):
         self.assertEqual("ubuntu-latest", self.light["runs-on"])
         self.assertIn("needs.pr-preflight.outputs.validation_path == 'light'", self.light["if"])
         light_steps = steps_by_id(self.light)
-        self.assertIn("install-formatters", light_steps)
         self.assertIn("format", light_steps)
         self.assertIn("verify-download-config", light_steps)
+        format_run = light_steps["format"]["run"]
+        self.assertIn("uv run --locked --only-group dev python format_repo_files.py --check", format_run)
         verify = light_steps["verify-download-config"]["run"]
         self.assertIn("latest_gamever", verify)
-        self.assertIn("configs\\$gamever.yaml", verify)
+        self.assertIn('Join-Path (Join-Path $env:WORKSPACE "configs") "${gamever}.yaml"', verify)
         self.assertNotIn("test-suites", light_steps)
         self.assertNotIn("analyze", light_steps)
         self.assertNotIn("build-snapshot", light_steps)

--- a/tests/test_pr_validation_mode.py
+++ b/tests/test_pr_validation_mode.py
@@ -193,6 +193,35 @@ class TestCli(unittest.TestCase):
         self.assertEqual(0, exit_code)
         self.assertIn("validation-mode=light", text)
 
+    def test_main_fails_closed_to_full_when_trusted_config_is_missing(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            output = Path(tmp) / "github-output.txt"
+            with (
+                mock.patch(
+                    "pr_validation_mode.load_rules_from_ref",
+                    side_effect=pvm.TrustedConfigMissingError("missing trusted config"),
+                ),
+                mock.patch(
+                    "pr_validation_mode.changed_paths",
+                    return_value=[ChangedPath("M", "docs/x.md", "docs/x.md")],
+                ),
+                mock.patch("pr_validation_mode.latest_gamever", return_value="14176"),
+            ):
+                exit_code = pvm.main(
+                    [
+                        "--repo-root",
+                        ".",
+                        "--base-ref",
+                        self.FAKE_SHA,
+                        "--force-light",
+                        "--github-output",
+                        str(output),
+                    ]
+                )
+            self.assertEqual(0, exit_code)
+            text = output.read_text(encoding="utf-8")
+            self.assertIn("validation-mode=full", text)
+
     def test_main_fails_closed_on_bad_base_ref(self) -> None:
         exit_code, _ = self._run_with_bad_base()
         self.assertEqual(1, exit_code)

--- a/tests/test_pr_validation_mode.py
+++ b/tests/test_pr_validation_mode.py
@@ -1,0 +1,272 @@
+"""Tests for the PR validation-mode classifier."""
+
+from __future__ import annotations
+
+import tempfile
+import unittest
+from pathlib import Path
+from unittest import mock
+
+import pr_validation_mode as pvm
+from gamesymbol_snapshot_lib.model import ChangedPath
+
+SAMPLE_RULES_YAML = """\
+schema_version: 1
+rules:
+  - paths:
+      - configs/*.yaml
+      - ida_analyze_bin.py
+    reason: analysis config and analyzer
+  - regexes:
+      - ^\\.claude/skills/find-.*
+    reason: find-* skills
+"""
+
+
+def _load_sample_rules() -> tuple[pvm.ImpactRule, ...]:
+    with tempfile.TemporaryDirectory() as tmp:
+        config = Path(tmp) / "pr_validation_mode.yaml"
+        config.write_text(SAMPLE_RULES_YAML, encoding="utf-8")
+        return pvm.load_rules_from_file(config)
+
+
+class TestParseRules(unittest.TestCase):
+    def test_valid_rules_parse(self) -> None:
+        rules = _load_sample_rules()
+        self.assertEqual(2, len(rules))
+        self.assertIn("configs/*.yaml", rules[0].glob_patterns)
+        self.assertEqual(1, len(rules[1].regex_patterns))
+
+    def test_unknown_top_level_key_rejected(self) -> None:
+        with self.assertRaises(pvm.PrValidationModeError):
+            pvm.parse_rules({"schema_version": 1, "rules": [], "extra": []})
+
+    def test_bad_schema_version_rejected(self) -> None:
+        with self.assertRaises(pvm.PrValidationModeError):
+            pvm.parse_rules({"schema_version": 2, "rules": [{"paths": ["a.py"]}]})
+
+    def test_empty_rules_rejected(self) -> None:
+        with self.assertRaises(pvm.PrValidationModeError):
+            pvm.parse_rules({"schema_version": 1, "rules": []})
+
+    def test_rule_without_paths_or_regexes_rejected(self) -> None:
+        with self.assertRaises(pvm.PrValidationModeError):
+            pvm.parse_rules({"schema_version": 1, "rules": [{"reason": "why"}]})
+
+    def test_unknown_rule_key_rejected(self) -> None:
+        with self.assertRaises(pvm.PrValidationModeError):
+            pvm.parse_rules({"schema_version": 1, "rules": [{"paths": ["a.py"], "scope": "all"}]})
+
+    def test_invalid_glob_rejected(self) -> None:
+        for pattern in ("a\\b.py", "/abs.py", "../up.py", "a[1].py", "a{b}.py", "a//b.py", ""):
+            with self.subTest(pattern=pattern), self.assertRaises(pvm.PrValidationModeError):
+                pvm.parse_rules({"schema_version": 1, "rules": [{"paths": [pattern]}]})
+
+    def test_invalid_regex_rejected(self) -> None:
+        with self.assertRaises(pvm.PrValidationModeError):
+            pvm.parse_rules({"schema_version": 1, "rules": [{"regexes": ["("]}]})
+
+    def test_non_string_path_entry_rejected(self) -> None:
+        with self.assertRaises(pvm.PrValidationModeError):
+            pvm.parse_rules({"schema_version": 1, "rules": [{"paths": ["a.py", 42]}]})
+
+
+class TestClassifyPaths(unittest.TestCase):
+    def setUp(self) -> None:
+        self.rules = _load_sample_rules()
+
+    def test_glob_hit_routes_full(self) -> None:
+        result = pvm.classify_paths(["configs/14176.yaml"], self.rules)
+        self.assertEqual("full", result.mode)
+        self.assertIn("analysis config and analyzer", result.matched_rules)
+
+    def test_glob_star_crosses_slash(self) -> None:
+        result = pvm.classify_paths(["configs/14176/extra.yaml"], self.rules)
+        self.assertEqual("full", result.mode)
+
+    def test_regex_hit_routes_full(self) -> None:
+        result = pvm.classify_paths([".claude/skills/find-Foo/SKILL.md"], self.rules)
+        self.assertEqual("full", result.mode)
+
+    def test_no_match_routes_light(self) -> None:
+        result = pvm.classify_paths(["docs/architecture.md"], self.rules)
+        self.assertEqual("light", result.mode)
+        self.assertEqual((), result.matched_rules)
+
+    def test_backslash_path_normalized(self) -> None:
+        result = pvm.classify_paths(["configs\\14176.yaml"], self.rules)
+        self.assertEqual("full", result.mode)
+
+    def test_leading_dot_slash_stripped(self) -> None:
+        result = pvm.classify_paths(["./ida_analyze_bin.py"], self.rules)
+        self.assertEqual("full", result.mode)
+
+    def test_force_light_overrides_match(self) -> None:
+        result = pvm.classify_paths(["ida_analyze_bin.py"], self.rules, force_light=True)
+        self.assertEqual("light", result.mode)
+        self.assertTrue(result.force_light)
+
+
+class TestParseChangedPaths(unittest.TestCase):
+    def test_rename_keeps_both_sides(self) -> None:
+        raw = b"R100\x00configs/old.yaml\x00configs/new.yaml\x00"
+        (change,) = pvm.parse_changed_paths(raw)
+        self.assertEqual("R", change.status)
+        self.assertEqual("configs/old.yaml", change.old_path)
+        self.assertEqual("configs/new.yaml", change.new_path)
+
+    def test_add_and_delete(self) -> None:
+        added, deleted = pvm.parse_changed_paths(b"A\x00gamesymbols/new.yaml\x00D\x00docs/old.md\x00")
+        self.assertEqual(ChangedPath("A", None, "gamesymbols/new.yaml"), added)
+        self.assertEqual(ChangedPath("D", "docs/old.md", None), deleted)
+
+    def test_malformed_status_rejected(self) -> None:
+        with self.assertRaises(pvm.PrValidationModeError):
+            pvm.parse_changed_paths(b"X\x00path\x00")
+
+    def test_rename_sides_both_route_full(self) -> None:
+        rules = pvm.parse_rules({"schema_version": 1, "rules": [{"paths": ["gamesymbols/**"]}]})
+        change = pvm.parse_changed_paths(b"R100\x00gamesymbols/old.yaml\x00gamesymbols/new.yaml\x00")[0]
+        paths = [path for path in (change.old_path, change.new_path) if path]
+        self.assertEqual("full", pvm.classify_paths(paths, rules).mode)
+
+
+class TestCli(unittest.TestCase):
+    FAKE_SHA = "a" * 40
+
+    def _run(self, *args, rules_yaml=SAMPLE_RULES_YAML):
+        with tempfile.TemporaryDirectory() as tmp:
+            config = Path(tmp) / "pr_validation_mode.yaml"
+            config.write_text(rules_yaml, encoding="utf-8")
+            output = Path(tmp) / "github-output.txt"
+            changes = [ChangedPath("M", "ida_analyze_bin.py", "ida_analyze_bin.py")]
+            with (
+                mock.patch("pr_validation_mode.changed_paths", return_value=changes),
+                mock.patch("pr_validation_mode.latest_gamever", return_value="14176"),
+            ):
+                exit_code = pvm.main(
+                    [
+                        "--repo-root",
+                        ".",
+                        "--base-ref",
+                        self.FAKE_SHA,
+                        "--config",
+                        str(config),
+                        "--github-output",
+                        str(output),
+                        *args,
+                    ]
+                )
+            return exit_code, output.read_text(encoding="utf-8") if output.exists() else ""
+
+    def test_main_writes_full_output(self) -> None:
+        exit_code, text = self._run()
+        self.assertEqual(0, exit_code)
+        self.assertIn("validation-mode=full", text)
+        self.assertIn("latest-gamever=14176", text)
+
+    def test_main_writes_light_output_for_unmatched(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            config = Path(tmp) / "pr_validation_mode.yaml"
+            config.write_text("schema_version: 1\nrules:\n  - paths: [configs/*.yaml]\n", encoding="utf-8")
+            output = Path(tmp) / "github-output.txt"
+            with mock.patch(
+                "pr_validation_mode.changed_paths", return_value=[ChangedPath("M", "docs/x.md", "docs/x.md")]
+            ):
+                exit_code = pvm.main(
+                    [
+                        "--repo-root",
+                        ".",
+                        "--base-ref",
+                        self.FAKE_SHA,
+                        "--config",
+                        str(config),
+                        "--github-output",
+                        str(output),
+                    ]
+                )
+            self.assertEqual(0, exit_code)
+            self.assertIn("validation-mode=light", output.read_text(encoding="utf-8"))
+
+    def test_main_force_light_overrides(self) -> None:
+        exit_code, text = self._run("--force-light")
+        self.assertEqual(0, exit_code)
+        self.assertIn("validation-mode=light", text)
+
+    def test_main_fails_closed_on_bad_base_ref(self) -> None:
+        exit_code, _ = self._run_with_bad_base()
+        self.assertEqual(1, exit_code)
+
+    def _run_with_bad_base(self) -> tuple[int, str]:
+        with tempfile.TemporaryDirectory() as tmp:
+            config = Path(tmp) / "pr_validation_mode.yaml"
+            config.write_text(SAMPLE_RULES_YAML, encoding="utf-8")
+            output = Path(tmp) / "github-output.txt"
+            exit_code = pvm.main(
+                ["--repo-root", ".", "--base-ref", "not-a-sha", "--config", str(config), "--github-output", str(output)]
+            )
+            return exit_code, output.read_text(encoding="utf-8") if output.exists() else ""
+
+
+class PrValidationModeRepositoryContractTests(unittest.TestCase):
+    def setUp(self) -> None:
+        repo_root = Path(__file__).resolve().parents[1]
+        self.rules = pvm.load_rules_from_file(repo_root / "pr_validation_mode.yaml")
+
+    def test_config_schema_is_current(self) -> None:
+        document = pvm.load_yaml((Path(__file__).resolve().parents[1] / "pr_validation_mode.yaml").read_bytes())
+        self.assertEqual(1, document["schema_version"])
+        self.assertTrue(document["rules"])
+
+    def test_analysis_paths_route_full(self) -> None:
+        full_paths = [
+            "download.yaml",
+            "configs/14176.yaml",
+            "gamesymbols/14176.yaml",
+            "pr_validation_version.py",
+            "ida_analyze_bin.py",
+            "ida_analyze_util.py",
+            "ida_skill_preprocessor.py",
+            "ida_preprocessor_scripts/find-Foo.py",
+            ".claude/skills/find-Foo/SKILL.md",
+            ".claude/skills/create-preprocessor-scripts/SKILL.md",
+            "gamesymbol_snapshot.py",
+            "gamesymbol_snapshot_lib/pr_validation.py",
+            "gamesymbol_candidate.py",
+            "gamesymbol_pr_validation.py",
+            "warmup_idb_worker.py",
+            "idb_cache.py",
+            "gamedata_candidate.py",
+            "gamedata-generators/CS2Fixes/gamedata.py",
+            "update_gamedata.py",
+            "run_cpp_tests.py",
+            "cpp_tests/foo.cpp",
+            "hl2sdk_cs2",
+            "process_scheduler_redis.py",
+            "release_workflow.py",
+            "release_workflow_lib/cli.py",
+            "agent_runner.py",
+            ".github/workflows/pr-self-runner.yml",
+            "pyproject.toml",
+            "pr_validation_mode.py",
+            "pr_validation_mode.yaml",
+        ]
+        for path in full_paths:
+            with self.subTest(path=path):
+                result = pvm.classify_paths([path], self.rules)
+                self.assertEqual("full", result.mode, f"expected full for {path}")
+
+    def test_innocuous_paths_stay_light(self) -> None:
+        for path in (
+            "README.md",
+            "docs/architecture.md",
+            "memory/notes.md",
+            ".claude/skills/cleanup-workspace/SKILL.md",
+        ):
+            with self.subTest(path=path):
+                result = pvm.classify_paths([path], self.rules)
+                self.assertEqual("light", result.mode, f"expected light for {path}")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- 新增路径分类器 `pr_validation_mode.py` + 规则配置 `pr_validation_mode.yaml`：按 PR 变更路径判定 full / lightweight。
- **Trusted split**：路由配置从 base commit 读取（`git show $BASE_SHA:pr_validation_mode.yaml`），PR 改的规则不能决定自己走不走 full/self-hosted；base 配置缺失即 fail-closed。
- 新增 `pr-validate-light` job（ubuntu-latest，格式检查 + download 配置存在性检查），仅对 light PR 运行；`pr-validate-full` 移除已死的 bump-download detect/bump-light 机制。
- 终局 `pr-validate` 按 `validation_path` 分流；默认规则集保守（含 process_*/release_workflow* 等仅由 full 集成测试覆盖的子系统）。
- 借鉴 GoldSrc (`D:/GoldSrc_VibeSignatures`) `plan_tag_impact` 的 trusted-split 与 impact-registry 思路，但不移植其 plan 机制（CS2 单 gamever 校验、full 内部已有增量/全量回退）。

## Design intent（设计意图）
- **问题**：此前 `validation-path=full` 对所有非 bump PR 硬编码，docs / release_workflow / process_* 等不涉及符号分析的 PR 也被迫占用 self-hosted 全量验证，成本高、排队长。
- **目标**：把"需要 full validation 的文件/路径"声明式写进配置文件（支持 glob 与正则），由分类器按变更路径判定 full/light 并路由到对应 job。
- **信任模型（核心不变量）**：full validation 是合并前的安全网。误判（false-light）会把坏符号直接合出，故障后置到发布流/运行时才暴露，代价远高于误判（false-full）仅浪费几分钟 CI。因此规则集刻意保守：
  - 不仅覆盖分析管线（ida_*.py、ida_preprocessor_scripts/、find-* skill、gamesymbols/**、configs/*.yaml 等），也覆盖仅由 full 的 redis/release 集成测试保障的子系统（process_*、release_workflow*、agent_runner）。
  - **Trusted split**：路由配置从 base commit 读取，PR 自己改的规则不能决定自己走不走 full/self-hosted；分类器与配置文件自身也列入 full 触发集（self-neutralization）；base 配置缺失时 fail-closed 全红。
- **借鉴来源**：GoldSrc（D:/GoldSrc_VibeSignatures）`plan_tag_impact` 的 trusted-split 与 impact-registry 设计；不移植其 plan 机制，因 CS2 是单 gamever 校验、full 内部已有 restore-base 的 incremental/bootstrap 回退，移植会重复造轮子。
- **路由语义映射**：full ≈ GoldSrc 的 analyze-self-hosted + validate-hosted；light ≈ no-op（无分析、无重建），仅做格式检查 + download 配置存在性检查，不跑测试套件。后续如需"无 IDA 的 hosted 重建"档位，可在 light 与 full 之间扩展三态。

## Test plan
- [x] `tests/run_test_suite.py unit -b`：1079/1079 通过
- [x] `tests/run_test_suite.py repository-contract -b`：92/92 通过（含更新的 `test_pr_self_runner_workflow` 与新防腐烂守卫）
- [x] ruff format / yamlfix 全合规；workflow 经 GitHubActionsLoader 解析通过
- [x] 分类器冒烟：pages/tests 变更→light；`ida_analyze_util.py`+`gamesymbols/*` 变更→full；trusted config 缺失→exit 1
- [ ] self-hosted 全量链路需真实 PR 上验证（本 PR 改动 workflow+路由自身，会走 full 自检验证）