### PR TITLE
feat(gamesymbols): add immutable alias metadata companion

### DIFF
--- a/.github/workflows/build-on-self-runner.yml
+++ b/.github/workflows/build-on-self-runner.yml
@@ -446,14 +446,17 @@ jobs:
           if ($LASTEXITCODE -ne 0) { throw "gamedata candidate guard failed before publication" }
           uv run gamedata_candidate.py publish -session "$env:GAMEDATA_SESSION" -outputdir "gamedata/$env:GAMEVER"
           if ($LASTEXITCODE -ne 0) { throw "gamedata publication failed with exit code $LASTEXITCODE" }
+          uv run gamesymbol_metadata.py generate -gamever "$env:GAMEVER" -configyaml "$env:ANALYSIS_CONFIG" -output "gamesymbols/$env:GAMEVER.metadata.yaml"
+          if ($LASTEXITCODE -ne 0) { throw "metadata generation failed with exit code $LASTEXITCODE" }
           $allowedSnapshot = "gamesymbols/$env:GAMEVER.yaml"
+          $allowedMetadata = "gamesymbols/$env:GAMEVER.metadata.yaml"
           $allowedGamedataPrefix = "gamedata/$env:GAMEVER/"
           $changedPaths = git status --porcelain=v1 --untracked-files=all | ForEach-Object {
             if ($_.Length -lt 4) { throw "Unexpected git status entry: $_" }
             $_.Substring(3).Replace('\', '/')
           }
           $rejected = @($changedPaths | Where-Object {
-            $_ -ne $allowedSnapshot -and -not $_.StartsWith($allowedGamedataPrefix, [StringComparison]::Ordinal)
+            $_ -ne $allowedSnapshot -and $_ -ne $allowedMetadata -and -not $_.StartsWith($allowedGamedataPrefix, [StringComparison]::Ordinal)
           })
           if ($rejected.Count -gt 0) {
             throw "Candidate publication changed paths outside the exact release outputs: $($rejected -join ', ')"
@@ -466,7 +469,7 @@ jobs:
           git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
           git checkout -b "$env:OUTPUT_BRANCH"
           if ($LASTEXITCODE -ne 0) { throw "Failed to create immutable output branch." }
-          git add -- "gamesymbols/$env:GAMEVER.yaml" "gamedata/$env:GAMEVER"
+          git add -- "gamesymbols/$env:GAMEVER.yaml" "gamesymbols/$env:GAMEVER.metadata.yaml" "gamedata/$env:GAMEVER"
           if ($LASTEXITCODE -ne 0) { throw "Failed to stage generated release output." }
           uv run release_workflow.py stage-build `
             --staging-root "$env:PERSISTED_WORKSPACE\release-staging" `

--- a/.github/workflows/deploy-pages.yml
+++ b/.github/workflows/deploy-pages.yml
@@ -6,7 +6,6 @@ on:
     paths:
       - 'pages/**'
       - 'gamesymbols/**'
-      - 'configs/**'
       - '.github/workflows/deploy-pages.yml'
   workflow_dispatch:
 

--- a/.github/workflows/promote-release-after-output-merge.yml
+++ b/.github/workflows/promote-release-after-output-merge.yml
@@ -146,7 +146,7 @@ jobs:
               throw "Source analysis config hash mismatch: expected $expectedConfigHash, actual $actualConfigHash"
             }
             $gamedataArgs = @(
-              "a", "gamedata-$gamever.7z", "configs\$gamever.yaml", "bin\$gamever", "gamesymbols/$gamever.yaml", "gamedata\$gamever", "hl2sdk_cs2", "-r",
+              "a", "gamedata-$gamever.7z", "configs\$gamever.yaml", "bin\$gamever", "gamesymbols/$gamever.yaml", "gamesymbols/$gamever.metadata.yaml", "gamedata\$gamever", "hl2sdk_cs2", "-r",
               "-x!*.dll", "-x!*.so", "-x!*.i64", "-x!*.idb", "-x!*.id0", "-x!*.id1", "-x!*.id2", "-x!*.nam", "-x!*.til",
               "-x!.git", "-x!.git-blame-ignore-revs", "-x!.gitmodules", "-xr!__pycache__"
             )

--- a/gamesymbol_metadata.py
+++ b/gamesymbol_metadata.py
@@ -1,0 +1,153 @@
+#!/usr/bin/env python3
+"""Generate the immutable alias-metadata companion for a game-symbol snapshot.
+
+``gamesymbols/<GAMEVER>.metadata.yaml`` carries the subset of
+``configs/<GAMEVER>.yaml`` that the pages app consumes at build time: the
+per-symbol alias map (``modules[].symbols[].alias``). It is emitted alongside
+the snapshot during release and freezes with it.
+
+Field-scope rule: a config field is included IFF it is present in the config,
+absent from the snapshot, and consumed by ``pages/``. Today that is only the
+alias map. See ``memory/gamesymbol_metadata.md``.
+"""
+
+from __future__ import annotations
+
+import argparse
+import os
+import tempfile
+import traceback
+from pathlib import Path
+
+import yaml
+
+from analysis_config import AnalysisConfigError, resolve_analysis_config
+from trusted_yaml import load_yaml_file
+
+REPO_ROOT = Path(__file__).resolve().parent
+
+
+class MetadataGenerationError(RuntimeError):
+    """Metadata could not be generated safely."""
+
+
+def normalize_alias_list(value) -> list[str]:
+    """Normalize a config ``alias`` value (string or list) into a string list."""
+    if value is None:
+        return []
+    if isinstance(value, str):
+        return [value] if value else []
+    if isinstance(value, list):
+        return [item for item in value if isinstance(item, str) and item]
+    return []
+
+
+def extract_alias_subset(raw: dict) -> dict:
+    """Return the config alias subset consumed by the pages app.
+
+    Mirrors ``pages/gameSymbolsPlugin.ts`` ``buildConfigAliasIndex``: read only
+    ``modules[].name``, ``modules[].symbols[].name``, and
+    ``modules[].symbols[].alias``. Symbols without aliases and modules without
+    any aliased symbol are omitted.
+    """
+    modules = []
+    for module in raw.get("modules", []):
+        if not isinstance(module, dict):
+            continue
+        module_name = module.get("name")
+        if not isinstance(module_name, str) or not module_name:
+            continue
+        symbols = []
+        for symbol in module.get("symbols", []) or []:
+            if not isinstance(symbol, dict):
+                continue
+            name = symbol.get("name")
+            if not isinstance(name, str) or not name:
+                continue
+            alias = normalize_alias_list(symbol.get("alias"))
+            if not alias:
+                continue
+            symbols.append({"name": name, "alias": alias})
+        if symbols:
+            modules.append({"name": module_name, "symbols": symbols})
+    return {"modules": modules}
+
+
+def _atomic_write_text(path: Path, data: str) -> None:
+    temporary = None
+    try:
+        path.parent.mkdir(parents=True, exist_ok=True)
+        with tempfile.NamedTemporaryFile(dir=path.parent, prefix=f".{path.name}.", delete=False) as handle:
+            temporary = Path(handle.name)
+            handle.write(data.encode("utf-8"))
+            handle.flush()
+            os.fsync(handle.fileno())
+        os.replace(temporary, path)
+    except OSError as exc:
+        raise MetadataGenerationError(f"unable to write metadata {path}: {exc}") from exc
+    finally:
+        if temporary and temporary.exists():
+            try:
+                temporary.unlink()
+            except OSError:
+                pass
+
+
+def generate_metadata(gamever: str, config_path, output_path: Path) -> Path:
+    raw = load_yaml_file(Path(config_path))
+    if not isinstance(raw, dict):
+        raise MetadataGenerationError(f"config root must be a mapping: {config_path}")
+    subset = extract_alias_subset(raw)
+    data = yaml.safe_dump(subset, sort_keys=False, allow_unicode=True)
+    destination = Path(output_path)
+    _atomic_write_text(destination, data)
+    return destination
+
+
+def default_metadata_path(gamever: str, *, repo_root: Path | None = None) -> Path:
+    root = Path(repo_root or REPO_ROOT)
+    return root / "gamesymbols" / f"{gamever}.metadata.yaml"
+
+
+def parse_args(argv=None):
+    parser = argparse.ArgumentParser(description="Generate game-symbol snapshot alias metadata")
+    parser.add_argument("-debug", action="store_true", help="Print tracebacks on errors")
+    commands = parser.add_subparsers(dest="command", required=True)
+    generate = commands.add_parser("generate")
+    generate.add_argument("-gamever", required=True)
+    generate.add_argument(
+        "-configyaml",
+        default=None,
+        help="Analysis config path; defaults to configs/<GAMEVER>.yaml",
+    )
+    generate.add_argument(
+        "-output",
+        default=None,
+        help="Output metadata path; defaults to gamesymbols/<GAMEVER>.metadata.yaml",
+    )
+    return parser.parse_args(argv)
+
+
+def _run(args) -> None:
+    if args.command != "generate":
+        raise MetadataGenerationError(f"unknown command: {args.command}")
+    config_path = resolve_analysis_config(args.gamever, args.configyaml)
+    output = Path(args.output) if args.output else default_metadata_path(args.gamever)
+    destination = generate_metadata(args.gamever, config_path, output)
+    print(f"Metadata written: {destination}")
+
+
+def main(argv=None) -> int:
+    args = parse_args(argv)
+    try:
+        _run(args)
+    except (AnalysisConfigError, MetadataGenerationError) as exc:
+        print(f"Error: {exc}")
+        if args.debug:
+            traceback.print_exc()
+        return 2
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/gamesymbols/14167.metadata.yaml
+++ b/gamesymbols/14167.metadata.yaml
@@ -1,0 +1,2861 @@
+modules:
+- name: networksystem
+  symbols:
+  - name: CNetworkMessages_RegisterNetworkCategory
+    alias:
+    - CNetworkMessages::RegisterNetworkCategory
+  - name: CNetworkMessages_AssociateNetMessageWithChannelCategoryAbstract
+    alias:
+    - CNetworkMessages::AssociateNetMessageWithChannelCategoryAbstract
+  - name: CNetworkMessages_FindOrCreateNetMessage
+    alias:
+    - CNetworkMessages::FindOrCreateNetMessage
+  - name: CNetworkMessages_SerializeInternal
+    alias:
+    - CNetworkMessages::SerializeInternal
+  - name: CNetworkMessages_UnserializeMessageInternal
+    alias:
+    - CNetworkMessages::UnserializeMessageInternal
+  - name: CNetworkMessages_SerializeMessageInternal
+    alias:
+    - CNetworkMessages::SerializeMessageInternal
+  - name: CNetworkMessages_UnserializeFromStream
+    alias:
+    - CNetworkMessages::UnserializeFromStream
+  - name: CNetworkMessages_AllocateAndCopyConstructNetMessageAbstract
+    alias:
+    - CNetworkMessages::AllocateAndCopyConstructNetMessageAbstract
+  - name: CNetworkMessages_DeallocateNetMessageAbstract
+    alias:
+    - CNetworkMessages::DeallocateNetMessageAbstract
+  - name: CNetworkMessages_RegisterNetworkFieldSerializer
+    alias:
+    - CNetworkMessages::RegisterNetworkFieldSerializer
+  - name: CNetworkMessages_RegisterNetworkArrayFieldSerializer
+    alias:
+    - CNetworkMessages::RegisterNetworkArrayFieldSerializer
+  - name: CNetworkMessages_AssociateNetMessageGroupIdWithChannelCategory
+    alias:
+    - CNetworkMessages::AssociateNetMessageGroupIdWithChannelCategory
+  - name: CNetworkMessages_RegisterNetworkFieldChangeCallbackInternal
+    alias:
+    - CNetworkMessages::RegisterNetworkFieldChangeCallbackInternal
+  - name: CNetworkMessages_AllowAdditionalMessageRegistration
+    alias:
+    - CNetworkMessages::AllowAdditionalMessageRegistration
+  - name: CNetworkMessages_IsAdditionalMessageRegistrationAllowed
+    alias:
+    - CNetworkMessages::IsAdditionalMessageRegistrationAllowed
+  - name: CNetworkMessages_RegisterFieldChangeCallbackPriority
+    alias:
+    - CNetworkMessages::RegisterFieldChangeCallbackPriority
+  - name: CNetworkMessages_ComputeOrderForPriority
+    alias:
+    - CNetworkMessages::ComputeOrderForPriority
+  - name: CNetworkMessages_dtor
+    alias:
+    - CNetworkMessages::~CNetworkMessages
+  - name: CNetworkMessages_GetIsForServer
+    alias:
+    - CNetworkMessages::GetIsForServer
+  - name: CNetworkMessages_GetNetworkSerializationContextData
+    alias:
+    - CNetworkMessages::GetNetworkSerializationContextData
+  - name: CNetChan_ParseMessagesDemoInternal
+    alias:
+    - CNetChan::ParseMessagesDemoInternal
+  - name: CNetChan_ParseNetMessageShowFilter
+    alias:
+    - CNetChan::ParseNetMessageShowFilter
+  - name: CNetworkMessages_FindNetworkMessagePartial
+    alias:
+    - CNetworkMessages::FindNetworkMessagePartial
+  - name: CNetworkMessages_FindNetworkMessage
+    alias:
+    - CNetworkMessages::FindNetworkMessage
+  - name: CNetworkMessages_FindNetworkGroup
+    alias:
+    - CNetworkMessages::FindNetworkGroup
+  - name: CNetworkSystem_SendNetworkStats
+    alias:
+    - CNetworkSystem::SendNetworkStats
+  - name: CNetworkMessages_GetNetworkGroupCount
+    alias:
+    - CNetworkMessages::GetNetworkGroupCount
+  - name: CNetworkMessages_GetNetworkGroupName
+    alias:
+    - CNetworkMessages::GetNetworkGroupName
+  - name: CNetworkMessages_GetNetworkGroupColor
+    alias:
+    - CNetworkMessages::GetNetworkGroupColor
+  - name: CNetworkMessages_ConfirmAllMessageHandlersInstalled
+    alias:
+    - CNetworkMessages::ConfirmAllMessageHandlersInstalled
+- name: engine
+  symbols:
+  - name: CServerSideClient_IsHearingClient
+    alias:
+    - IsHearingClient
+  - name: CGameResourceService_BuildResourceManifest
+    alias:
+    - CGameResourceService::BuildResourceManifest
+    - BuildResourceManifest
+  - name: CGameResourceService_m_pEntitySystem
+    alias:
+    - GameEntitySystem
+  - name: CGameResourceService_LoadGameResourceManifestNamed
+    alias:
+    - CGameResourceService::LoadGameResourceManifestNamed
+  - name: CGameResourceService_LoadGameResourceManifestGroup
+    alias:
+    - CGameResourceService::LoadGameResourceManifestGroup
+  - name: CGameResourceService_GetResourceManifestDebugName
+    alias:
+    - CGameResourceService::GetResourceManifestDebugName
+  - name: CGameResourceService_PrecacheEntitiesAndConfirmResourcesAreLoaded
+    alias:
+    - CGameResourceService::PrecacheEntitiesAndConfirmResourcesAreLoaded
+  - name: CGameResourceService_LoadGameResourceManifest_IEntityResourceManifest
+    alias:
+    - CGameResourceService::LoadGameResourceManifest
+  - name: CGameResourceService_DescribeContents
+    alias:
+    - CGameResourceService::DescribeContents
+  - name: CGameResourceService_AppendToGameResourceManifest
+    alias:
+    - CGameResourceService::AppendToGameResourceManifest
+  - name: CGameResourceService_RegisterEventMap
+    alias:
+    - CGameResourceService::RegisterEventMap
+  - name: IEntityResourceManifestBuilder_BuildResourceManifest_ManifestNameOrGroupName
+    alias:
+    - IEntityResourceManifestBuilder::BuildResourceManifest
+  - name: CServerSideClientBase_ClientPrintf
+    alias:
+    - CServerSideClientBase::ClientPrintf
+    - ClientPrintf
+  - name: CNetworkGameServer_ClientList
+    alias:
+    - CNetworkGameServer::ClientList
+  - name: CNetworkGameServerBase_SendPeerList
+    alias:
+    - CNetworkGameServerBase::SendPeerList
+  - name: CNetworkGameServerBase_ConnectClient
+    alias:
+    - CNetworkGameServerBase::ConnectClient
+  - name: CNetworkGameServerBase_ServerSimulateInternal
+    alias:
+    - CNetworkGameServerBase::ServerSimulateInternal
+  - name: CNetworkGameServerBase_ServerSimulate
+    alias:
+    - CNetworkGameServerBase::ServerSimulate
+  - name: CNetworkGameServerBase_ServerPollNetworking
+    alias:
+    - CNetworkGameServerBase::ServerPollNetworking
+  - name: CNetworkGameServerBase_BroadcastMessage
+    alias:
+    - CNetworkGameServerBase::BroadcastMessage
+  - name: CNetworkGameServerBase_BroadcastPrintf
+    alias:
+    - CNetworkGameServerBase::BroadcastPrintf
+  - name: CNetworkGameServerBase_ReserveServerForQueuedGame
+    alias:
+    - CNetworkGameServerBase::ReserveServerForQueuedGame
+  - name: CNetworkGameServerBase_FinishChangeLevel
+    alias:
+    - CNetworkGameServerBase::FinishChangeLevel
+  - name: CNetworkGameServerBase_StartChangeLevel
+    alias:
+    - CNetworkGameServerBase::StartChangeLevel
+  - name: CNetworkGameServerBase_SetServerState
+    alias:
+    - CNetworkGameServerBase::SetServerState
+  - name: CNetworkGameServer_GetFreeClient
+    alias:
+    - CNetworkGameServer::GetFreeClient
+    - GetFreeClient
+  - name: CNetworkGameServerBase_CreateFakeClient
+    alias:
+    - CNetworkGameServerBase::CreateFakeClient
+  - name: CNetworkGameServerBase_UserInfoChanged
+    alias:
+    - CNetworkGameServerBase::UserInfoChanged
+  - name: CNetworkGameServerBase_StartHLTVMaster
+    alias:
+    - CNetworkGameServerBase::StartHLTVMaster
+  - name: CNetworkGameServerBase_RegisterLoadingSpawnGroups
+    alias:
+    - CNetworkGameServerBase::RegisterLoadingSpawnGroups
+  - name: CNetworkServerSpawnGroupCreatePrerequisites_Init
+    alias:
+    - CNetworkServerSpawnGroupCreatePrerequisites::Init
+  - name: CNetworkGameServerBase_LoadSpawnGroup
+    alias:
+    - CNetworkGameServerBase::LoadSpawnGroup
+  - name: CNetworkGameServerBase_SpawnGroupThink
+    alias:
+    - CNetworkGameServerBase::SpawnGroupThink
+  - name: CNetworkGameServerBase_PrintSpawnGroupStatus
+    alias:
+    - CNetworkGameServerBase::PrintSpawnGroupStatus
+  - name: CNetworkGameServerBase_AsyncUnloadSpawnGroup
+    alias:
+    - CNetworkGameServerBase::AsyncUnloadSpawnGroup
+  - name: CNetworkGameServerBase_AsyncUnloadSpawnGroupInternal
+    alias:
+    - CNetworkGameServerBase::AsyncUnloadSpawnGroupInternal
+  - name: CNetworkGameServer_PrepareForAssetLoad
+    alias:
+    - CNetworkGameServer::PrepareForAssetLoad
+  - name: CNetworkGameServerBase_IsSaveRestoreAllowed
+    alias:
+    - CNetworkGameServerBase::IsSaveRestoreAllowed
+  - name: CNetworkGameServerBase_Init
+    alias:
+    - CNetworkGameServerBase::Init
+  - name: CNetworkGameServerBase_Shutdown
+    alias:
+    - CNetworkGameServerBase::Shutdown
+  - name: CNetworkGameServerBase_ShutdownInternal
+    alias:
+    - CNetworkGameServerBase::ShutdownInternal
+  - name: CNetworkGameServer_ActivateServer
+    alias:
+    - CNetworkGameServer::ActivateServer
+  - name: CNetworkGameServer_DirectUpdate
+    alias:
+    - CNetworkGameServer::DirectUpdate
+  - name: CNetworkGameServer_Init
+    alias:
+    - CNetworkGameServer::Init
+  - name: CNetworkGameServer_Shutdown
+    alias:
+    - CNetworkGameServer::Shutdown
+  - name: CNetworkGameServer_SpawnServer
+    alias:
+    - CNetworkGameServer::SpawnServer
+  - name: CNetworkGameServerBase_GetMaxClients
+    alias:
+    - CNetworkGameServerBase::GetMaxClients
+  - name: CNetworkGameServerBase_SetMaxClients
+    alias:
+    - CNetworkGameServerBase::SetMaxClients
+  - name: CNetworkGameServerBase_CheckTimeouts
+    alias:
+    - CNetworkGameServerBase::CheckTimeouts
+  - name: CNetworkGameServerBase_OnKickById
+    alias:
+    - CNetworkGameServerBase::OnKickById
+  - name: CNetworkGameServerBase_OnKickByName
+    alias:
+    - CNetworkGameServerBase::OnKickByName
+  - name: CNetworkGameClient_SendMovePacket
+    alias:
+    - CNetworkGameClient::SendMovePacket
+    - SendMovePacket
+  - name: CNetworkGameClient_SendMove
+    alias:
+    - CNetworkGameClient::SendMove
+    - SendMove
+  - name: INetworkMessages_Serialize
+    alias:
+    - INetworkMessages::Serialize
+  - name: CDemoRecorder_ParseMessage
+    alias:
+    - CDemoRecorder::ParseMessage
+  - name: CDemoRecorder_WriteSpawnGroups
+    alias:
+    - CDemoRecorder::WriteSpawnGroups
+  - name: INetworkMessages_SerializeAbstract
+    alias:
+    - INetworkMessages::SerializeAbstract
+  - name: INetworkMessages_GetNetMessageInfo
+    alias:
+    - INetworkMessages::GetNetMessageInfo
+  - name: INetworkMessages_FindNetworkMessageById
+    alias:
+    - INetworkMessages::FindNetworkMessageById
+  - name: CNetChan_ProcessMessages
+    alias:
+    - CNetChan::ProcessMessages
+  - name: CNetChan_ParseMessagesDemo
+    alias:
+    - CNetChan::ParseMessagesDemo
+  - name: CNetworkGameClient_ProcessPacketEntitiesInternal
+    alias:
+    - CNetworkGameClient::ProcessPacketEntitiesInternal
+  - name: CNetworkGameClient_ProcessPacketEntities
+    alias:
+    - CNetworkGameClient::ProcessPacketEntities
+    - ProcessPacketEntities
+  - name: CNetworkGameClient_RecordEntityBandwidth
+    alias:
+    - CNetworkGameClient::RecordEntityBandwidth
+    - RecordEntityBandwidth
+  - name: CNetworkGameClient_PrintNetStats
+    alias:
+    - CNetworkGameClient::PrintNetStats
+  - name: CMsgSource2NetworkFlowQuality_PrintStats
+    alias:
+    - CMsgSource2NetworkFlowQuality::PrintStats
+  - name: CNetworkGameClient_DisconnectGame
+    alias:
+    - CNetworkGameClient::DisconnectGame
+  - name: INetworkMessages_FindNetworkGroup
+    alias:
+    - INetworkMessages::FindNetworkGroup
+  - name: INetworkClientService_IsActive
+    alias:
+    - INetworkClientService::IsActive
+  - name: INetworkClientService_IsConnected
+    alias:
+    - INetworkClientService::IsConnected
+  - name: CNetworkClientService_ReceivedServerInfo
+    alias:
+    - CNetworkClientService::ReceivedServerInfo
+  - name: CNetworkClientService_SplitScreenConnect
+    alias:
+    - CNetworkClientService::SplitScreenConnect
+  - name: CNetworkClientService_SendNetMessage
+    alias:
+    - CNetworkClientService::SendNetMessage
+  - name: CNetworkClientService_SendStringCmd
+    alias:
+    - CNetworkClientService::SendStringCmd
+  - name: CNetworkClientService_StartChangeLevel
+    alias:
+    - CNetworkClientService::StartChangeLevel
+  - name: CNetworkClientService_FinishChangeLevel
+    alias:
+    - CNetworkClientService::FinishChangeLevel
+  - name: CNetworkClientService_PrintConnectionStatus
+    alias:
+    - CNetworkClientService::PrintConnectionStatus
+  - name: CNetworkClientService_OnStatus
+    alias:
+    - CNetworkClientService::OnStatus
+  - name: CNetworkClientService_ServerCmd
+    alias:
+    - CNetworkClientService::ServerCmd
+  - name: CNetworkClientService_GetDisconnectReason
+    alias:
+    - CNetworkClientService::GetDisconnectReason
+  - name: CNetworkClientService_PrintSpawnGroupStatus
+    alias:
+    - CNetworkClientService::PrintSpawnGroupStatus
+  - name: CNetworkClientService_IsActive
+    alias:
+    - CNetworkClientService::IsActive
+  - name: CNetworkClientService_IsConnected
+    alias:
+    - CNetworkClientService::IsConnected
+  - name: CNetworkClientService_ClockDriftAdjustFrameTime
+    alias:
+    - CNetworkClientService::ClockDriftAdjustFrameTime
+  - name: CNetworkClientService_Init
+    alias:
+    - CNetworkClientService::Init
+  - name: CNetworkClientService_Shutdown
+    alias:
+    - CNetworkClientService::Shutdown
+  - name: CNetworkClientService_DisconnectGameNow
+    alias:
+    - CNetworkClientService::DisconnectGameNow
+  - name: CGameClientConnectPrerequisite_ctor
+    alias:
+    - CGameClientConnectPrerequisite::CGameClientConnectPrerequisite
+  - name: CNetworkClientService_AddClientPrerequisites
+    alias:
+    - CNetworkClientService::AddClientPrerequisites
+  - name: CNetworkClientService_AllocateRemoteConnectionClient
+    alias:
+    - CNetworkClientService::AllocateRemoteConnectionClient
+  - name: CNetworkServerService_Init
+    alias:
+    - CNetworkServerService::Init
+  - name: CNetworkServerService_StartupServer
+    alias:
+    - CNetworkServerService::StartupServer
+  - name: CNetworkServerService_RegisterEventMapInternal
+    alias:
+    - CNetworkServerService::RegisterEventMapInternal
+  - name: CNetworkServerService_OnServerAdvanceTick
+    alias:
+    - CNetworkServerService::OnServerAdvanceTick
+  - name: CNetworkServerService_OnServerPollNetworking
+    alias:
+    - CNetworkServerService::OnServerPollNetworking
+  - name: CNetworkServerService_OnServerProcessNetworking
+    alias:
+    - CNetworkServerService::OnServerProcessNetworking
+  - name: CNetworkServerService_OnServerBeginSimulate
+    alias:
+    - CNetworkServerService::OnServerBeginSimulate
+  - name: CNetworkServerService_OnServerEndSimulate
+    alias:
+    - CNetworkServerService::OnServerEndSimulate
+  - name: CNetworkServerService_OnServerPostSimulate
+    alias:
+    - CNetworkServerService::OnServerPostSimulate
+  - name: CNetworkServerService_OnServerPostAdvanceTick
+    alias:
+    - CNetworkServerService::OnServerPostAdvanceTick
+  - name: CNetworkServerService_OnFrameBoundary
+    alias:
+    - CNetworkServerService::OnFrameBoundary
+  - name: CNetworkServerService_OnClientPollNetworking
+    alias:
+    - CNetworkServerService::OnClientPollNetworking
+  - name: CNetworkServerService_OnSimpleLoopFrameUpdate
+    alias:
+    - CNetworkServerService::OnSimpleLoopFrameUpdate
+  - name: CNetworkServerService_OnKickByIdHLTV
+    alias:
+    - CNetworkServerService::OnKickByIdHLTV
+  - name: CNetworkServerService_DisconnectGameNow
+    alias:
+    - CNetworkServerService::DisconnectGameNow
+  - name: INetworkGameServer_GetMaxClients
+    alias:
+    - INetworkGameServer::GetMaxClients
+  - name: INetworkGameServer_PreWorldUpdate
+    alias:
+    - INetworkGameServer::PreWorldUpdate
+  - name: CNetworkGameServer_PreWorldUpdate
+    alias:
+    - CNetworkGameServer::PreWorldUpdate
+  - name: INetworkGameServer_ServerEndSimulate
+    alias:
+    - INetworkGameServer::ServerEndSimulate
+  - name: CNetworkGameServerBase_ServerEndSimulate
+    alias:
+    - CNetworkGameServerBase::ServerEndSimulate
+  - name: INetworkGameServer_ServerPostSimulate
+    alias:
+    - INetworkGameServer::ServerPostSimulate
+  - name: CNetworkGameServerBase_ServerPostSimulate
+    alias:
+    - CNetworkGameServerBase::ServerPostSimulate
+  - name: INetworkGameServer_ServerAdvanceTick
+    alias:
+    - INetworkGameServer::ServerAdvanceTick
+  - name: CNetworkGameServerBase_ServerAdvanceTick
+    alias:
+    - CNetworkGameServerBase::ServerAdvanceTick
+  - name: INetworkGameServer_ServerProcessNetworking
+    alias:
+    - INetworkGameServer::ServerProcessNetworking
+  - name: CNetworkGameServerBase_ServerProcessNetworking
+    alias:
+    - CNetworkGameServerBase::ServerProcessNetworking
+  - name: INetworkGameServer_GetTimescale
+    alias:
+    - INetworkGameServer::GetTimescale
+  - name: CNetworkGameServerBase_GetTimescale
+    alias:
+    - CNetworkGameServerBase::GetTimescale
+  - name: ISource2Server_PreWorldUpdate
+    alias:
+    - ISource2Server::PreWorldUpdate
+  - name: ISource2Server_OutOfGameFrameBoundary
+    alias:
+    - ISource2Server::OutOfGameFrameBoundary
+  - name: INetworkMessages_SetIsForServer
+    alias:
+    - INetworkMessages::SetIsForServer
+  - name: CEngineClient_DumpNetStats
+    alias:
+    - CEngineClient::DumpNetStats
+  - name: CEngineServer_DumpNetStats
+    alias:
+    - CEngineServer::DumpNetStats
+  - name: CEngineServer_ClientPrintf
+    alias:
+    - CEngineServer::ClientPrintf
+  - name: CEngineServer_GetFrameTimeAmnesty
+    alias:
+    - CEngineServer::GetFrameTimeAmnesty
+  - name: CEngineServer_ShowFrameTimeReport
+    alias:
+    - CEngineServer::ShowFrameTimeReport
+  - name: CEngineServer_SetFrameTimeAmnesty
+    alias:
+    - CEngineServer::SetFrameTimeAmnesty
+  - name: CEngineServer_GetSteamUniverse
+    alias:
+    - CEngineServer::GetSteamUniverse
+  - name: CEngineServer_ChangeLevel
+    alias:
+    - CEngineServer::ChangeLevel
+  - name: CMapListService_IsMapValid
+    alias:
+    - CMapListService::IsMapValid
+    - IMapListService::IsMapValid
+  - name: CEngineServer_IsMapValid
+    alias:
+    - CEngineServer::IsMapValid
+  - name: CEngineServer_PrecacheGeneric
+    alias:
+    - CEngineServer::PrecacheGeneric
+  - name: CEngineServer_LightStyle
+    alias:
+    - CEngineServer::LightStyle
+  - name: CEngineServer_ClientCommand
+    alias:
+    - CEngineServer::ClientCommand
+  - name: CEngineServer_GetClientConVarValue
+    alias:
+    - CEngineServer::GetClientConVarValue
+  - name: CEngineServer_SetFakeClientConVarValue
+    alias:
+    - CEngineServer::SetFakeClientConVarValue
+  - name: CEngineServer_CreateFakeClient
+    alias:
+    - CEngineServer::CreateFakeClient
+  - name: CEngineServer_GetPlayerInfo
+    alias:
+    - CEngineServer::GetPlayerInfo
+  - name: CEngineServer_ClientCommandKeyValues
+    alias:
+    - CEngineServer::ClientCommandKeyValues
+  - name: CLog_Print
+    alias:
+    - CLog::Print
+  - name: CEngineServer_LogPrint
+    alias:
+    - CEngineServer::LogPrint
+  - name: CEngineServer_KickClient
+    alias:
+    - CEngineServer::KickClient
+  - name: CEngineServer_IsDedicatedServer
+    alias:
+    - CEngineServer::IsDedicatedServer
+  - name: CEngineServer_ServerCommand
+    alias:
+    - CEngineServer::ServerCommand
+  - name: CLoopTypeClientSimple_ActivateEngineServices
+    alias:
+    - CLoopTypeClientServer::ActivateEngineServices
+  - name: CLoopTypeClientServer_LoopTypeInit
+    alias:
+    - CLoopTypeClientServer::LoopTypeInit
+  - name: CLoopTypeClientServer_AdvanceTime
+    alias:
+    - CLoopTypeClientServer::AdvanceTime
+  - name: CLoopTypeClientServer_Update
+    alias:
+    - CLoopTypeClientServer::Update
+  - name: CLoopTypeClientServer_ActivateLoop
+    alias:
+    - CLoopTypeClientServer::ActivateLoop
+  - name: CLoopTypeClientServer_AllocateLoopMode
+    alias:
+    - CLoopTypeClientServer::AllocateLoopMode
+  - name: CLoopTypeClientServer_WritePerfStats
+    alias:
+    - CLoopTypeClientServer::WritePerfStats
+  - name: CLoopTypeClientServer_DeactivateLoop
+    alias:
+    - CLoopTypeClientServer::DeactivateLoop
+  - name: CLoopTypeClientServer_OutputListeners
+    alias:
+    - CLoopTypeClientServer::OutputListeners
+  - name: CLoopTypeSimple_FrameUpdate
+    alias:
+    - CLoopTypeSimple::FrameUpdate
+  - name: CLoopTypeClientServerService_OnLoopActivate
+    alias:
+    - CLoopTypeClientServerService::OnLoopActivate
+  - name: CLoopTypeSimpleService_OnLoopActivate
+    alias:
+    - CLoopTypeSimpleService::OnLoopActivate
+  - name: CLoopTypeClientServerService_HandleInputEvent
+    alias:
+    - CLoopTypeClientServerService::HandleInputEvent
+  - name: ILoopMode_HandleInputEvent
+    alias:
+    - ILoopMode::HandleInputEvent
+  - name: ILoopType_AddEngineService
+    alias:
+    - ILoopType::AddEngineService
+  - name: CLoopTypeBase_DeallocateLoopMode
+    alias:
+    - CLoopTypeBase::DeallocateLoopMode
+  - name: CLoopTypeBase_EngineLoop
+    alias:
+    - CLoopTypeBase::EngineLoop
+  - name: CLoopTypeBase_FrameUpdate
+    alias:
+    - CLoopTypeBase::FrameUpdate
+  - name: CLoopTypeBase_ActivateLoop
+    alias:
+    - CLoopTypeBase::ActivateLoop
+  - name: CLoopTypeBase_AllocateLoopMode
+    alias:
+    - CLoopTypeBase::AllocateLoopMode
+  - name: CLoopTypeBase_DeactivateLoop
+    alias:
+    - CLoopTypeBase::DeactivateLoop
+  - name: CLoopTypeBase_LoopTypeInit
+    alias:
+    - CLoopTypeBase::LoopTypeInit
+  - name: CLoopTypeBase_LoopTypeShutdown
+    alias:
+    - CLoopTypeBase::LoopTypeShutdown
+  - name: CLoopTypeBase_GetClientServerMode
+    alias:
+    - CLoopTypeBase::GetClientServerMode
+  - name: CLoopTypeBase_GetImplType
+    alias:
+    - CLoopTypeBase::GetImplType
+  - name: CLoopTypeBase_AddDependentServices
+    alias:
+    - CLoopTypeBase::AddDependentServices
+  - name: CLoopTypeBase_GenerateServiceDependencies
+    alias:
+    - CLoopTypeBase::GenerateServiceDependencies
+  - name: CLoopTypeBase_GenerateSecondaryDependencies
+    alias:
+    - CLoopTypeBase::GenerateSecondaryDependencies
+  - name: CLoopTypeBase_LoadDependentServices
+    alias:
+    - CLoopTypeBase::LoadDependentServices
+  - name: IEngineService_GetServiceDependencies
+    alias:
+    - IEngineService::GetServiceDependencies
+  - name: IEngineService_GetName
+    alias:
+    - IEngineService::GetName
+  - name: ILoopModeFactory_GetLoopModeType
+    alias:
+    - ILoopModeFactory::GetLoopModeType
+  - name: ILoopModeFactory_Shutdown
+    alias:
+    - ILoopModeFactory::Shutdown
+  - name: CEngineServiceMgr_RegisterEngineService
+    alias:
+    - CEngineServiceMgr::RegisterEngineService
+  - name: CEngineServiceMgr_RegisterLoopMode
+    alias:
+    - CEngineServiceMgr::RegisterLoopMode
+  - name: CEngineServiceMgr_UnregisterLoopMode
+    alias:
+    - CEngineServiceMgr::UnregisterLoopMode
+  - name: CEngineServiceMgr_UnregisterEngineService
+    alias:
+    - CEngineServiceMgr::UnregisterEngineService
+  - name: CEngineServiceMgr_SwitchToLoop
+    alias:
+    - CEngineServiceMgr::SwitchToLoop
+  - name: CEngineServiceMgr_PrintStatus
+    alias:
+    - CEngineServiceMgr::PrintStatus
+  - name: CEngineServiceMgr__MainLoop
+    alias:
+    - CEngineServiceMgr::_MainLoop
+  - name: CEngineServiceMgr_DeactivateLoop
+    alias:
+    - CEngineServiceMgr::DeactivateLoop
+  - name: CEngineServiceMgr_Shutdown
+    alias:
+    - CEngineServiceMgr::Shutdown
+  - name: CEngineServiceMgr_GetActiveLoopClientServerMode
+    alias:
+    - CEngineServiceMgr::GetActiveLoopClientServerMode
+  - name: CEngineServiceMgr_GetEventDispatcher
+    alias:
+    - CEngineServiceMgr::GetEventDispatcher
+  - name: CEngineGameUI_Shutdown
+    alias:
+    - CEngineGameUI::Shutdown
+  - name: IAppSystem_Shutdown
+    alias:
+    - IAppSystem::Shutdown
+  - name: CSplitScreenService_AddSplitScreenUser
+    alias:
+    - CSplitScreenService::AddSplitScreenUser
+  - name: CSplitScreenService_LoadUserConfiguration
+    alias:
+    - CSplitScreenService::LoadUserConfiguration
+  - name: CHLTVClient_ProcessSetConVar
+    alias:
+    - CHLTVClient::ProcessSetConVar
+  - name: CServerSideClientBase_ProcessTick
+    alias:
+    - CServerSideClientBase::ProcessTick
+  - name: CServerSideClientBase_ProcessStringCmd
+    alias:
+    - CServerSideClientBase::ProcessStringCmd
+  - name: CServerSideClientBase_MarkSpawnGroupLoadCompleted
+    alias:
+    - CServerSideClientBase::MarkSpawnGroupLoadCompleted
+  - name: CServerSideClientBase_ProcessSpawnGroup_LoadCompleted
+    alias:
+    - CServerSideClientBase::ProcessSpawnGroup_LoadCompleted
+  - name: CServerSideClientBase_ProcessClientInfo
+    alias:
+    - CServerSideClientBase::ProcessClientInfo
+  - name: CServerSideClientBase_ProcessBaselineAck
+    alias:
+    - CServerSideClientBase::ProcessBaselineAck
+  - name: CServerSideClientBase_ProcessSplitPlayerConnectInternal
+    alias:
+    - CServerSideClientBase::ProcessSplitPlayerConnectInternal
+  - name: CServerSideClientBase_ProcessSplitPlayerConnect
+    alias:
+    - CServerSideClientBase::ProcessSplitPlayerConnect
+  - name: CServerSideClientBase_GetUserIDString
+    alias:
+    - CServerSideClientBase::GetUserIDString
+  - name: CServerSideClientBase_GetNetworkIDString
+    alias:
+    - CServerSideClientBase::GetNetworkIDString
+  - name: CServerSideClientBase_Connect
+    alias:
+    - CServerSideClientBase::Connect
+  - name: CServerSideClientBase_GetPlayerInfo
+    alias:
+    - CServerSideClientBase::GetPlayerInfo
+  - name: CNetworkGameServer_GetPlayerNetworkIDString
+    alias:
+    - CNetworkGameServer::GetPlayerNetworkIDString
+  - name: CNetworkGameServerBase_RemoveClientFromGame
+    alias:
+    - CNetworkGameServerBase::RemoveClientFromGame
+  - name: CEngineServer_GetPlayerNetworkIDString
+    alias:
+    - CEngineServer::GetPlayerNetworkIDString
+  - name: CNetworkGameClientBase_ProcessSetConVar
+    alias:
+    - CNetworkGameClientBase::ProcessSetConVar
+  - name: CNetworkGameClientBase_SendStringCmd
+    alias:
+    - CNetworkGameClientBase::SendStringCmd
+  - name: CNetworkGameClientBase_StartChangeLevel
+    alias:
+    - CNetworkGameClientBase::StartChangeLevel
+  - name: CNetworkGameClientBase_FinishChangeLevel
+    alias:
+    - CNetworkGameClientBase::FinishChangeLevel
+  - name: CNetworkGameClientBase_DeferActivate
+    alias:
+    - CNetworkGameClientBase::DeferActivate
+  - name: CNetworkGameClientBase_ClockDrift_AdjustFrameTime
+    alias:
+    - CNetworkGameClientBase::ClockDrift_AdjustFrameTime
+  - name: CNetworkGameClientBase_Connect
+    alias:
+    - CNetworkGameClientBase::Connect
+  - name: CNetworkGameClientBase_DisconnectGame
+    alias:
+    - CNetworkGameClientBase::DisconnectGame
+  - name: CNetSupportImpl_Connect
+    alias:
+    - CNetSupportImpl::Connect
+- name: client
+  symbols:
+  - name: CLoopModeGame_RegisterEventMapInternal
+    alias:
+    - CLoopModeGame::RegisterEventMapInternal
+  - name: CLoopModeGame_OnClientPollNetworking
+    alias:
+    - CLoopModeGame::OnClientPollNetworking
+  - name: CLoopModeGame_OnClientAdvanceTick
+    alias:
+    - CLoopModeGame::OnClientAdvanceTick
+  - name: CLoopModeGame_OnClientPostAdvanceTick
+    alias:
+    - CLoopModeGame::OnClientPostAdvanceTick
+  - name: CLoopModeGame_OnClientPreSimulate
+    alias:
+    - CLoopModeGame::OnClientPreSimulate
+  - name: CLoopModeGame_OnClientPreOutput
+    alias:
+    - CLoopModeGame::OnClientPreOutput
+  - name: CLoopModeGame_OnClientPreOutputParallelWithServer
+    alias:
+    - CLoopModeGame::OnClientPreOutputParallelWithServer
+  - name: CLoopModeGame_OnClientPostOutput
+    alias:
+    - CLoopModeGame::OnClientPostOutput
+  - name: CLoopModeGame_OnClientFrameSimulate
+    alias:
+    - CLoopModeGame::OnClientFrameSimulate
+  - name: CLoopModeGame_OnClientAdvanceNonRenderedFrame
+    alias:
+    - CLoopModeGame::OnClientAdvanceNonRenderedFrame
+  - name: CLoopModeGame_OnClientPostSimulate
+    alias:
+    - CLoopModeGame::OnClientPostSimulate
+  - name: CLoopModeGame_OnClientPauseSimulate
+    alias:
+    - CLoopModeGame::OnClientPauseSimulate
+  - name: CLoopModeGame_OnClientSimulate
+    alias:
+    - CLoopModeGame::OnClientSimulate
+  - name: CLoopModeGame_OnPostDataUpdate
+    alias:
+    - CLoopModeGame::OnPostDataUpdate
+  - name: CLoopModeGame_OnPreDataUpdate
+    alias:
+    - CLoopModeGame::OnPreDataUpdate
+  - name: CLoopModeGame_OnFrameBoundary
+    alias:
+    - CLoopModeGame::OnFrameBoundary
+  - name: CLoopModeGame_StaticInit
+    alias:
+    - CLoopModeGame::StaticInit
+  - name: CLoopModeFactory_CLoopModeGame_Init
+    alias:
+    - CLoopModeFactory<CLoopModeGame>::Init
+  - name: CLoopModeFactory_CLoopModeGame_Shutdown
+    alias:
+    - CLoopModeFactory<CLoopModeGame>::Shutdown
+  - name: CLoopModeGame_OnLoopActivate
+    alias:
+    - CLoopModeGame::OnLoopActivate
+  - name: ILoopMode_OnLoopActivate
+    alias:
+    - ILoopMode::OnLoopActivate
+  - name: CLoopModeGame_AddViewsToSceneSystem
+    alias:
+    - CLoopModeGame::AddViewsToSceneSystem
+  - name: ILoopMode_AddViewsToSceneSystem
+    alias:
+    - ILoopMode::AddViewsToSceneSystem
+  - name: CLoopModeGame_LoopInitInternal
+    alias:
+    - CLoopModeGame::LoopInitInternal
+  - name: CLoopModeGame_LoopInit
+    alias:
+    - CLoopModeGame::LoopInit
+  - name: ILoopMode_LoopInit
+    alias:
+    - ILoopMode::LoopInit
+  - name: ILoopMode_LoopShutdown
+    alias:
+    - ILoopMode::LoopShutdown
+  - name: CLoopModeGame_ReceivedServerInfo
+    alias:
+    - CLoopModeGame::ReceivedServerInfo
+  - name: CLoopModeGame_RegisterEventMap
+    alias:
+    - CLoopModeGame::RegisterEventMap
+  - name: ILoopMode_RegisterEventMap
+    alias:
+    - ILoopMode::RegisterEventMap
+  - name: CLoopModeGame_SetWorldSession
+    alias:
+    - CLoopModeGame::SetWorldSession
+  - name: CLoopModeGame_SetGameSystemState
+    alias:
+    - CLoopModeGame::SetGameSystemState
+  - name: CLoopModeGame_LoopShutdown
+    alias:
+    - CLoopModeGame::LoopShutdown
+  - name: IGameSystem_AddByName
+    alias:
+    - IGameSystem::AddByName
+  - name: IGameSystem_Add
+    alias:
+    - IGameSystem::Add
+  - name: IGameSystem_PostInit
+    alias:
+    - IGameSystem::PostInit
+  - name: IGameSystem_InitAllSystems
+    alias:
+    - IGameSystem::InitAllSystems
+  - name: IGameSystem_LoopInitAllSystems
+    alias:
+    - IGameSystem::LoopInitAllSystems
+  - name: IGameSystemFactory_PostInit
+    alias:
+    - IGameSystemFactory::PostInit
+  - name: IGameSystemFactory_GetStaticGameSystem
+    alias:
+    - IGameSystemFactory::GetStaticGameSystem
+  - name: IGameSystemFactory_ShouldAutoAdd
+    alias:
+    - IGameSystemFactory::ShouldAutoAdd
+  - name: IGameSystemFactory_CreateGameSystem
+    alias:
+    - IGameSystemFactory::CreateGameSystem
+  - name: IGameSystemFactory_IsReallocating
+    alias:
+    - IGameSystemFactory::IsReallocating
+  - name: IGameSystem_SetName
+    alias:
+    - IGameSystem::SetName
+  - name: CSpawnGroupMgrGameSystem_DoesGameSystemReallocate
+    alias:
+    - IGameSystem::DoesGameSystemReallocate
+  - name: IGameSystem_DestroyAllGameSystems
+    alias:
+    - IGameSystem::DestroyAllGameSystems
+  - name: IGameSystem_ShutdownAllSystems
+    alias:
+    - IGameSystem::ShutdownAllSystems
+  - name: IGameSystem_LoopDestroyAllSystems
+    alias:
+    - IGameSystem::LoopDestroyAllSystems
+  - name: IGameSystem_LoopPreShutdownAllSystems
+    alias:
+    - IGameSystem::LoopPreShutdownAllSystems
+  - name: IGameSystem_OnClientPollNetworking
+    alias:
+    - IGameSystem::OnClientPollNetworking
+  - name: IGameSystem_OnClientGamePostSimulate
+    alias:
+    - IGameSystem::ClientGamePostSimulate
+  - name: IGameSystem_OnClientPauseSimulate
+    alias:
+    - IGameSystem::OnClientPauseSimulate
+  - name: IGameSystem_OnClientPreUpdate
+    alias:
+    - IGameSystem::OnClientPreUpdate
+  - name: IGameSystem_OnClientPostUpdate
+    alias:
+    - IGameSystem::OnClientPostUpdate
+  - name: IGameSystem_OnClientPostDataUpdate
+    alias:
+    - IGameSystem::OnClientPostDataUpdate
+  - name: IGameSystem_OnGameFrameBoundary
+    alias:
+    - IGameSystem::OnGameFrameBoundary
+  - name: IGameSystem_OnClientAdvanceNonRenderedFrame
+    alias:
+    - IGameSystem::OnClientAdvanceNonRenderedFrame
+  - name: IGameSystem_OnClientFrameSimulate
+    alias:
+    - IGameSystem::OnClientFrameSimulate
+  - name: IGameSystem_OnClientAdvanceTick
+    alias:
+    - IGameSystem::ClientAdvanceTick
+  - name: IGameSystem_OnClientPostAdvanceTick
+    alias:
+    - IGameSystem::ClientPostAdvanceTick
+  - name: IGameSystem_OnClientPostRender
+    alias:
+    - IGameSystem::OnClientPostRender
+  - name: IGameSystem_OnClientPreRender
+    alias:
+    - IGameSystem::OnClientPreRender
+  - name: IGameSystem_OnClientPreRenderAlt
+    alias:
+    - IGameSystem::OnClientPreRenderAlt
+  - name: CSource2Client_OnDisconnect
+    alias:
+    - CSource2Client::OnDisconnect
+  - name: IGameSystem_OnClientDisconnect
+    alias:
+    - IGameSystem::OnClientDisconnect
+  - name: IGameSystem_OnClientPreEntityThink
+    alias:
+    - IGameSystem::OnClientPreEntityThink
+  - name: CSteamworksGameStats_OnReceivedSessionID
+    alias:
+    - CSteamworksGameStats::OnReceivedSessionID
+  - name: IGameSystem_GetName
+    alias:
+    - IGameSystem::GetName
+  - name: IGameSystemFactory_DestroyGameSystem
+    alias:
+    - IGameSystemFactory::DestroyGameSystem
+  - name: IGameSystemFactory_Init
+    alias:
+    - IGameSystemFactory::Init
+  - name: IGameSystemFactory_GetPriority
+    alias:
+    - IGameSystemFactory::GetPriority
+  - name: IGameSystemFactory_Shutdown
+    alias:
+    - IGameSystemFactory::Shutdown
+  - name: IGameSystemFactory_SetGlobalPtr
+    alias:
+    - IGameSystemFactory::SetGlobalPtr
+  - name: CPrediction_PostNetworkDataReceived
+    alias:
+    - CPrediction::PostNetworkDataReceived
+  - name: IEngineServiceMgr_GetActiveLoopClientServerMode
+    alias:
+    - IEngineServiceMgr::GetActiveLoopClientServerMode
+  - name: IEngineServiceMgr_GetEventDispatcher
+    alias:
+    - IEngineServiceMgr::GetEventDispatcher
+  - name: ClientModeCSNormal_Update
+    alias:
+    - ClientModeCSNormal::Update
+  - name: CEntitySystem_ctor
+    alias:
+    - CEntitySystem::CEntitySystem
+  - name: CGameEntitySystem_ctor
+    alias:
+    - CGameEntitySystem::CGameEntitySystem
+  - name: CEntitySystem_Init
+    alias:
+    - CEntitySystem::Init
+  - name: CEntitySystem_PostCreateEntitySystem
+    alias:
+    - CEntitySystem::PostCreateEntitySystem
+  - name: CSource2EntitySystem_StaticInit
+    alias:
+    - CSource2EntitySystem::StaticInit
+  - name: CGameSystemReallocatingFactory_CSource2EntitySystem_Init
+    alias:
+    - CGameSystemReallocatingFactory<CSource2EntitySystem>::Init
+  - name: CGameSystemReallocatingFactory_CSource2EntitySystem_CreateGameSystem
+    alias:
+    - CGameSystemReallocatingFactory<CSource2EntitySystem>::CreateGameSystem
+  - name: CSkeletonInstance_PostDataUpdate
+    alias:
+    - CSkeletonInstance::PostDataUpdate
+  - name: CSkeletonInstance_m_simulationState_m_nTotalTransformCount
+    alias:
+    - CSkeletonInstance::m_simulationState.m_nTotalTransformCount
+  - name: CSkeletonInstance_m_simulationState_m_nBoneCount
+    alias:
+    - CSkeletonInstance::m_simulationState.m_nBoneCount
+  - name: CSkeletonInstance_m_simulationState_m_nAttachmentCount
+    alias:
+    - CSkeletonInstance::m_simulationState.m_nAttachmentCount
+  - name: CSkeletonInstance_m_modelState_m_hModel
+    alias:
+    - CSkeletonInstance::m_modelState.m_hModel
+  - name: IVEngineClient2_GetNetworkClient
+    alias:
+    - IVEngineClient2::GetNetworkClient
+  - name: INetworkClient_GetLocalAddress
+    alias:
+    - INetworkClient::GetLocalAddress
+  - name: INetworkClientService_IsConnected
+    alias:
+    - INetworkClientService::IsConnected
+  - name: INetworkClientService_SendNetMessage
+    alias:
+    - INetworkClientService::SendNetMessage
+  - name: IGameResourceService_SetEntityResourceManifestHandler
+    alias:
+    - IGameResourceService::SetEntityResourceManifestHandler
+  - name: CNetworkSerializerBindingBuildFilter_GetFieldPriority
+    alias:
+    - CNetworkSerializerBindingBuildFilter::GetFieldPriority
+- name: server
+  symbols:
+  - name: CSource2Server_OnStreamEntitiesFromFileCompleted
+    alias:
+    - CSource2Server::OnStreamEntitiesFromFileCompleted
+  - name: CSource2Server_PreWorldUpdate
+    alias:
+    - CSource2Server::PreWorldUpdate
+  - name: CSource2Server_OutOfGameFrameBoundary
+    alias:
+    - CSource2Server::OutOfGameFrameBoundary
+  - name: CGameSystemReallocatingFactory_CSource2EntitySystem_Init
+    alias:
+    - CGameSystemReallocatingFactory<CSource2EntitySystem>::Init
+  - name: CGameSystemReallocatingFactory_CSource2EntitySystem_CreateGameSystem
+    alias:
+    - CGameSystemReallocatingFactory<CSource2EntitySystem>::CreateGameSystem
+  - name: IGameSystemFactory_Init
+    alias:
+    - IGameSystemFactory::Init
+  - name: IGameSystemFactory_Shutdown
+    alias:
+    - IGameSystemFactory::Shutdown
+  - name: IGameSystemFactory_SetGlobalPtr
+    alias:
+    - IGameSystemFactory::SetGlobalPtr
+  - name: CGameSystemReallocatingFactory_CSpawnGroupMgrGameSystem_DestroyGameSystem
+    alias:
+    - CGameSystemReallocatingFactory<CSpawnGroupMgrGameSystem>::Deallocate
+  - name: IGameSystem_SetGameSystemGlobalPtrs
+    alias:
+    - IGameSystem::SetGameSystemGlobalPtrs
+  - name: IGameSystem_vdtor
+    alias:
+    - IGameSystem::~IGameSystem
+  - name: IGameSystem_OnGameInit
+    alias:
+    - IGameSystem::GameInit
+  - name: CMultiplayRules_ctor
+    alias:
+    - CMultiplayRules::CMultiplayRules
+  - name: CGameMoney_OnMoneySpent
+    alias:
+    - CGameMoney::OnMoneySpent
+  - name: CGameMoney_m_DataMap
+    alias:
+    - CGameMoney::m_DataMap
+  - name: CGameMoney_GetDataDescMap
+    alias:
+    - CGameMoney::GetDataDescMap
+  - name: CCSPlayer_UseServices_OnUseImpl
+    alias:
+    - CCSPlayer_UseServices::OnUseImpl
+  - name: CCSPlayer_UseServices_OnUse
+    alias:
+    - CCSPlayer_UseServices::OnUse
+  - name: CCSPlayer_MovementServices_ProcessMovement
+    alias:
+    - CCSPlayer_MovementServices::ProcessMovement
+    - ProcessMovement
+  - name: CCSPlayer_MovementServices_CheckMovingGround
+    alias:
+    - CCSPlayer_MovementServices::CheckMovingGround
+    - CheckMovingGround
+  - name: CCSPlayer_MovementServices_WalkMove
+    alias:
+    - CCSPlayer_MovementServices::WalkMove
+    - WalkMove
+  - name: CCSPlayer_MovementServices_FullWalkMove
+    alias:
+    - CCSPlayer_MovementServices::FullWalkMove
+    - FullWalkMove
+  - name: CCSPlayer_MovementServices_CheckVelocity
+    alias:
+    - CCSPlayer_MovementServices::CheckVelocity
+    - CheckVelocity
+  - name: CCSPlayer_MovementServices_WaterMove
+    alias:
+    - CCSPlayer_MovementServices::WaterMove
+    - WaterMove
+  - name: CCSPlayer_MovementServices_FullWalkMove_SpeedClamp
+    alias:
+    - ServerMovementUnlock
+  - name: CCSPlayer_MovementServices_CheckJumpButton
+    alias:
+    - CCSPlayer_MovementServices::CheckJumpButton
+  - name: CCSPlayer_MovementServices_CheckJumpButton_WaterPatch
+    alias:
+    - CheckJumpButtonWater
+    - FixWaterFloorJump
+  - name: CPlayer_MovementServices_PlayWaterStepSound
+    alias:
+    - CPlayer_MovementServices::PlayWaterStepSound
+  - name: CPlayer_MovementServices_ForceButtons
+    alias:
+    - CPlayer_MovementServices::ForceButtons
+  - name: CPlayer_MovementServices_ForceButtonState
+    alias:
+    - CPlayer_MovementServices::ForceButtonState
+  - name: CPlayer_MovementServices_s_pRunCommandPawn
+    alias:
+    - CPlayer_MovementServices::s_pRunCommandPawn
+  - name: CEntityInstance_m_pEntity
+    alias:
+    - CEntityInstance::m_pEntity
+  - name: CEntityInstance_m_hPrivateScope
+    alias:
+    - CEntityInstance::m_hPrivateScope
+  - name: CEntityInstance_m_CScriptComponent
+    alias:
+    - CEntityInstance::m_CScriptComponent
+  - name: CEntityInstance_m_pKeyValues
+    alias:
+    - CEntityInstance::m_pKeyValues
+  - name: CEntityInstance_m_iszPrivateVScripts
+    alias:
+    - CEntityInstance::m_iszPrivateVScripts
+  - name: CBaseEntity_OnRestore
+    alias:
+    - CBaseEntity::OnRestore
+  - name: CEntityInstance_OnRestore
+    alias:
+    - CEntityInstance::OnRestore
+  - name: CBaseEntity_ctor
+    alias:
+    - CBaseEntity::CBaseEntity
+  - name: CBaseEntity_dtor
+    alias:
+    - CBaseEntity::~CBaseEntity
+  - name: CBaseEntity_vdtor
+    alias:
+    - CBaseEntity::~CBaseEntity (virtual)
+  - name: CEntityInstance_vdtor
+    alias:
+    - CEntityInstance::~CEntityInstance (virtual)
+  - name: CEntitySaveRestoreBlockHandler_PreSave
+    alias:
+    - CEntitySaveRestoreBlockHandler::PreSave
+  - name: CEntitySaveRestoreBlockHandler_SaveInternal
+    alias:
+    - CEntitySaveRestoreBlockHandler::SaveInternal
+  - name: CEntitySaveRestoreBlockHandler_Save
+    alias:
+    - CEntitySaveRestoreBlockHandler::Save
+  - name: CEntitySaveRestoreBlockHandler_Restore
+    alias:
+    - CEntitySaveRestoreBlockHandler::Restore
+  - name: CEntitySaveRestoreBlockHandler_DoRestoreEntity
+    alias:
+    - CEntitySaveRestoreBlockHandler::DoRestoreEntity
+  - name: CEntitySaveRestoreBlockHandler_RestoreEntity
+    alias:
+    - CEntitySaveRestoreBlockHandler::RestoreEntity
+  - name: CreateEntityTransitionList
+    alias:
+    - CreateEntityTransitionList
+  - name: CEntitySaveRestoreBlockHandler_WriteSaveHeaders
+    alias:
+    - CEntitySaveRestoreBlockHandler::WriteSaveHeaders
+  - name: CEntitySaveRestoreBlockHandler_ReadRestoreHeaders
+    alias:
+    - CEntitySaveRestoreBlockHandler::ReadRestoreHeaders
+  - name: CEntity2SaveRestore_StreamEntitiesFromFile
+    alias:
+    - CEntity2SaveRestore::StreamEntitiesFromFile
+  - name: CSaveRestoreBlockSet_PreRestore
+    alias:
+    - CSaveRestoreBlockSet::PreRestore
+  - name: CSaveRestoreBlockSet_PostRestore
+    alias:
+    - CSaveRestoreBlockSet::PostRestore
+  - name: CEntitySaveRestoreBlockHandler_PreRestore
+    alias:
+    - CEntitySaveRestoreBlockHandler::PreRestore
+  - name: CEntitySaveRestoreBlockHandler_PostRestore
+    alias:
+    - CEntitySaveRestoreBlockHandler::PostRestore
+  - name: CEntitySystem_ForceSetInPVSCallsIntoQueue
+    alias:
+    - CEntitySystem::ForceSetInPVSCallsIntoQueue
+  - name: CEntitySystem_ExecuteQueuedSetInPVS
+    alias:
+    - CEntitySystem::ExecuteQueuedSetInPVS
+  - name: CEntitySystem_m_nSuppressDormancyChangeCount
+    alias:
+    - CEntitySystem::m_nSuppressDormancyChangeCount
+  - name: CEntitySystem_m_nExecuteQueuedCreationDepth
+    alias:
+    - CEntitySystem::m_nExecuteQueuedCreationDepth
+  - name: CEntitySystem_m_queuedDormancyChanges
+    alias:
+    - CEntitySystem::m_queuedDormancyChanges
+  - name: CEntitySystem_SetInPVS
+    alias:
+    - CEntitySystem::SetInPVS
+  - name: CEntitySystem_OnSetDormant
+    alias:
+    - CEntitySystem::OnSetDormant
+  - name: CEntitySystem_BuildResourceManifestForEntity
+    alias:
+    - CEntitySystem::BuildResourceManifestForEntity
+  - name: CEntityInstance_ObjectCaps
+    alias:
+    - CEntityInstance::ObjectCaps
+  - name: CEntityInstance_Save
+    alias:
+    - CEntityInstance::Save
+  - name: CEntityInstance_Restore
+    alias:
+    - CEntityInstance::Restore
+  - name: CEntitySaveRestoreBlockHandler_SaveInitEntities
+    alias:
+    - CEntitySaveRestoreBlockHandler::SaveInitEntities
+  - name: CEntityInstance_OnSave
+    alias:
+    - CEntityInstance::OnSave
+  - name: CEntityInstance_RequiredEdictIndex
+    alias:
+    - CEntityInstance::RequiredEdictIndex
+  - name: PolymorphicHelper_t__SetPolymorphicPointer
+    alias:
+    - PolymorphicHelper_t::SetPolymorphicPointer
+  - name: CEntityInstance_AddChangeAccessorPathPolymorphic
+    alias:
+    - CEntityInstance::AddChangeAccessorPathPolymorphic
+  - name: CEntityInstance_AssignChangeAccessorPathIdsPolymorphic
+    alias:
+    - CEntityInstance::AssignChangeAccessorPathIdsPolymorphic
+  - name: CEntityInstance_AddChangeAccessorPath
+    alias:
+    - CEntityInstance::AddChangeAccessorPath
+  - name: CEntityInstance_AssignChangeAccessorPathIds
+    alias:
+    - CEntityInstance::AssignChangeAccessorPathIds
+  - name: CEntityInstance_GetChangeAccessorPathInfo_2
+    alias:
+    - CEntityInstance::GetChangeAccessorPathInfo_2
+  - name: CBaseEntity_GetChangeAccessorPathInfo_2
+    alias:
+    - CBaseEntity::GetChangeAccessorPathInfo_2
+  - name: CBaseEntity_GetChangeAccessorPathInfo_1
+    alias:
+    - CBaseEntity::GetChangeAccessorPathInfo_1
+  - name: CMomentaryRotButton_Use
+    alias:
+    - CMomentaryRotButton::Use
+  - name: CBaseEntity_TakeDamageOld
+    alias:
+    - CBaseEntity::TakeDamageOld
+  - name: CBaseEntity_OnTakeDamage
+    alias:
+    - CBasePlayerPawn::OnTakeDamage
+  - name: CBasePlayerPawn_OnTakeDamage_Alive
+    alias:
+    - CBasePlayerPawn::OnTakeDamage_Alive
+  - name: CBasePlayerPawn_OnTakeDamage_Dying
+    alias:
+    - CBasePlayerPawn::OnTakeDamage_Dying
+  - name: CBasePlayerPawn_OnTakeDamage_Dead
+    alias:
+    - CBasePlayerPawn::OnTakeDamage_Dead
+  - name: CBasePlayerPawn_OnTakeDamage
+    alias:
+    - CBasePlayerPawn::OnTakeDamage
+  - name: CCSPlayerPawn_OnTakeDamage_Alive
+    alias:
+    - CCSPlayerPawn::OnTakeDamage_Alive
+  - name: CCSPlayerPawn_OnTakeDamage_Dying
+    alias:
+    - CCSPlayerPawn::OnTakeDamage_Dying
+  - name: CCSPlayerPawn_OnTakeDamage_Dead
+    alias:
+    - CCSPlayerPawn::OnTakeDamage_Dead
+  - name: CFlashbangProjectile_Spawn
+    alias:
+    - CFlashbangProjectile::Spawn
+  - name: CSmokeGrenadeProjectile_Create
+    alias:
+    - CSmokeGrenadeProjectile::Create
+  - name: CEntitySystem_QueueDestroyEntity
+    alias:
+    - CEntitySystem::QueueDestroyEntity
+  - name: CEntitySystem_ExecuteQueuedDeletion
+    alias:
+    - CEntitySystem::ExecuteQueuedDeletion
+  - name: CEntitySystem_m_nExecuteQueuedDeletionDepth
+    alias:
+    - CEntitySystem::m_nExecuteQueuedDeletionDepth
+  - name: CBaseModelEntity_SetModel
+    alias:
+    - CBaseModelEntity::SetModel
+  - name: CBaseModelEntity_SetRenderAttribute
+    alias:
+    - CBaseModelEntity::SetRenderAttribute
+  - name: CBaseEntity_GetScriptDescInternal
+    alias:
+    - CBaseEntity::GetScriptDescInternal
+  - name: CBaseModelEntity_GetScriptDescInternal
+    alias:
+    - CBaseModelEntity::GetScriptDescInternal
+  - name: CBaseModelEntity_GetModelScale
+    alias:
+    - CBaseModelEntity::GetModelScale
+  - name: CBaseModelEntity_Script_SetModelScale
+    alias:
+    - CBaseModelEntity::Script_SetModelScale
+  - name: CBaseModelEntity_ScriptLookupAttachment
+    alias:
+    - CBaseModelEntity::ScriptLookupAttachment
+  - name: CBaseModelEntity_ScriptGetAttachmentOrigin
+    alias:
+    - CBaseModelEntity::ScriptGetAttachmentOrigin
+  - name: CBaseModelEntity_ScriptGetAttachmentAngles
+    alias:
+    - CBaseModelEntity::ScriptGetAttachmentAngles
+  - name: CBaseModelEntity_ScriptGetAttachmentForward
+    alias:
+    - CBaseModelEntity::ScriptGetAttachmentForward
+  - name: CBaseModelEntity_ScriptSetSize
+    alias:
+    - CBaseModelEntity::ScriptSetSize
+  - name: CBaseModelEntity_ScriptSetModel
+    alias:
+    - CBaseModelEntity::ScriptSetModel
+  - name: CBaseModelEntity_ScriptGetRenderAlpha
+    alias:
+    - CBaseModelEntity::ScriptGetRenderAlpha
+  - name: CBaseModelEntity_ScriptSetRenderAlpha
+    alias:
+    - CBaseModelEntity::ScriptSetRenderAlpha
+  - name: CBaseModelEntity_ScriptSetRenderMode
+    alias:
+    - CBaseModelEntity::ScriptSetRenderMode
+  - name: CBaseModelEntity_ScriptSetRenderColor
+    alias:
+    - CBaseModelEntity::ScriptSetRenderColor
+  - name: CBaseModelEntity_ScriptGetRenderColor
+    alias:
+    - CBaseModelEntity::ScriptGetRenderColor
+  - name: CBaseModelEntity_ScriptSetMaterialGroup
+    alias:
+    - CBaseModelEntity::ScriptSetMaterialGroup
+  - name: CBaseModelEntity_ScriptSetMaterialGroupHash
+    alias:
+    - CBaseModelEntity::ScriptSetMaterialGroupHash
+  - name: CBaseModelEntity_ScriptGetMaterialGroupHash
+    alias:
+    - CBaseModelEntity::ScriptGetMaterialGroupHash
+  - name: CBaseModelEntity_ScriptSetSingleMeshGroup
+    alias:
+    - CBaseModelEntity::ScriptSetSingleMeshGroup
+  - name: CBaseModelEntity_ScriptSetMeshGroupMask
+    alias:
+    - CBaseModelEntity::ScriptSetMeshGroupMask
+  - name: CBaseModelEntity_ScriptGetMeshGroupMask
+    alias:
+    - CBaseModelEntity::ScriptGetMeshGroupMask
+  - name: CBaseModelEntity_ScriptSetBodygroupByName
+    alias:
+    - CBaseModelEntity::ScriptSetBodygroupByName
+  - name: CBaseModelEntity_Script_SetBodygroup
+    alias:
+    - CBaseModelEntity::Script_SetBodygroup
+  - name: CBaseModelEntity_Script_SetSkin
+    alias:
+    - CBaseModelEntity::Script_SetSkin
+  - name: CEntityInstance_NetworkUpdateState_thunk
+    alias:
+    - CEntityInstance::NetworkUpdateState_thunk
+  - name: CBaseEntity_SetGravityScale
+    alias:
+    - CBaseEntity::SetGravityScale
+  - name: CTriggerGravity_GravityTouch
+    alias:
+    - CTriggerGravity::GravityTouch
+  - name: CTriggerGravity_GetTouchFunction
+    alias:
+    - CTriggerGravity::GetTouchFunction
+  - name: CBasePlayerController_HandleCommand_JoinTeam
+    alias:
+    - CBasePlayerController::HandleCommand_JoinTeam
+  - name: CBasePlayerController_SetPlayerName
+    alias:
+    - CBasePlayerController::SetPlayerName
+  - name: CBasePlayerController_ProcessUsercmds
+    alias:
+    - ProcessUsercmds
+  - name: CBasePlayerController_SetPawn
+    alias:
+    - CBasePlayerController::SetPawn
+  - name: CBasePlayerController_GetPawn
+    alias:
+    - CBasePlayerController::GetPawn
+  - name: CBasePlayerController_Connect
+    alias:
+    - CBasePlayerController::Connect
+  - name: CSource2GameClients_ClientDisconnect
+    alias:
+    - CSource2GameClients::ClientDisconnect
+  - name: CSource2GameClients_ClientPutInServer
+    alias:
+    - CSource2GameClients::ClientPutInServer
+  - name: CSource2GameClients_ClientConnect
+    alias:
+    - CSource2GameClients::ClientConnect
+  - name: CSource2GameClients_ClientActive
+    alias:
+    - CSource2GameClients::ClientActive
+  - name: CSource2GameClients_ClientFullyConnect
+    alias:
+    - CSource2GameClients::ClientFullyConnect
+  - name: CSource2GameClients_ClientCommand
+    alias:
+    - CSource2GameClients::ClientCommand
+  - name: CSource2GameClients_ProcessUsercmds
+    alias:
+    - CSource2GameClients::ProcessUsercmds
+  - name: CSource2GameClients_GetBugReportInfo
+    alias:
+    - CSource2GameClients::GetBugReportInfo
+  - name: CSource2GameClients_ClientDiagnostic
+    alias:
+    - CSource2GameClients::ClientDiagnostic
+  - name: CSource2GameClients_SendHLTVStatusMessage
+    alias:
+    - CSource2GameClients::SendHLTVStatusMessage
+  - name: CSource2GameClients_OnClientConnected
+    alias:
+    - CSource2GameClients::OnClientConnected
+  - name: CGameRules_FindPickerEntity
+    alias:
+    - CGameRules::FindPickerEntity
+  - name: CCSGameRules_FindPickerEntity
+    alias:
+    - CCSGameRules::FindPickerEntity
+  - name: CCSGameRules_TerminateRound
+    alias:
+    - CCSGameRules::TerminateRound
+    - CGameRules::TerminateRound
+    - CGameRules_TerminateRound
+  - name: CCSGameRules_GoToIntermission
+    alias:
+    - CCSGameRules::GoToIntermission
+  - name: CEntityInstance_AcceptInput
+    alias:
+    - CEntityInstance::AcceptInput
+    - AcceptInput
+  - name: CEntityIdentity_AcceptInput
+    alias:
+    - CEntityIdentity::AcceptInput
+  - name: CEntityIdentity_AcceptInputInternal
+    alias:
+    - CEntityIdentity::AcceptInputInternal
+  - name: CEntityInstance_ScriptAcceptInput
+    alias:
+    - CEntityInstance::ScriptAcceptInput
+  - name: CEntityIdentity_SetEntityName
+    alias:
+    - CEntityIdentity::SetEntityName
+  - name: CEntitySystem_RemoveEntityFromNameMap
+    alias:
+    - CEntitySystem::RemoveEntityFromNameMap
+  - name: CEntitySystem_AddEntityToNameMap
+    alias:
+    - CEntitySystem::AddEntityToNameMap
+  - name: ScriptBinding_Entity_SetEntityName
+    alias:
+    - Entity::SetEntityName
+  - name: CBtActionCoordinatedBuy_Update
+    alias:
+    - CBtActionCoordinatedBuy::Update
+  - name: CCSPlayer_ItemServices_CanAcquire
+    alias:
+    - CCSPlayer_ItemServices::CanAcquire
+  - name: CCSPlayer_ItemServices_GiveDefaultItems
+    alias:
+    - CCSPlayer_ItemServices::GiveDefaultItems
+  - name: CCSPlayer_ItemServices_GiveNamedItem
+    alias:
+    - CCSPlayer_ItemServices::GiveNamedItem
+  - name: CCSPlayer_ItemServices_GiveNamedItemBool
+    alias:
+    - CCSPlayer_ItemServices::GiveNamedItemBool
+  - name: CCSPlayer_WeaponServices_CanUse
+    alias:
+    - CCSPlayer_WeaponServices::CanUse
+  - name: CCSPlayer_WeaponServices_PickupItem
+    alias:
+    - CCSPlayer_WeaponServices::PickupItem
+  - name: CCSPlayer_WeaponServices_EquipWeapon
+    alias:
+    - CCSPlayer_WeaponServices::EquipWeapon
+  - name: CCSPlayer_WeaponServices_Weapon_GetSlot
+    alias:
+    - CCSPlayer_WeaponServices_Weapon_GetSlot
+  - name: CCSPlayerController_ChangeTeam
+    alias:
+    - CCSPlayerController::ChangeTeam
+  - name: CCSPlayerController_GetThinkFunction
+    alias:
+    - CCSPlayerController::GetThinkFunction
+  - name: CCSPlayerController_PlayerForceTeamThink
+    alias:
+    - PlayerForceTeamThink
+    - CCSPlayerController::PlayerForceTeamThink
+  - name: CCSPlayerController_ResetForceTeamThink
+    alias:
+    - ResetForceTeamThink
+    - CCSPlayerController::ResetForceTeamThink
+  - name: CCSPlayerController_ResourceDataThink
+    alias:
+    - ResourceDataThink
+    - CCSPlayerController::ResourceDataThink
+  - name: CCSPlayerController_InventoryUpdateThink
+    alias:
+    - InventoryUpdateThink
+    - CCSPlayerController::InventoryUpdateThink
+  - name: g_CCSPlayerController_PlayerForceTeamThink
+    alias:
+    - g_CCSPlayerController::PlayerForceTeamThink
+  - name: g_CCSPlayerController_ResetForceTeamThink
+    alias:
+    - g_CCSPlayerController::ResetForceTeamThink
+  - name: g_CCSPlayerController_ResourceDataThink
+    alias:
+    - g_CCSPlayerController::ResourceDataThink
+  - name: g_CCSPlayerController_InventoryUpdateThink
+    alias:
+    - g_CCSPlayerController::InventoryUpdateThink
+  - name: CCSGameRules__sm_mapGcBanInformation
+    alias:
+    - CCSGameRules::sm_mapGcBanInformation
+  - name: CCSGameRules_BeginRound
+    alias:
+    - CCSGameRules::BeginRound
+  - name: CCSGameRules_PlayerSpawn
+    alias:
+    - CCSGameRules::PlayerSpawn
+  - name: CBasePlayerController_Respawn
+    alias:
+    - CBasePlayerController::Respawn
+  - name: CCSPlayerController_Respawn
+    alias:
+    - CCSPlayerController::Respawn
+  - name: CCSPlayerController_Connect
+    alias:
+    - CCSPlayerController::Connect
+  - name: CCSPlayerController_SwitchTeam
+    alias:
+    - CCSPlayerController::SwitchTeam
+  - name: CCSPlayerPawnBase_OnSetDormant
+    alias:
+    - CCSPlayerPawnBase::OnSetDormant
+  - name: CCSPlayerPawnBase_CheckForIdle
+    alias:
+    - CCSPlayerPawnBase::CheckForIdle
+  - name: CCSPlayerPawnBase_CheckForIdleInternal
+    alias:
+    - CCSPlayerPawnBase::CheckForIdleInternal
+  - name: CCSPlayerPawn_PostThink
+    alias:
+    - CCSPlayerPawnBase::PostThink
+    - CCSPlayerPawn::PostThink
+    - CCSPlayerPawnBase_PostThink
+    - CCSPlayerPawn_PostThink
+    - PostThink
+  - name: CCSPlayerPawn_OnSwitchWeapons
+    alias:
+    - CCSPlayerPawn::OnSwitchWeapons
+  - name: CCSPlayerPawn_ProcessSuicideAsKillReward
+    alias:
+    - CCSPlayerPawn::ProcessSuicideAsKillReward
+  - name: CGameRules_ClientSettingsChanged
+    alias:
+    - CGameRules::ClientSettingsChanged
+  - name: CGameRulesGameSystem_OnGameInit
+    alias:
+    - CGameRulesGameSystem::GameInit
+  - name: CGameRulesGameSystem_OnGameShutdown
+    alias:
+    - CGameRulesGameSystem::GameShutdown
+  - name: IGameSystem_OnGameShutdown
+    alias:
+    - IGameSystem::GameShutdown
+  - name: IGameSystem_OnGamePostInit
+    alias:
+    - IGameSystem::GamePostInit
+  - name: IGameSystem_OnGamePreShutdown
+    alias:
+    - IGameSystem::GamePreShutdown
+  - name: CMultiplayRules_ClientDisconnected
+    alias:
+    - CMultiplayRules::ClientDisconnected
+  - name: CSource2Server_Init
+    alias:
+    - CSource2Server::Init
+  - name: CSource2Server_ApplyGameSettings
+    alias:
+    - CSource2Server::ApplyGameSettings
+  - name: CSource2Server_WriteSignonMessages
+    alias:
+    - CSource2Server::WriteSignonMessages
+  - name: CSource2Server_GameCreateNetworkStringTables
+    alias:
+    - CSource2Server::GameCreateNetworkStringTables
+  - name: CSource2Server_GetMatchmakingGameData
+    alias:
+    - CSource2Server::GetMatchmakingGameData
+  - name: CSource2Server_GameServerSteamAPIActivated
+    alias:
+    - CSource2Server::GameServerSteamAPIActivated
+  - name: CSource2Server_GameServerSteamAPIDeactivated
+    alias:
+    - CSource2Server::GameServerSteamAPIDeactivated
+  - name: CSource2Server_OnHostNameChanged
+    alias:
+    - CSource2Server::OnHostNameChanged
+  - name: CSource2Server_GetLevelsFromSaveFile
+    alias:
+    - CSource2Server::GetLevelsFromSaveFile
+  - name: CSource2Server_ServerConVarChanged
+    alias:
+    - CSource2Server::ServerConVarChanged
+  - name: CSource2Server_Save
+    alias:
+    - CSource2Server::Save
+  - name: CSource2Server_Connect
+    alias:
+    - CSource2Server::Connect
+  - name: CSource2Server_PreShutdown
+    alias:
+    - CSource2Server::PreShutdown
+  - name: IAppSystem_Connect
+    alias:
+    - IAppSystem::Connect
+  - name: IAppSystem_PreShutdown
+    alias:
+    - IAppSystem::PreShutdown
+  - name: IVEngineServer2_ServerCommand
+    alias:
+    - IVEngineServer2::ServerCommand
+  - name: IVEngineServer2_IsDedicatedServer
+    alias:
+    - IVEngineServer2::IsDedicatedServer
+  - name: CSource2Server_Shutdown
+    alias:
+    - CSource2Server::Shutdown
+  - name: CGameEventManager_Shutdown
+    alias:
+    - CGameEventManager::Shutdown
+  - name: CLoopModeRegistry_UnregisterLoopModes
+    alias:
+    - CLoopModeRegistry::UnregisterLoopModes
+  - name: CEngineServiceRegistry_UnregisterEngineServices
+    alias:
+    - CEngineServiceRegistry::UnregisterEngineServices
+  - name: IEngineServiceMgr_UnregisterLoopMode
+    alias:
+    - IEngineServiceMgr::UnregisterLoopMode
+  - name: IEngineServiceMgr_UnregisterEngineService
+    alias:
+    - IEngineServiceMgr::UnregisterEngineService
+  - name: CSource2Server_GameFrame
+    alias:
+    - CSource2Server::GameFrame
+  - name: CGameEventManager_Init
+    alias:
+    - CGameEventManager::Init
+  - name: CTakeDamageInfo_HitGroupInfo
+    alias:
+    - CTakeDamageInfo::HitGroupInfo
+    - CTakeDamageInfo::HitGroup
+    - CTakeDamageInfo_HitGroup
+  - name: CEntitySystem_RegisterEntityClass
+    alias:
+    - CEntitySystem::RegisterEntityClass
+  - name: CEntitySystem_AddComponentFieldUnserializer
+    alias:
+    - CEntitySystem::AddComponentFieldUnserializer
+  - name: CEntitySystem_CreateEntityByName
+    alias:
+    - CEntitySystem::CreateEntityByName
+  - name: CEntitySystem_CreateEntity
+    alias:
+    - CEntitySystem::CreateEntity
+  - name: CEntitySystem_AddEntityToEntityDataBase
+    alias:
+    - CEntitySystem::AddEntityToEntityDataBase
+  - name: CEntitySystem_OnAddEntity
+    alias:
+    - CEntitySystem::OnAddEntity
+  - name: CEntitySystem_OnEntityParentChanged
+    alias:
+    - CEntitySystem::OnEntityParentChanged
+  - name: CEntitySystem_PrecacheEntity
+    alias:
+    - CEntitySystem::PrecacheEntity
+  - name: CEntitySystem_InvokePrecacheCallback
+    alias:
+    - CEntitySystem::InvokePrecacheCallback
+  - name: CEntitySystem_DestroyEntity
+    alias:
+    - CEntitySystem::DestroyEntity
+  - name: CConcreteEntityList_AllocEntity
+    alias:
+    - CConcreteEntityList::AllocEntity
+  - name: CEntitySystem_ConstructEntity
+    alias:
+    - CEntitySystem::ConstructEntity
+  - name: CEntitySystem_DoConstructEntity
+    alias:
+    - CEntitySystem::DoConstructEntity
+  - name: CEntitySystem_GetSpawnGroupWorldId
+    alias:
+    - CEntitySystem::GetSpawnGroupWorldId
+  - name: CEntitySystem_FindClassByDesignName
+    alias:
+    - CEntitySystem::FindClassByDesignName
+  - name: CEntitySystem_m_EntityList
+    alias:
+    - CEntitySystem::m_EntityList
+  - name: CEntitySystem_m_entityNames
+    alias:
+    - CEntitySystem::m_entityNames
+  - name: CEntitySystem_m_entityComponentHelpers
+    alias:
+    - CEntitySystem::m_entityComponentHelpers
+  - name: CEntitySystem_m_DataDescKeyUnserializers
+    alias:
+    - CEntitySystem::m_DataDescKeyUnserializers
+  - name: CEntitySystem_m_EntityPostSpawnCallback
+    alias:
+    - CEntitySystem::m_EntityPostSpawnCallback
+  - name: CEntityIdentity_FreeAttributes
+    alias:
+    - CEntityIdentity::FreeAttributes
+  - name: CConcreteEntityList_FreeEntity
+    alias:
+    - CConcreteEntityList::FreeEntity
+  - name: UTIL_CreateEntityByName
+    alias:
+    - CreateEntityByName
+  - name: CBaseEntity_DispatchSpawn
+    alias:
+    - CBaseEntity::DispatchSpawn
+    - DispatchSpawn
+  - name: CEntitySystem_QueueSpawnEntity
+    alias:
+    - CEntitySystem::QueueSpawnEntity
+  - name: CEntitySystem_HelperExecuteQueuedSpawn
+    alias:
+    - CEntitySystem::HelperExecuteQueuedSpawn
+  - name: CEntitySystem_SortEntities
+    alias:
+    - CEntitySystem::SortEntities
+  - name: CGameEntitySystem_SortEntities
+    alias:
+    - CGameEntitySystem::SortEntities
+  - name: CEntitySystem_InstallCreationWrapperCallbacks
+    alias:
+    - CEntitySystem::InstallCreationWrapperCallbacks
+  - name: CEntitySystem_ExecuteQueuedCreation
+    alias:
+    - CEntitySystem::ExecuteQueuedCreation
+  - name: CEntitySystem_ExecuteQueuedActivates
+    alias:
+    - CEntitySystem::ExecuteQueuedActivates
+  - name: CEntitySystem_ExecuteQueuedPostDataUpdateAndActivates
+    alias:
+    - CEntitySystem::ExecuteQueuedPostDataUpdateAndActivates
+  - name: CEntitySystem_Activate
+    alias:
+    - CEntitySystem::Activate
+  - name: CEntitySystem_PostDataUpdate
+    alias:
+    - CEntitySystem::PostDataUpdate
+  - name: CBaseEntity_NetworkStateChangedLog
+    alias:
+    - CBaseEntity::NetworkStateChangedLog
+  - name: CBaseEntity_NetworkStateChanged
+    alias:
+    - CBaseEntity::NetworkStateChanged
+  - name: CBaseEntity_FullEdictChanged
+    alias:
+    - CBaseEntity::FullEdictChanged
+  - name: CBaseEntity_m_NetworkTransmitComponent
+    alias:
+    - CBaseEntity::m_NetworkTransmitComponent
+  - name: CNetworkTransmitComponent_StateChanged
+    alias:
+    - CNetworkTransmitComponent::StateChanged
+  - name: CNetworkTransmitComponent_m_nStateFlags
+    alias:
+    - CNetworkTransmitComponent::m_nStateFlags
+  - name: CInferno_InfernoThink
+    alias:
+    - CInferno::InfernoThink
+  - name: CPhysExplosion_Activate
+    alias:
+    - CPhysExplosion::Activate
+  - name: CPhysExplosion_Explode
+    alias:
+    - CPhysExplosion::Explode
+  - name: UTIL_SayTextFilter2
+    alias:
+    - UTIL_SayText2Filter
+  - name: CCSWeaponBase_ItemPostFrame_ProcessReloadAction
+    alias:
+    - CCSWeaponBase::ItemPostFrame::ProcessReloadAction
+  - name: CCSPlayer_WeaponServices_HandleDropWeapon
+    alias:
+    - CCSPlayer_WeaponServices::HandleDropWeapon
+  - name: CCSPlayer_UseServices_BumpWeapon
+    alias:
+    - CCSPlayer_UseServices::BumpWeapon
+  - name: CCSPlayerPawn_HandleDropWeapon
+    alias:
+    - CCSPlayerPawn::HandleDropWeapon
+  - name: CCSPlayerPawn_ClientCommand
+    alias:
+    - CCSPlayerPawn::ClientCommand
+  - name: CCSPlayerPawn_SprayPaint
+    alias:
+    - CCSPlayerPawn::SprayPaint
+  - name: CEntitySpawner_CPlayerSprayDecal_Spawn
+    alias:
+    - CEntitySpawner<CPlayerSprayDecal>::Spawn
+  - name: CEntityKeyValuesAllocator_GetTempBuffer
+    alias:
+    - CEntityKeyValuesAllocator::GetTempBuffer
+  - name: CEntityKeyValues_LoadFromContext
+    alias:
+    - CEntityKeyValues::LoadFromContext
+  - name: CEntityKeyValues_Initialized
+    alias:
+    - CEntityKeyValues::Initialized
+  - name: CEntitySystem_m_nEntityKeyValuesAllocatorRefCount
+    alias:
+    - CEntitySystem::m_nEntityKeyValuesAllocatorRefCount
+  - name: CEntitySystem_AddRefKeyValues
+    alias:
+    - CEntitySystem::AddRefKeyValues
+  - name: CEntitySystem_ReleaseKeyValues
+    alias:
+    - CEntitySystem::ReleaseKeyValues
+  - name: CCSPlayerController_HandleCommandDrop
+    alias:
+    - CCSPlayerController::HandleCommandDrop
+  - name: IGameSystem_InitAllSystems
+    alias:
+    - IGameSystem::InitAllSystems
+  - name: IGameSystem_LoopInitAllSystems
+    alias:
+    - IGameSystem::LoopInitAllSystems
+  - name: IGameSystem_LoopPostInitAllSystems
+    alias:
+    - IGameSystem::LoopPostInitAllSystems
+  - name: IGameSystem_PostInit
+    alias:
+    - IGameSystem::PostInit
+  - name: IGameSystemFactory_PostInit
+    alias:
+    - IGameSystemFactory::PostInit
+  - name: IGameSystemFactory_GetStaticGameSystem
+    alias:
+    - IGameSystemFactory::GetStaticGameSystem
+  - name: IGameSystem_InitAllSystems_pFirst
+    alias:
+    - IGameSystem::InitAllSystems::pFirst
+    - IGameSystem::InitAllSystems->pFirst
+  - name: IGameSystem_LoopPostInitAllSystems_pEventDispatcher
+    alias:
+    - IGameSystem::LoopPostInitAllSystems::pEventDispatcher
+    - IGameSystem::LoopPostInitAllSystems->pEventDispatcher
+  - name: IGameSystem_LoopDestroyAllSystems_s_GameSystems
+    alias:
+    - IGameSystem::LoopDestroyAllSystems::s_GameSystems
+    - IGameSystem::LoopDestroyAllSystems->s_GameSystems
+  - name: CSource2GameEntities_CheckTransmit
+    alias:
+    - CSource2GameEntities::CheckTransmit
+    - ISource2GameEntities::CheckTransmit
+    - ISource2GameEntities_CheckTransmit
+    - CheckTransmit
+  - name: CBaseEntity_EmitSoundFilter
+    alias:
+    - CBaseEntity::EmitSoundFilter
+  - name: CBaseEntity_ScriptInputKill
+    alias:
+    - CBaseEntity::ScriptInputKill
+  - name: CBaseEntity_ScriptGetForward
+    alias:
+    - CBaseEntity::ScriptGetForward
+  - name: CBaseEntity_ScriptGetRight
+    alias:
+    - CBaseEntity::ScriptGetRight
+  - name: CBaseEntity_ScriptGetLeft
+    alias:
+    - CBaseEntity::ScriptGetLeft
+  - name: CBaseEntity_ScriptGetUp
+    alias:
+    - CBaseEntity::ScriptGetUp
+  - name: CBaseEntity_ScriptGetModelName
+    alias:
+    - CBaseEntity::ScriptGetModelName
+  - name: CBaseEntity_ScriptGetMoveParent
+    alias:
+    - CBaseEntity::ScriptGetMoveParent
+  - name: CBaseEntity_ScriptGetRootMoveParent
+    alias:
+    - CBaseEntity::ScriptGetRootMoveParent
+  - name: CBaseEntity_ScriptFirstMoveChild
+    alias:
+    - CBaseEntity::ScriptFirstMoveChild
+  - name: CBaseEntity_ScriptNextMovePeer
+    alias:
+    - CBaseEntity::ScriptNextMovePeer
+  - name: CBaseEntity_ScriptGetOwnerEntity
+    alias:
+    - CBaseEntity::ScriptGetOwnerEntity
+  - name: CBaseEntity_Script_GetChildren
+    alias:
+    - CBaseEntity::Script_GetChildren
+  - name: CBaseEntity_ScriptSetParent
+    alias:
+    - CBaseEntity::ScriptSetParent
+  - name: CBaseEntity_ScriptEyePosition
+    alias:
+    - CBaseEntity::ScriptEyePosition
+  - name: CBaseEntity_ScriptSetAngles
+    alias:
+    - CBaseEntity::ScriptSetAngles
+  - name: CBaseEntity_ScriptSetAbsAngles
+    alias:
+    - CBaseEntity::ScriptSetAbsAngles
+  - name: CBaseEntity_ScriptGetAngles
+    alias:
+    - CBaseEntity::ScriptGetAngles
+  - name: CBaseEntity_ScriptEyeAngles
+    alias:
+    - CBaseEntity::ScriptEyeAngles
+  - name: CBaseEntity_ScriptSetOrigin
+    alias:
+    - CBaseEntity::ScriptSetOrigin
+  - name: CBaseEntity_ScriptSetLocalAngles
+    alias:
+    - CBaseEntity::ScriptSetLocalAngles
+  - name: CBaseEntity_ScriptGetLocalAngles
+    alias:
+    - CBaseEntity::ScriptGetLocalAngles
+  - name: CBaseEntity_ScriptSetLocalOrigin
+    alias:
+    - CBaseEntity::ScriptSetLocalOrigin
+  - name: CBaseEntity_ScriptGetLocalOrigin
+    alias:
+    - CBaseEntity::ScriptGetLocalOrigin
+  - name: CBaseEntity_ScriptTransformPointEntityToWorld
+    alias:
+    - CBaseEntity::ScriptTransformPointEntityToWorld
+  - name: CBaseEntity_ScriptTransformPointWorldToEntity
+    alias:
+    - CBaseEntity::ScriptTransformPointWorldToEntity
+  - name: CBaseEntity_ScriptSetForward
+    alias:
+    - CBaseEntity::ScriptSetForward
+  - name: CBaseEntity_ScriptGetBoundingMins
+    alias:
+    - CBaseEntity::ScriptGetBoundingMins
+  - name: CBaseEntity_ScriptGetBoundingMaxs
+    alias:
+    - CBaseEntity::ScriptGetBoundingMaxs
+  - name: CBaseEntity_ScriptGetBounds
+    alias:
+    - CBaseEntity::ScriptGetBounds
+  - name: CBaseEntity_ScriptGetLocalAngularVelocity_OBSOLETE
+    alias:
+    - CBaseEntity::ScriptGetLocalAngularVelocity_OBSOLETE
+  - name: CBaseEntity_ScriptSetLocalAngularVelocity_OBSOLETE
+    alias:
+    - CBaseEntity::ScriptSetLocalAngularVelocity_OBSOLETE
+  - name: CBaseEntity_ScriptAddEffects
+    alias:
+    - CBaseEntity::ScriptAddEffects
+  - name: CBaseEntity_ScriptRemoveEffects
+    alias:
+    - CBaseEntity::ScriptRemoveEffects
+  - name: CBaseEntity_ScriptSetAttributeFloatValue
+    alias:
+    - CBaseEntity::ScriptSetAttributeFloatValue
+  - name: CBaseEntity_ScriptGetAttributeFloatValue
+    alias:
+    - CBaseEntity::ScriptGetAttributeFloatValue
+  - name: CBaseEntity_ScriptSetAttributeIntValue
+    alias:
+    - CBaseEntity::ScriptSetAttributeIntValue
+  - name: CBaseEntity_ScriptGetAttributeIntValue
+    alias:
+    - CBaseEntity::ScriptGetAttributeIntValue
+  - name: CBaseEntity_ScriptHasAttribute
+    alias:
+    - CBaseEntity::ScriptHasAttribute
+  - name: CBaseEntity_ScriptDeleteAttribute
+    alias:
+    - CBaseEntity::ScriptDeleteAttribute
+  - name: CBaseEntity_GetScriptOwnerEntity
+    alias:
+    - CBaseEntity::GetScriptOwnerEntity
+  - name: CBaseEntity_SetScriptOwnerEntity
+    alias:
+    - CBaseEntity::SetScriptOwnerEntity
+  - name: CBaseEntity_ScriptSetEntityName
+    alias:
+    - CBaseEntity::ScriptSetEntityName
+  - name: CBaseEntity_ScriptGetMass
+    alias:
+    - CBaseEntity::ScriptGetMass
+  - name: CBaseEntity_ScriptSetMass
+    alias:
+    - CBaseEntity::ScriptSetMass
+  - name: CBaseEntity_ScriptGetSpawnGroupHandle
+    alias:
+    - CBaseEntity::ScriptGetSpawnGroupHandle
+  - name: CBaseEntity_GetAbsAngles
+    alias:
+    - CBaseEntity::GetAbsAngles
+  - name: CBaseEntity_Script_GetTeamNumber
+    alias:
+    - CBaseEntity::Script_GetTeamNumber
+  - name: CBaseEntity_Script_FollowEntity
+    alias:
+    - CBaseEntity::Script_FollowEntity
+  - name: CBaseEntity_Script_FollowEntityMerge
+    alias:
+    - CBaseEntity::Script_FollowEntityMerge
+  - name: CBaseEntity_Script_Trigger
+    alias:
+    - CBaseEntity::Script_Trigger
+  - name: CBaseEntity_Script_SetContextThink
+    alias:
+    - CBaseEntity::Script_SetContextThink
+  - name: CBaseEntity_AddContextForScript
+    alias:
+    - CBaseEntity::AddContextForScript
+  - name: CBaseEntity_AddContextForScriptNumeric
+    alias:
+    - CBaseEntity::AddContextForScriptNumeric
+  - name: CBaseEntity_GetContextForScript
+    alias:
+    - CBaseEntity::GetContextForScript
+  - name: CBaseEntity_ScriptGatherCriteria
+    alias:
+    - CBaseEntity::ScriptGatherCriteria
+  - name: CBaseEntity_Script_TakeDamage
+    alias:
+    - CBaseEntity::Script_TakeDamage
+  - name: CBaseEntity_SetGravityScale
+    alias:
+    - CBaseEntity::SetGravityScale
+  - name: CBaseEntity_SetAbsVelocity
+    alias:
+    - CBaseEntity::SetAbsVelocity
+  - name: CBaseEntity_GetAbsVelocity
+    alias:
+    - CBaseEntity::GetAbsVelocity
+  - name: CBaseEntity_Script_ApplyLocalAngularVelocityImpulse
+    alias:
+    - CBaseEntity::Script_ApplyLocalAngularVelocityImpulse
+  - name: CBaseEntity_GetLocalAngularVelocity_OBSOLETE
+    alias:
+    - CBaseEntity::GetLocalAngularVelocity_OBSOLETE
+  - name: CBaseEntity_ScriptEmitSoundParams
+    alias:
+    - CBaseEntity::ScriptEmitSoundParams
+    - CBaseEntity::EmitSoundParams
+    - CBaseEntity_EmitSoundParams
+  - name: CBaseEntity_ScriptStopSound
+    alias:
+    - CBaseEntity::ScriptStopSound
+  - name: CBaseEntity_ScriptSoundDuration
+    alias:
+    - CBaseEntity::ScriptSoundDuration
+  - name: CBaseEntity_ScriptGetAbsOrigin
+    alias:
+    - CBaseEntity::ScriptGetAbsOrigin
+  - name: CBaseEntity_Precache
+    alias:
+    - CBaseEntity::Precache
+    - Precache
+  - name: CEnvEntityIgniter_Precache
+    alias:
+    - CEnvEntityIgniter::Precache
+  - name: CEnvShake_Spawn
+    alias:
+    - CEnvShake::Spawn
+  - name: CBaseEntity_SetMoveType
+    alias:
+    - CBaseEntity::SetMoveType
+  - name: CBasePlayerPawn_CommitSuicide
+    alias:
+    - CBasePlayerPawn::CommitSuicide
+    - CommitSuicide
+  - name: CBaseCombatCharacter_OnKilled
+    alias:
+    - CBaseCombatCharacter::OnKilled
+  - name: ScriptBinding_CSPlayerPawn_DestroyWeapon
+    alias:
+    - CSPlayerPawn::DestroyWeapon
+  - name: CBasePlayerPawn_RemovePlayerItem
+    alias:
+    - CBasePlayerPawn::RemovePlayerItem
+  - name: CBasePlayerPawn_DropActivePlayerWeapon
+    alias:
+    - CBasePlayerPawn::DropActivePlayerWeapon
+  - name: CBasePlayerPawn_GetEyePosition
+    alias:
+    - CBasePlayerPawn::GetEyePosition
+  - name: CBaseEntity_GetEyePosition
+    alias:
+    - CBaseEntity::GetEyePosition
+  - name: CCSBotManager_BotPlaceCommand
+    alias:
+    - CCSBotManager::BotPlace
+  - name: CBasePlayerPawn_EyeVectors
+    alias:
+    - CBasePlayerPawn::EyeVectors
+  - name: CBasePlayerPawn_GetEyeAngles
+    alias:
+    - CBasePlayerPawn::GetEyeAngles
+  - name: CBaseEntity_GetEyeAngles
+    alias:
+    - CBaseEntity::GetEyeAngles
+  - name: CCSBot_Upkeep
+    alias:
+    - CCSBot::Upkeep
+  - name: CCSBot_SetState
+    alias:
+    - CCSBot::SetState
+  - name: CCSBot_UpdatePathMovement
+    alias:
+    - CCSBot::UpdatePathMovement
+  - name: CCSBot_PrintIfWatched
+    alias:
+    - CCSBot::PrintIfWatched
+  - name: HideState_OnUpdate
+    alias:
+    - HideState::OnUpdate
+  - name: CCSBot_Attack
+    alias:
+    - CCSBot::Attack
+  - name: CCSBot_MoveTo
+    alias:
+    - CCSBot::MoveTo
+  - name: CCSBot_InhibitLookAround
+    alias:
+    - CCSBot::InhibitLookAround
+  - name: CCSBot_SetDisposition
+    alias:
+    - CCSBot::SetDisposition
+  - name: CCSBot_Idle
+    alias:
+    - CCSBot::Idle
+  - name: CCSBot_ComputePath
+    alias:
+    - CCSBot::ComputePath
+  - name: CBaseEntity_IsAlive
+    alias:
+    - CBaseEntity::IsAlive
+  - name: CBaseEntity_SetOwner
+    alias:
+    - CBaseEntity::SetOwner
+  - name: CBaseEntity_CollisionRulesChanged
+    alias:
+    - CBaseEntity::CollisionRulesChanged
+    - CollisionRulesChanged
+  - name: CBaseEntity_Use
+    alias:
+    - CBaseEntity::Use
+  - name: CGameSceneNode_PostSpawnKeyValues
+    alias:
+    - CGameSceneNode::PostSpawnKeyValues
+  - name: CBaseEntity_Spawn
+    alias:
+    - CBaseEntity::Spawn
+    - Spawn
+  - name: CBaseEntity_SpawnRadius
+    alias:
+    - CBaseEntity::SpawnRadius
+  - name: CCSPlayer_ItemServices_DropActivePlayerWeapon
+    alias:
+    - CCSPlayer_ItemServices::DropActivePlayerWeapon
+  - name: CCSPlayer_WeaponServices_DropWeapon
+    alias:
+    - CCSPlayer_WeaponServices::DropWeapon
+  - name: CCSPlayer_ItemServices_RemoveWeapons
+    alias:
+    - CCSPlayer_ItemServices::RemoveWeapons
+  - name: CCSPlayer_WeaponServices_SelectItem
+    alias:
+    - CCSPlayer_WeaponServices::SelectItem
+  - name: CEntFireOutputAutoCompletionFunctor_FireOutput
+    alias:
+    - CEntFireOutputAutoCompletionFunctor::FireOutput
+  - name: CEntityInstance_FindOutputsByName
+    alias:
+    - CEntityInstance::FindOutputsByName
+  - name: CEntityInstance_ScriptEntityIO
+    alias:
+    - CEntityInstance::ScriptEntityIO
+  - name: CEntityIOOutput_FireOutputInternal
+    alias:
+    - CEntityIOOutput::FireOutputInternal
+  - name: CEntitySystem_AddEntityIOEvent
+    alias:
+    - CEntitySystem::AddEntityIOEvent
+  - name: CEntitySystem_AddEntityIOEvent2
+    alias:
+    - CEntitySystem::AddEntityIOEvent2
+  - name: CEntitySystem_AddEntityIOEventBuildStruct
+    alias:
+    - CEntitySystem::AddEntityIOEventBuildStruct
+  - name: CEntitySystem_AddEntityIOEventToQueue
+    alias:
+    - CEntitySystem::AddEntityIOEventToQueue
+  - name: CEntitySystem_m_EventQueue
+    alias:
+    - CEntitySystem::m_EventQueue
+  - name: CGameEntitySystem_FindEntityByClassName
+    alias:
+    - CGameEntitySystem::FindEntityByClassName
+  - name: CGameEntitySystem_FindEntityByName
+    alias:
+    - CGameEntitySystem::FindEntityByName
+  - name: CGameEntitySystem_OnAddEntity
+    alias:
+    - CGameEntitySystem::OnAddEntity
+  - name: CGameEntitySystem_BuildResourceManifest_ManifestNameOrGroupName
+    alias:
+    - CGameEntitySystem::BuildResourceManifest_ManifestNameOrGroupName
+  - name: CGameEntitySystem_BuildResourceManifest_KeyValuesVectors
+    alias:
+    - CGameEntitySystem::BuildResourceManifest_KeyValuesVectors
+  - name: CGameEntitySystem_FindEntityProcedural
+    alias:
+    - CGameEntitySystem::FindEntityProcedural
+  - name: CGameEntitySystem_Spawn
+    alias:
+    - CGameEntitySystem::Spawn
+  - name: CEntitySystem_Spawn
+    alias:
+    - CEntitySystem::Spawn
+  - name: CBodyGameSystem_SpawnDependencyIsland
+    alias:
+    - CBodyGameSystem::SpawnDependencyIsland
+  - name: CGameEntitySystem_CheckGlobalState
+    alias:
+    - CGameEntitySystem::CheckGlobalState
+  - name: IGameSystem_OnBuildGameSessionManifest
+    alias:
+    - IGameSystem::BuildGameSessionManifest
+  - name: IGameSystem_OnServerPreEntityThink
+    alias:
+    - IGameSystem::OnServerPreEntityThink
+  - name: IGameSystem_OnServerPostEntityThink
+    alias:
+    - IGameSystem::OnServerPostEntityThink
+  - name: IGameSystem_OnServerPreClientUpdate
+    alias:
+    - IGameSystem::ServerPreClientUpdate
+  - name: IGameSystem_OnServerAdvanceTick
+    alias:
+    - IGameSystem::ServerAdvanceTick
+  - name: IGameSystem_OnServerGamePostSimulate
+    alias:
+    - IGameSystem::ServerGamePostSimulate
+  - name: IGameSystem_OnServerPostAdvanceTick
+    alias:
+    - IGameSystem::ServerPostAdvanceTick
+  - name: IGameSystem_OnServerBeginAsyncPostTickWork
+    alias:
+    - IGameSystem::OnServerBeginAsyncPostTickWork
+  - name: IGameSystem_OnServerPreEndAsyncPostTickWork
+    alias:
+    - IGameSystem::OnServerPreEndAsyncPostTickWork
+  - name: IGameSystem_OnServerPostEndAsyncPostTickWork
+    alias:
+    - IGameSystem::OnServerPostEndAsyncPostTickWork
+  - name: IGameSystem_OnSaveGame
+    alias:
+    - IGameSystem::OnSaveGame
+  - name: IGameSystem_OnRestoreGame
+    alias:
+    - IGameSystem::OnRestoreGame
+  - name: IGameSystem_OnOutOfGameFrameBoundary
+    alias:
+    - IGameSystem::OnOutOfGameFrameBoundary
+  - name: CSource2GameClients_StartHLTVServer
+    alias:
+    - CSource2GameClients::StartHLTVServer
+  - name: LegacyGameEventListener
+    alias:
+    - GetLegacyGameEventListener
+  - name: CPhysicsGameSystem_ProcessContactEvents
+    alias:
+    - CPhysicsGameSystem::ProcessContactEvents
+  - name: CBaseEntity_PhysicsDispatchStartTouch
+    alias:
+    - CBaseEntity::PhysicsDispatchStartTouch
+  - name: CBaseEntity_PhysicsNotifyOtherOfEndTouch
+    alias:
+    - CBaseEntity::PhysicsNotifyOtherOfEndTouch
+  - name: CBaseEntity_PhysicsDispatchTouch
+    alias:
+    - CBaseEntity::PhysicsDispatchTouch
+  - name: CBaseEntity_StartTouch
+    alias:
+    - CBaseEntity::StartTouch
+    - StartTouch
+  - name: CBaseEntity_Touch
+    alias:
+    - CBaseEntity::Touch
+    - Touch
+  - name: CBaseEntity_EndTouch
+    alias:
+    - CBaseEntity::EndTouch
+    - EndTouch
+  - name: IVPhys2World_GetTouchingList
+    alias:
+    - IVPhys2World::GetTouchingList
+    - CVPhys2World::GetTouchingList
+  - name: CTriggerPush_Touch
+    alias:
+    - CTriggerPush::Touch
+    - TriggerPush_Touch
+  - name: CPhysBox_Use
+    alias:
+    - CPhysBox::Use
+  - name: CBaseEntity_SetGroundEntity
+    alias:
+    - SetGroundEntity
+  - name: CBaseEntity_GetHammerUniqueId
+    alias:
+    - CBaseEntity::GetHammerUniqueId
+    - GetHammerUniqueId
+  - name: CBaseEntity_IsPlayerPawn
+    alias:
+    - CBaseEntity::IsPlayerPawn
+    - IsEntityPawn
+    - IsPlayerPawn
+  - name: CBaseEntity_IsPlayerController
+    alias:
+    - CBaseEntity::IsPlayerController
+    - IsEntityController
+    - IsPlayerController
+  - name: CBaseTrigger_StartTouch
+    alias:
+    - CBaseTrigger::StartTouch
+  - name: CBaseTrigger_EndTouch
+    alias:
+    - CBaseTrigger::EndTouch
+  - name: CBaseTrigger_PassesTriggerFilters
+    alias:
+    - CBaseTrigger::PassesTriggerFilters
+    - PassesTriggerFilters
+  - name: CBaseAnimGraph_GetAnimationController
+    alias:
+    - CBaseAnimGraph::GetAnimationController
+  - name: CBaseAnimGraph_m_skeletonInstance
+    alias:
+    - CBaseAnimGraph::m_skeletonInstance
+  - name: CGameSceneNode_PreInstanceSpawn
+    alias:
+    - CGameSceneNode::PreInstanceSpawn
+  - name: CGameSceneNode_GetSkeletonInstance
+    alias:
+    - CGameSceneNode::GetSkeletonInstance
+  - name: CSkeletonInstance_m_animationController
+    alias:
+    - CSkeletonInstance::m_animationController
+  - name: CSkeletonInstance_PostDataUpdate
+    alias:
+    - CSkeletonInstance::PostDataUpdate
+  - name: CGameSceneNode_PostDataUpdate
+    alias:
+    - CGameSceneNode::PostDataUpdate
+  - name: CGameSceneNode_UpdateEntityForHierarchyChange
+    alias:
+    - CGameSceneNode::UpdateEntityForHierarchyChange
+  - name: CPointTeleportAPI_TeleportEntityInternal
+    alias:
+    - CPointTeleportAPI::TeleportEntityInternal
+  - name: CBaseEntity_Teleport
+    alias:
+    - CBaseEntity::Teleport
+  - name: CPointTeleport_Activate
+    alias:
+    - CPointTeleport::Activate
+  - name: CBaseEntity_Activate
+    alias:
+    - CBaseEntity::Activate
+    - Activate
+  - name: CBaseEntity_DrawDebugTextOverlays
+    alias:
+    - CBaseEntity::DrawDebugTextOverlays
+  - name: CRagdollProp_DrawEntityDebugOverlays
+    alias:
+    - CRagdollProp::DrawEntityDebugOverlays
+  - name: CBaseEntity_ReloadPrivateScripts
+    alias:
+    - CBaseEntity::ReloadPrivateScripts
+  - name: CCheckTransmitInfo_m_nPlayerSlot
+    alias:
+    - CCheckTransmitInfo::m_nPlayerSlot
+    - CheckTransmitPlayerSlot
+  - name: CDedicatedServerWorkshopManager_SwitchToWorkshopMapGroup
+    alias:
+    - CDedicatedServerWorkshopManager::SwitchToWorkshopMapGroup
+  - name: IGameTypes_CreateWorkshopMapGroup
+    alias:
+    - IGameTypes::CreateWorkshopMapGroup
+  - name: CSpawnGroupMgrGameSystem_GetSpawnGroups
+    alias:
+    - CSpawnGroupMgrGameSystem::GetSpawnGroups
+    - GetSpawnGroups
+  - name: CSpawnGroupMgrGameSystem_DumpSpawnGroups
+    alias:
+    - CSpawnGroupMgrGameSystem::DumpSpawnGroups
+    - DumpSpawnGroups
+  - name: CSpawnGroupMgrGameSystem_SpawnGroupSpawnEntitiesInternal
+    alias:
+    - CSpawnGroupMgrGameSystem::SpawnGroupSpawnEntitiesInternal
+    - SpawnGroupSpawnEntitiesInternal
+  - name: IGameSystem_OnPreSpawnGroupLoad
+    alias:
+    - IGameSystem::OnPreSpawnGroupLoad
+  - name: IGameSystem_OnPostSpawnGroupLoad
+    alias:
+    - IGameSystem::OnPostSpawnGroupLoad
+  - name: CSpawnGroupMgrGameSystem_SpawnGroupShutdown
+    alias:
+    - CSpawnGroupMgrGameSystem::SpawnGroupShutdown
+    - SpawnGroupShutdown
+  - name: CSpawnGroupMgrGameSystem_SpawnGroupActuallyShutdown
+    alias:
+    - CSpawnGroupMgrGameSystem::SpawnGroupActuallyShutdown
+    - SpawnGroupActuallyShutdown
+  - name: IGameSystem_OnPreSpawnGroupUnload
+    alias:
+    - IGameSystem::OnPreSpawnGroupUnload
+  - name: IGameSystem_OnPostSpawnGroupUnload
+    alias:
+    - IGameSystem::OnPostSpawnGroupUnload
+  - name: CLoadingSpawnGroup_CreateEntityToSpawn
+    alias:
+    - CLoadingSpawnGroup::CreateEntityToSpawn
+  - name: CSpawnGroupMgrGameSystem_OnSpawnGroupPrecache
+    alias:
+    - CSpawnGroupMgrGameSystem::OnSpawnGroupPrecache
+    - SpawnGroupPrecache
+  - name: CSpawnGroupMgrGameSystem_AllocateSpawnGroup
+    alias:
+    - CSpawnGroupMgrGameSystem::AllocateSpawnGroup
+  - name: CSpawnGroupMgrGameSystem_ReleaseSpawnGroup
+    alias:
+    - CSpawnGroupMgrGameSystem::ReleaseSpawnGroup
+  - name: CSpawnGroupMgrGameSystem_SpawnGroupInit
+    alias:
+    - CSpawnGroupMgrGameSystem::SpawnGroupInit
+  - name: CSpawnGroupMgrGameSystem_CreateLoadingSpawnGroup
+    alias:
+    - CSpawnGroupMgrGameSystem::CreateLoadingSpawnGroup
+  - name: CSpawnGroupMgrGameSystem_CreateLoadingSpawnGroupForSaveFile
+    alias:
+    - CSpawnGroupMgrGameSystem::CreateLoadingSpawnGroupForSaveFile
+  - name: CSpawnGroupMgrGameSystem_SpawnGroupSpawnEntities
+    alias:
+    - CSpawnGroupMgrGameSystem::SpawnGroupSpawnEntities
+  - name: CSpawnGroupMgrGameSystem_SetActiveSpawnGroup
+    alias:
+    - CSpawnGroupMgrGameSystem::SetActiveSpawnGroup
+  - name: CSpawnGroupMgrGameSystem_UnloadSpawnGroup
+    alias:
+    - CSpawnGroupMgrGameSystem::UnloadSpawnGroup
+  - name: CSpawnGroupMgrGameSystem_SaveGame_Start
+    alias:
+    - CSpawnGroupMgrGameSystem::SaveGame_Start
+  - name: IGameSystem_OnSpawnGroupPrecache
+    alias:
+    - IGameSystem::OnSpawnGroupPrecache
+  - name: IGameSystem_OnSpawnGroupUncache
+    alias:
+    - IGameSystem::OnSpawnGroupUncache
+  - name: CBaseFilter_InputTestActivator
+    alias:
+    - CBaseFilter::InputTestActivator
+  - name: CGamePlayerEquip_InputTriggerForAllPlayers
+    alias:
+    - CGamePlayerEquip::InputTriggerForAllPlayers
+  - name: CGamePlayerEquip_InputTriggerForActivatedPlayer
+    alias:
+    - CGamePlayerEquip::InputTriggerForActivatedPlayer
+  - name: CNavMesh_GetNearestNavArea
+    alias:
+    - CNavMesh::GetNearestNavArea
+  - name: CCSBotManager_AddBot
+    alias:
+    - CCSBotManager::AddBot
+  - name: BotAdd_CommandHandler
+    alias:
+    - CCSBotManager::BotAddCommand
+  - name: BotKill_CommandHandler
+    alias:
+    - CCSBotManager::BotKillCommand
+  - name: EntInfo_CommandHandler
+    alias:
+    - CC_Ent_Info
+  - name: CEntitySystem_DestroyEntityImmediate
+    alias:
+    - CEntitySystem::DestroyEntityImmediate
+  - name: CEntitySystem_OnRemoveEntityFromDatabase
+    alias:
+    - CEntitySystem::OnRemoveEntityFromDatabase
+  - name: CEntitySystem_DoDestructEntity
+    alias:
+    - CEntitySystem::DoDestructEntity
+  - name: CEntitySystem_UpdateOnRemove
+    alias:
+    - CEntitySystem::UpdateOnRemove
+  - name: ClientPrintToController
+    alias:
+    - ClientPrint
+  - name: CCSBotManager_AddBot_BotNavIgnore
+    alias:
+    - BotNavIgnore
+  - name: CEnvHudHint_API_ShowHudHint
+    alias:
+    - CEnvHudHint_API::ShowHudHint
+  - name: UTIL_GetPlayerControllerForEntity
+    alias:
+    - UTIL_GetPlayerControllerForEntity
+  - name: CEntitySystem_ctor
+    alias:
+    - CEntitySystem::CEntitySystem
+  - name: CGameEntitySystem_ctor
+    alias:
+    - CGameEntitySystem::CGameEntitySystem
+  - name: CEntitySystem_RegisterAccessor
+    alias:
+    - CEntitySystem::RegisterAccessor
+  - name: CEntitySystem_Init
+    alias:
+    - CEntitySystem::Init
+  - name: CEntitySystem_ProcessEntityRegistration
+    alias:
+    - CEntitySystem::ProcessEntityRegistration
+  - name: CEntitySystem_PostCreateEntitySystem
+    alias:
+    - CEntitySystem::PostCreateEntitySystem
+  - name: CSource2EntitySystem_StaticInit
+    alias:
+    - CSource2EntitySystem::StaticInit
+  - name: CSpawnGroupEntityFilterRegistrar_RegisterSpawnGroupEntityFilters
+    alias:
+    - CSpawnGroupEntityFilterRegistrar::RegisterSpawnGroupEntityFilters
+  - name: CGameEntitySystem_m_spawnGroupEntityFilters
+    alias:
+    - CGameEntitySystem::m_spawnGroupEntityFilters
+  - name: CGameEntitySystem_m_pEntity2Networkables
+    alias:
+    - CGameEntitySystem::m_pEntity2Networkables
+  - name: CEntity2NetworkClasses_ServerClass_InitEntity2NetworkClasses
+    alias:
+    - CEntity2NetworkClasses<ServerClass>::InitEntity2NetworkClasses
+  - name: CEntitySystem_m_Symbols
+    alias:
+    - CEntitySystem::m_Symbols
+  - name: CEntitySystem_m_pNetworkFieldChangedEventQueue
+    alias:
+    - CEntitySystem::m_pNetworkFieldChangedEventQueue
+  - name: CEntitySystem_m_pNetworkFieldScratchData
+    alias:
+    - CEntitySystem::m_pNetworkFieldScratchData
+  - name: CEntitySystem_m_pFieldChangeLimitSpew
+    alias:
+    - CEntitySystem::m_pFieldChangeLimitSpew
+  - name: CEntitySystem_m_ComponentUnserializerInfoAllocator
+    alias:
+    - CEntitySystem::m_ComponentUnserializerInfoAllocator
+  - name: CEntitySystem_m_EntityMaterialAttributes
+    alias:
+    - CEntitySystem::m_EntityMaterialAttributes
+  - name: CEntitySystem_m_flChangeCallbackSpewThreshold
+    alias:
+    - CEntitySystem::m_flChangeCallbackSpewThreshold
+  - name: CEntitySystem_ClearEntityDatabase
+    alias:
+    - CEntitySystem::ClearEntityDatabase
+  - name: INetworkMessages_SetNetworkSerializationContextData
+    alias:
+    - INetworkMessages::SetNetworkSerializationContextData
+  - name: CFlattenedSerializers_CreateFieldChangedEventQueue
+    alias:
+    - CFlattenedSerializers::CreateFieldChangedEventQueue
+  - name: INetworkMessages_RegisterSchemaTypeOverride
+    alias:
+    - INetworkMessages::RegisterSchemaTypeOverride
+  - name: PolymorphicHelper_t__SetPolymorphicPointer
+    alias:
+    - PolymorphicHelper_t::SetPolymorphicPointer
+  - name: CSceneEntity_GetScriptDesc
+    alias:
+    - CSceneEntity::GetScriptDesc
+  - name: CEntityInstance_GetScriptDesc
+    alias:
+    - CEntityInstance::GetScriptDesc
+  - name: CEntityInstance_Spawn
+    alias:
+    - CEntityInstance::Spawn
+  - name: CEntityInstance_Activate
+    alias:
+    - CEntityInstance::Activate
+  - name: CEntityInstance_Precache
+    alias:
+    - CEntityInstance::Precache
+  - name: CEntityInstance_GetDataDescMap
+    alias:
+    - CEntityInstance::GetDataDescMap
+  - name: CEntityInstance_ReloadPrivateScripts
+    alias:
+    - CEntityInstance::ReloadPrivateScripts
+  - name: CEntityInstance_ValidatePrivateScriptScope
+    alias:
+    - CEntityInstance::ValidatePrivateScriptScope
+  - name: CEntityInstance_NetworkStateChanged
+    alias:
+    - CEntityInstance::NetworkStateChanged
+  - name: CEntityInstance_FullEdictChanged
+    alias:
+    - CEntityInstance::FullEdictChanged
+  - name: CEntityInstance_NetworkUpdateState
+    alias:
+    - CEntityInstance::NetworkUpdateState
+  - name: CEntityInstance_NetworkStateChangedLog
+    alias:
+    - CEntityInstance::NetworkStateChangedLog
+  - name: CEntityInstance_DrawDebugTextOverlays
+    alias:
+    - CEntityInstance::DrawDebugTextOverlays
+  - name: CEntityInstance_DrawEntityDebugOverlays
+    alias:
+    - CEntityInstance::DrawEntityDebugOverlays
+  - name: CEntityInstance_PostDataUpdateDelta
+    alias:
+    - CEntityInstance::PostDataUpdateDelta
+  - name: CEntityInstance_PreDataUpdate
+    alias:
+    - CEntityInstance::PreDataUpdate
+  - name: CEntityInstance_PostDataUpdate
+    alias:
+    - CEntityInstance::PostDataUpdate
+  - name: CEntityInstance_PostDataUpdatePreserve
+    alias:
+    - CEntityInstance::PostDataUpdatePreserve
+  - name: CEntityInstance_Connect
+    alias:
+    - CEntityInstance::Connect
+  - name: CEntityInstance_UpdateOnRemove
+    alias:
+    - CEntityInstance::UpdateOnRemove
+  - name: CEntityInstance_Disconnect
+    alias:
+    - CEntityInstance::Disconnect
+  - name: CEntityInstance_AddedToEntityDatabase
+    alias:
+    - CEntityInstance::AddedToEntityDatabase
+  - name: CEntityInstance_OnSetDormant
+    alias:
+    - CEntityInstance::OnSetDormant
+  - name: CEntityInstance_Schema_DynamicBinding
+    alias:
+    - CEntityInstance::Schema_DynamicBinding
+  - name: CEntitySystem_OnRemoveEntity
+    alias:
+    - CEntitySystem::OnRemoveEntity
+  - name: CEntityComponentHelperT_Free
+    alias:
+    - CEntityComponentHelperT::Free
+  - name: CScriptedSequence_SynchronizeSequence
+    alias:
+    - CScriptedSequence::SynchronizeSequence
+  - name: CNetworkUtlVectorEmbedded_NetworkStateChanged_m_vecRenderAttributes
+    alias:
+    - CNetworkUtlVectorEmbedded<CRenderAttribute>::NetworkStateChanged_m_vecRenderAttributes
+  - name: CNetworkUtlVectorEmbedded_NetworkStateChanged_m_perRoundStats
+    alias:
+    - CNetworkUtlVectorEmbedded<CSPerRoundStats_t>::NetworkStateChanged_m_perRoundStats
+  - name: CUtlVectorEmbeddedNetworkVar_CSPerRoundStats_t_NetworkVar_m_perRoundStats_SetCount
+    alias:
+    - CUtlVectorEmbeddedNetworkVar<CSPerRoundStats_t, NetworkVar>::SetCount
+  - name: CNetworkUtlVectorEmbedded_TryLateResolve_m_vecRenderAttributes
+    alias:
+    - CNetworkUtlVectorEmbedded<CRenderAttribute>::TryLateResolve
+  - name: INetworkMessages_GetLoggingChannel
+    alias:
+    - INetworkMessages::GetLoggingChannel
+  - name: CPhysicsEntitySolver_PhysEnableEntityCollisions
+    alias:
+    - CPhysicsEntitySolver::PhysEnableEntityCollisions
+  - name: CLoopModeGame_StaticInit
+    alias:
+    - CLoopModeGame::StaticInit
+  - name: CLoopModeFactory_CLoopModeGame_Init
+    alias:
+    - CLoopModeFactory<CLoopModeGame>::Init
+  - name: CLoopModeFactory_CLoopModeGame_Shutdown
+    alias:
+    - CLoopModeFactory<CLoopModeGame>::Shutdown
+  - name: CLoopModeGame_OnLoopActivate
+    alias:
+    - CLoopModeGame::OnLoopActivate
+  - name: ILoopMode_OnLoopActivate
+    alias:
+    - ILoopMode::OnLoopActivate
+  - name: CLoopModeGame_AddViewsToSceneSystem
+    alias:
+    - CLoopModeGame::AddViewsToSceneSystem
+  - name: ILoopMode_AddViewsToSceneSystem
+    alias:
+    - ILoopMode::AddViewsToSceneSystem
+  - name: CLoopModeGame_LoopInitInternal
+    alias:
+    - CLoopModeGame::LoopInitInternal
+  - name: CLoopModeGame_LoopInit
+    alias:
+    - CLoopModeGame::LoopInit
+  - name: ILoopMode_LoopInit
+    alias:
+    - ILoopMode::LoopInit
+  - name: ILoopMode_LoopShutdown
+    alias:
+    - ILoopMode::LoopShutdown
+  - name: CLoopModeGame_RegisterEventMapInternal
+    alias:
+    - CLoopModeGame::RegisterEventMapInternal
+  - name: CLoopModeGame_OnServerAdvanceTick
+    alias:
+    - CLoopModeGame::OnServerAdvanceTick
+  - name: CLoopModeGame_OnServerBeginSimulate
+    alias:
+    - CLoopModeGame::OnServerBeginSimulate
+  - name: CLoopModeGame_OnServerPostSimulate
+    alias:
+    - CLoopModeGame::OnServerPostSimulate
+  - name: CLoopModeGame_OnServerPostAdvanceTick
+    alias:
+    - CLoopModeGame::OnServerPostAdvanceTick
+  - name: CLoopModeGame_OnServerBeginAsyncPostTickWork
+    alias:
+    - CLoopModeGame::OnServerBeginAsyncPostTickWork
+  - name: CLoopModeGame_OnServerEndAsyncPostTickWork
+    alias:
+    - CLoopModeGame::OnServerEndAsyncPostTickWork
+  - name: CLoopModeGame_OnFrameBoundary
+    alias:
+    - CLoopModeGame::OnFrameBoundary
+  - name: CLoopModeGame_ReceivedServerInfo
+    alias:
+    - CLoopModeGame::ReceivedServerInfo
+  - name: CLoopModeGame_SetWorldSession
+    alias:
+    - CLoopModeGame::SetWorldSession
+  - name: CLoopModeGame_SetGameSystemState
+    alias:
+    - CLoopModeGame::SetGameSystemState
+  - name: IGameSystem_DestroyAllGameSystems
+    alias:
+    - IGameSystem::DestroyAllGameSystems
+  - name: IGameSystem_ShutdownAllSystems
+    alias:
+    - IGameSystem::ShutdownAllSystems
+  - name: IGameSystem_LoopDestroyAllSystems
+    alias:
+    - IGameSystem::LoopDestroyAllSystems
+  - name: IGameSystem_LoopPreShutdownAllSystems
+    alias:
+    - IGameSystem::LoopPreShutdownAllSystems
+  - name: CLoopModeGame_Shutdown
+    alias:
+    - CLoopModeGame::Shutdown
+  - name: CLoopModeGame_LoopShutdown
+    alias:
+    - CLoopModeGame::LoopShutdown
+  - name: CLoopModeGame_ShutdownServer
+    alias:
+    - CLoopModeGame::ShutdownServer
+  - name: CLoopModeGame_OnLoopDeactivate
+    alias:
+    - CLoopModeGame::OnLoopDeactivate
+  - name: ILoopMode_OnLoopDeactivate
+    alias:
+    - ILoopMode::OnLoopDeactivate
+  - name: CPlayerCommandQueue_ctor
+    alias:
+    - CPlayerCommandQueue::CPlayerCommandQueue
+  - name: IGameResourceService_SetEntityResourceManifestHandler
+    alias:
+    - IGameResourceService::SetEntityResourceManifestHandler
+  - name: CNetworkSerializerBindingBuildFilter_GetFieldPriority
+    alias:
+    - CNetworkSerializerBindingBuildFilter::GetFieldPriority
+  - name: CEntitySystem_FindComponentTypeByName
+    alias:
+    - CEntitySystem::FindComponentTypeByName
+- name: networksystem
+  symbols:
+  - name: INetworkMessages_GetFieldChangeCallbackOrderCount
+    alias:
+    - INetworkMessages::GetFieldChangeCallbackOrderCount
+  - name: INetworkMessages_GetFieldChangeCallbackPriorities
+    alias:
+    - INetworkMessages::GetFieldChangeCallbackPriorities

--- a/gamesymbols/14168.metadata.yaml
+++ b/gamesymbols/14168.metadata.yaml
@@ -1,0 +1,2879 @@
+modules:
+- name: networksystem
+  symbols:
+  - name: CNetworkMessages_RegisterNetworkCategory
+    alias:
+    - CNetworkMessages::RegisterNetworkCategory
+  - name: CNetworkMessages_AssociateNetMessageWithChannelCategoryAbstract
+    alias:
+    - CNetworkMessages::AssociateNetMessageWithChannelCategoryAbstract
+  - name: CNetworkMessages_FindOrCreateNetMessage
+    alias:
+    - CNetworkMessages::FindOrCreateNetMessage
+  - name: CNetworkMessages_SerializeInternal
+    alias:
+    - CNetworkMessages::SerializeInternal
+  - name: CNetworkMessages_UnserializeMessageInternal
+    alias:
+    - CNetworkMessages::UnserializeMessageInternal
+  - name: CNetworkMessages_SerializeMessageInternal
+    alias:
+    - CNetworkMessages::SerializeMessageInternal
+  - name: CNetworkMessages_UnserializeFromStream
+    alias:
+    - CNetworkMessages::UnserializeFromStream
+  - name: CNetworkMessages_AllocateAndCopyConstructNetMessageAbstract
+    alias:
+    - CNetworkMessages::AllocateAndCopyConstructNetMessageAbstract
+  - name: CNetworkMessages_DeallocateNetMessageAbstract
+    alias:
+    - CNetworkMessages::DeallocateNetMessageAbstract
+  - name: CNetworkMessages_RegisterNetworkFieldSerializer
+    alias:
+    - CNetworkMessages::RegisterNetworkFieldSerializer
+  - name: CNetworkMessages_RegisterNetworkArrayFieldSerializer
+    alias:
+    - CNetworkMessages::RegisterNetworkArrayFieldSerializer
+  - name: CNetworkMessages_AssociateNetMessageGroupIdWithChannelCategory
+    alias:
+    - CNetworkMessages::AssociateNetMessageGroupIdWithChannelCategory
+  - name: CNetworkMessages_RegisterNetworkFieldChangeCallbackInternal
+    alias:
+    - CNetworkMessages::RegisterNetworkFieldChangeCallbackInternal
+  - name: CNetworkMessages_AllowAdditionalMessageRegistration
+    alias:
+    - CNetworkMessages::AllowAdditionalMessageRegistration
+  - name: CNetworkMessages_IsAdditionalMessageRegistrationAllowed
+    alias:
+    - CNetworkMessages::IsAdditionalMessageRegistrationAllowed
+  - name: CNetworkMessages_RegisterFieldChangeCallbackPriority
+    alias:
+    - CNetworkMessages::RegisterFieldChangeCallbackPriority
+  - name: CNetworkMessages_ComputeOrderForPriority
+    alias:
+    - CNetworkMessages::ComputeOrderForPriority
+  - name: CNetworkMessages_dtor
+    alias:
+    - CNetworkMessages::~CNetworkMessages
+  - name: CNetworkMessages_GetIsForServer
+    alias:
+    - CNetworkMessages::GetIsForServer
+  - name: CNetworkMessages_GetNetworkSerializationContextData
+    alias:
+    - CNetworkMessages::GetNetworkSerializationContextData
+  - name: CNetChan_ParseMessagesDemoInternal
+    alias:
+    - CNetChan::ParseMessagesDemoInternal
+  - name: CNetChan_ParseNetMessageShowFilter
+    alias:
+    - CNetChan::ParseNetMessageShowFilter
+  - name: CNetworkMessages_FindNetworkMessagePartial
+    alias:
+    - CNetworkMessages::FindNetworkMessagePartial
+  - name: CNetworkMessages_FindNetworkMessage
+    alias:
+    - CNetworkMessages::FindNetworkMessage
+  - name: CNetworkMessages_FindNetworkGroup
+    alias:
+    - CNetworkMessages::FindNetworkGroup
+  - name: CNetworkSystem_SendNetworkStats
+    alias:
+    - CNetworkSystem::SendNetworkStats
+  - name: CNetworkMessages_GetNetworkGroupCount
+    alias:
+    - CNetworkMessages::GetNetworkGroupCount
+  - name: CNetworkMessages_GetNetworkGroupName
+    alias:
+    - CNetworkMessages::GetNetworkGroupName
+  - name: CNetworkMessages_GetNetworkGroupColor
+    alias:
+    - CNetworkMessages::GetNetworkGroupColor
+  - name: CNetworkMessages_ConfirmAllMessageHandlersInstalled
+    alias:
+    - CNetworkMessages::ConfirmAllMessageHandlersInstalled
+- name: engine
+  symbols:
+  - name: CServerSideClient_IsHearingClient
+    alias:
+    - IsHearingClient
+  - name: CGameResourceService_BuildResourceManifest
+    alias:
+    - CGameResourceService::BuildResourceManifest
+    - BuildResourceManifest
+  - name: CGameResourceService_m_pEntitySystem
+    alias:
+    - GameEntitySystem
+  - name: CGameResourceService_LoadGameResourceManifestNamed
+    alias:
+    - CGameResourceService::LoadGameResourceManifestNamed
+  - name: CGameResourceService_LoadGameResourceManifestGroup
+    alias:
+    - CGameResourceService::LoadGameResourceManifestGroup
+  - name: CGameResourceService_GetResourceManifestDebugName
+    alias:
+    - CGameResourceService::GetResourceManifestDebugName
+  - name: CGameResourceService_PrecacheEntitiesAndConfirmResourcesAreLoaded
+    alias:
+    - CGameResourceService::PrecacheEntitiesAndConfirmResourcesAreLoaded
+  - name: CGameResourceService_LoadGameResourceManifest_IEntityResourceManifest
+    alias:
+    - CGameResourceService::LoadGameResourceManifest
+  - name: CGameResourceService_DescribeContents
+    alias:
+    - CGameResourceService::DescribeContents
+  - name: CGameResourceService_AppendToGameResourceManifest
+    alias:
+    - CGameResourceService::AppendToGameResourceManifest
+  - name: CGameResourceService_RegisterEventMap
+    alias:
+    - CGameResourceService::RegisterEventMap
+  - name: IEntityResourceManifestBuilder_BuildResourceManifest_ManifestNameOrGroupName
+    alias:
+    - IEntityResourceManifestBuilder::BuildResourceManifest
+  - name: CServerSideClientBase_ClientPrintf
+    alias:
+    - CServerSideClientBase::ClientPrintf
+    - ClientPrintf
+  - name: CNetworkGameServer_ClientList
+    alias:
+    - CNetworkGameServer::ClientList
+  - name: CNetworkGameServerBase_SendPeerList
+    alias:
+    - CNetworkGameServerBase::SendPeerList
+  - name: CNetworkGameServerBase_ConnectClient
+    alias:
+    - CNetworkGameServerBase::ConnectClient
+  - name: CNetworkGameServerBase_ServerSimulateInternal
+    alias:
+    - CNetworkGameServerBase::ServerSimulateInternal
+  - name: CNetworkGameServerBase_ServerSimulate
+    alias:
+    - CNetworkGameServerBase::ServerSimulate
+  - name: CNetworkGameServerBase_ServerPollNetworking
+    alias:
+    - CNetworkGameServerBase::ServerPollNetworking
+  - name: CNetworkGameServerBase_BroadcastMessage
+    alias:
+    - CNetworkGameServerBase::BroadcastMessage
+  - name: CNetworkGameServerBase_BroadcastPrintf
+    alias:
+    - CNetworkGameServerBase::BroadcastPrintf
+  - name: CNetworkGameServerBase_ReserveServerForQueuedGame
+    alias:
+    - CNetworkGameServerBase::ReserveServerForQueuedGame
+  - name: CNetworkGameServerBase_FinishChangeLevel
+    alias:
+    - CNetworkGameServerBase::FinishChangeLevel
+  - name: CNetworkGameServerBase_StartChangeLevel
+    alias:
+    - CNetworkGameServerBase::StartChangeLevel
+  - name: CNetworkGameServerBase_SetServerState
+    alias:
+    - CNetworkGameServerBase::SetServerState
+  - name: CNetworkGameServer_GetFreeClient
+    alias:
+    - CNetworkGameServer::GetFreeClient
+    - GetFreeClient
+  - name: CNetworkGameServerBase_CreateFakeClient
+    alias:
+    - CNetworkGameServerBase::CreateFakeClient
+  - name: CNetworkGameServerBase_UserInfoChanged
+    alias:
+    - CNetworkGameServerBase::UserInfoChanged
+  - name: CNetworkGameServerBase_GetPlayerNetworkIDString
+    alias:
+    - CNetworkGameServerBase::GetPlayerNetworkIDString
+  - name: CNetworkGameServerBase_StartHLTVMaster
+    alias:
+    - CNetworkGameServerBase::StartHLTVMaster
+  - name: CNetworkGameServerBase_RegisterLoadingSpawnGroups
+    alias:
+    - CNetworkGameServerBase::RegisterLoadingSpawnGroups
+  - name: CNetworkServerSpawnGroupCreatePrerequisites_Init
+    alias:
+    - CNetworkServerSpawnGroupCreatePrerequisites::Init
+  - name: CNetworkGameServerBase_LoadSpawnGroup
+    alias:
+    - CNetworkGameServerBase::LoadSpawnGroup
+  - name: CNetworkGameServerBase_SpawnGroupThink
+    alias:
+    - CNetworkGameServerBase::SpawnGroupThink
+  - name: CNetworkGameServerBase_PrintSpawnGroupStatus
+    alias:
+    - CNetworkGameServerBase::PrintSpawnGroupStatus
+  - name: CNetworkGameServerBase_AsyncUnloadSpawnGroup
+    alias:
+    - CNetworkGameServerBase::AsyncUnloadSpawnGroup
+  - name: CNetworkGameServerBase_AsyncUnloadSpawnGroupInternal
+    alias:
+    - CNetworkGameServerBase::AsyncUnloadSpawnGroupInternal
+  - name: CNetworkGameServer_PrepareForAssetLoad
+    alias:
+    - CNetworkGameServer::PrepareForAssetLoad
+  - name: CNetworkGameServerBase_IsSaveRestoreAllowed
+    alias:
+    - CNetworkGameServerBase::IsSaveRestoreAllowed
+  - name: CNetworkGameServerBase_Init
+    alias:
+    - CNetworkGameServerBase::Init
+  - name: CNetworkGameServerBase_Shutdown
+    alias:
+    - CNetworkGameServerBase::Shutdown
+  - name: CNetworkGameServerBase_ShutdownInternal
+    alias:
+    - CNetworkGameServerBase::ShutdownInternal
+  - name: CNetworkGameServer_ActivateServer
+    alias:
+    - CNetworkGameServer::ActivateServer
+  - name: CNetworkGameServer_DirectUpdate
+    alias:
+    - CNetworkGameServer::DirectUpdate
+  - name: CNetworkGameServer_Init
+    alias:
+    - CNetworkGameServer::Init
+  - name: CNetworkGameServer_Shutdown
+    alias:
+    - CNetworkGameServer::Shutdown
+  - name: CNetworkGameServer_SpawnServer
+    alias:
+    - CNetworkGameServer::SpawnServer
+  - name: CNetworkGameServerBase_GetMaxClients
+    alias:
+    - CNetworkGameServerBase::GetMaxClients
+  - name: CNetworkGameServerBase_SetMaxClients
+    alias:
+    - CNetworkGameServerBase::SetMaxClients
+  - name: CNetworkGameServerBase_CheckTimeouts
+    alias:
+    - CNetworkGameServerBase::CheckTimeouts
+  - name: CNetworkGameServerBase_OnKickById
+    alias:
+    - CNetworkGameServerBase::OnKickById
+  - name: CNetworkGameServerBase_OnKickByName
+    alias:
+    - CNetworkGameServerBase::OnKickByName
+  - name: CNetworkGameClient_SendMovePacket
+    alias:
+    - CNetworkGameClient::SendMovePacket
+    - SendMovePacket
+  - name: CNetworkGameClient_SendMove
+    alias:
+    - CNetworkGameClient::SendMove
+    - SendMove
+  - name: INetworkMessages_Serialize
+    alias:
+    - INetworkMessages::Serialize
+  - name: CDemoRecorder_ParseMessage
+    alias:
+    - CDemoRecorder::ParseMessage
+  - name: CDemoRecorder_WriteSpawnGroups
+    alias:
+    - CDemoRecorder::WriteSpawnGroups
+  - name: INetworkMessages_SerializeAbstract
+    alias:
+    - INetworkMessages::SerializeAbstract
+  - name: INetworkMessages_GetNetMessageInfo
+    alias:
+    - INetworkMessages::GetNetMessageInfo
+  - name: INetworkMessages_FindNetworkMessageById
+    alias:
+    - INetworkMessages::FindNetworkMessageById
+  - name: CNetChan_ProcessMessages
+    alias:
+    - CNetChan::ProcessMessages
+  - name: CNetChan_ParseMessagesDemo
+    alias:
+    - CNetChan::ParseMessagesDemo
+  - name: CNetworkGameClient_ProcessPacketEntitiesInternal
+    alias:
+    - CNetworkGameClient::ProcessPacketEntitiesInternal
+  - name: CNetworkGameClient_ProcessPacketEntities
+    alias:
+    - CNetworkGameClient::ProcessPacketEntities
+    - ProcessPacketEntities
+  - name: CNetworkGameClient_RecordEntityBandwidth
+    alias:
+    - CNetworkGameClient::RecordEntityBandwidth
+    - RecordEntityBandwidth
+  - name: CNetworkGameClient_PrintNetStats
+    alias:
+    - CNetworkGameClient::PrintNetStats
+  - name: CMsgSource2NetworkFlowQuality_PrintStats
+    alias:
+    - CMsgSource2NetworkFlowQuality::PrintStats
+  - name: CNetworkGameClient_DisconnectGame
+    alias:
+    - CNetworkGameClient::DisconnectGame
+  - name: INetworkMessages_FindNetworkGroup
+    alias:
+    - INetworkMessages::FindNetworkGroup
+  - name: INetworkClientService_IsActive
+    alias:
+    - INetworkClientService::IsActive
+  - name: INetworkClientService_IsConnected
+    alias:
+    - INetworkClientService::IsConnected
+  - name: CNetworkClientService_ReceivedServerInfo
+    alias:
+    - CNetworkClientService::ReceivedServerInfo
+  - name: CNetworkClientService_SplitScreenConnect
+    alias:
+    - CNetworkClientService::SplitScreenConnect
+  - name: CNetworkClientService_SendNetMessage
+    alias:
+    - CNetworkClientService::SendNetMessage
+  - name: CNetworkClientService_SendStringCmd
+    alias:
+    - CNetworkClientService::SendStringCmd
+  - name: CNetworkClientService_StartChangeLevel
+    alias:
+    - CNetworkClientService::StartChangeLevel
+  - name: CNetworkClientService_FinishChangeLevel
+    alias:
+    - CNetworkClientService::FinishChangeLevel
+  - name: CNetworkClientService_PrintConnectionStatus
+    alias:
+    - CNetworkClientService::PrintConnectionStatus
+  - name: CNetworkClientService_OnStatus
+    alias:
+    - CNetworkClientService::OnStatus
+  - name: CNetworkClientService_ServerCmd
+    alias:
+    - CNetworkClientService::ServerCmd
+  - name: CNetworkClientService_GetDisconnectReason
+    alias:
+    - CNetworkClientService::GetDisconnectReason
+  - name: CNetworkClientService_PrintSpawnGroupStatus
+    alias:
+    - CNetworkClientService::PrintSpawnGroupStatus
+  - name: CNetworkClientService_IsActive
+    alias:
+    - CNetworkClientService::IsActive
+  - name: CNetworkClientService_IsConnected
+    alias:
+    - CNetworkClientService::IsConnected
+  - name: CNetworkClientService_ClockDriftAdjustFrameTime
+    alias:
+    - CNetworkClientService::ClockDriftAdjustFrameTime
+  - name: CNetworkClientService_Init
+    alias:
+    - CNetworkClientService::Init
+  - name: CNetworkClientService_Shutdown
+    alias:
+    - CNetworkClientService::Shutdown
+  - name: CNetworkClientService_DisconnectGameNow
+    alias:
+    - CNetworkClientService::DisconnectGameNow
+  - name: CGameClientConnectPrerequisite_ctor
+    alias:
+    - CGameClientConnectPrerequisite::CGameClientConnectPrerequisite
+  - name: CNetworkClientService_AddClientPrerequisites
+    alias:
+    - CNetworkClientService::AddClientPrerequisites
+  - name: CNetworkClientService_AllocateRemoteConnectionClient
+    alias:
+    - CNetworkClientService::AllocateRemoteConnectionClient
+  - name: CNetworkServerService_Init
+    alias:
+    - CNetworkServerService::Init
+  - name: CNetworkServerService_StartupServer
+    alias:
+    - CNetworkServerService::StartupServer
+  - name: CNetworkServerService_RegisterEventMapInternal
+    alias:
+    - CNetworkServerService::RegisterEventMapInternal
+  - name: CNetworkServerService_OnServerAdvanceTick
+    alias:
+    - CNetworkServerService::OnServerAdvanceTick
+  - name: CNetworkServerService_OnServerPollNetworking
+    alias:
+    - CNetworkServerService::OnServerPollNetworking
+  - name: CNetworkServerService_OnServerProcessNetworking
+    alias:
+    - CNetworkServerService::OnServerProcessNetworking
+  - name: CNetworkServerService_OnServerBeginSimulate
+    alias:
+    - CNetworkServerService::OnServerBeginSimulate
+  - name: CNetworkServerService_OnServerEndSimulate
+    alias:
+    - CNetworkServerService::OnServerEndSimulate
+  - name: CNetworkServerService_OnServerPostSimulate
+    alias:
+    - CNetworkServerService::OnServerPostSimulate
+  - name: CNetworkServerService_OnServerPostAdvanceTick
+    alias:
+    - CNetworkServerService::OnServerPostAdvanceTick
+  - name: CNetworkServerService_OnFrameBoundary
+    alias:
+    - CNetworkServerService::OnFrameBoundary
+  - name: CNetworkServerService_OnClientPollNetworking
+    alias:
+    - CNetworkServerService::OnClientPollNetworking
+  - name: CNetworkServerService_OnSimpleLoopFrameUpdate
+    alias:
+    - CNetworkServerService::OnSimpleLoopFrameUpdate
+  - name: CNetworkServerService_OnKickByIdHLTV
+    alias:
+    - CNetworkServerService::OnKickByIdHLTV
+  - name: CNetworkServerService_DisconnectGameNow
+    alias:
+    - CNetworkServerService::DisconnectGameNow
+  - name: INetworkGameServer_GetMaxClients
+    alias:
+    - INetworkGameServer::GetMaxClients
+  - name: INetworkGameServer_PreWorldUpdate
+    alias:
+    - INetworkGameServer::PreWorldUpdate
+  - name: CNetworkGameServer_PreWorldUpdate
+    alias:
+    - CNetworkGameServer::PreWorldUpdate
+  - name: INetworkGameServer_ServerEndSimulate
+    alias:
+    - INetworkGameServer::ServerEndSimulate
+  - name: CNetworkGameServerBase_ServerEndSimulate
+    alias:
+    - CNetworkGameServerBase::ServerEndSimulate
+  - name: INetworkGameServer_ServerPostSimulate
+    alias:
+    - INetworkGameServer::ServerPostSimulate
+  - name: CNetworkGameServerBase_ServerPostSimulate
+    alias:
+    - CNetworkGameServerBase::ServerPostSimulate
+  - name: INetworkGameServer_ServerAdvanceTick
+    alias:
+    - INetworkGameServer::ServerAdvanceTick
+  - name: CNetworkGameServerBase_ServerAdvanceTick
+    alias:
+    - CNetworkGameServerBase::ServerAdvanceTick
+  - name: INetworkGameServer_ServerProcessNetworking
+    alias:
+    - INetworkGameServer::ServerProcessNetworking
+  - name: CNetworkGameServerBase_ServerProcessNetworking
+    alias:
+    - CNetworkGameServerBase::ServerProcessNetworking
+  - name: INetworkGameServer_GetTimescale
+    alias:
+    - INetworkGameServer::GetTimescale
+  - name: CNetworkGameServerBase_GetTimescale
+    alias:
+    - CNetworkGameServerBase::GetTimescale
+  - name: ISource2Server_PreWorldUpdate
+    alias:
+    - ISource2Server::PreWorldUpdate
+  - name: ISource2Server_OutOfGameFrameBoundary
+    alias:
+    - ISource2Server::OutOfGameFrameBoundary
+  - name: INetworkMessages_SetIsForServer
+    alias:
+    - INetworkMessages::SetIsForServer
+  - name: CEngineClient_DumpNetStats
+    alias:
+    - CEngineClient::DumpNetStats
+  - name: CEngineServer_DumpNetStats
+    alias:
+    - CEngineServer::DumpNetStats
+  - name: CEngineServer_ClientPrintf
+    alias:
+    - CEngineServer::ClientPrintf
+  - name: CEngineServer_GetFrameTimeAmnesty
+    alias:
+    - CEngineServer::GetFrameTimeAmnesty
+  - name: CEngineServer_ShowFrameTimeReport
+    alias:
+    - CEngineServer::ShowFrameTimeReport
+  - name: CEngineServer_SetFrameTimeAmnesty
+    alias:
+    - CEngineServer::SetFrameTimeAmnesty
+  - name: CEngineServer_GetSteamUniverse
+    alias:
+    - CEngineServer::GetSteamUniverse
+  - name: CEngineServer_ChangeLevel
+    alias:
+    - CEngineServer::ChangeLevel
+  - name: CMapListService_IsMapValid
+    alias:
+    - CMapListService::IsMapValid
+    - IMapListService::IsMapValid
+  - name: CEngineServer_IsMapValid
+    alias:
+    - CEngineServer::IsMapValid
+  - name: CEngineServer_PrecacheGeneric
+    alias:
+    - CEngineServer::PrecacheGeneric
+  - name: CEngineServer_ClientCommand
+    alias:
+    - CEngineServer::ClientCommand
+  - name: CEngineServer_GetClientConVarValue
+    alias:
+    - CEngineServer::GetClientConVarValue
+  - name: CEngineServer_SetFakeClientConVarValue
+    alias:
+    - CEngineServer::SetFakeClientConVarValue
+  - name: CEngineServer_CreateFakeClient
+    alias:
+    - CEngineServer::CreateFakeClient
+  - name: CEngineServer_GetPlayerInfo
+    alias:
+    - CEngineServer::GetPlayerInfo
+  - name: CEngineServer_ClientCommandKeyValues
+    alias:
+    - CEngineServer::ClientCommandKeyValues
+  - name: CLog_Print
+    alias:
+    - CLog::Print
+  - name: CEngineServer_LogPrint
+    alias:
+    - CEngineServer::LogPrint
+  - name: CEngineServer_KickClient
+    alias:
+    - CEngineServer::KickClient
+  - name: CEngineServer_IsDedicatedServer
+    alias:
+    - CEngineServer::IsDedicatedServer
+  - name: CEngineServer_ServerCommand
+    alias:
+    - CEngineServer::ServerCommand
+  - name: CLoopTypeClientSimple_ActivateEngineServices
+    alias:
+    - CLoopTypeClientServer::ActivateEngineServices
+  - name: CLoopTypeClientServer_LoopTypeInit
+    alias:
+    - CLoopTypeClientServer::LoopTypeInit
+  - name: CLoopTypeClientServer_AdvanceTime
+    alias:
+    - CLoopTypeClientServer::AdvanceTime
+  - name: CLoopTypeClientServer_Update
+    alias:
+    - CLoopTypeClientServer::Update
+  - name: CLoopTypeClientServer_ActivateLoop
+    alias:
+    - CLoopTypeClientServer::ActivateLoop
+  - name: CLoopTypeClientServer_AllocateLoopMode
+    alias:
+    - CLoopTypeClientServer::AllocateLoopMode
+  - name: CLoopTypeClientServer_WritePerfStats
+    alias:
+    - CLoopTypeClientServer::WritePerfStats
+  - name: CLoopTypeClientServer_DeactivateLoop
+    alias:
+    - CLoopTypeClientServer::DeactivateLoop
+  - name: CLoopTypeClientServer_OutputListeners
+    alias:
+    - CLoopTypeClientServer::OutputListeners
+  - name: CLoopTypeSimple_FrameUpdate
+    alias:
+    - CLoopTypeSimple::FrameUpdate
+  - name: CLoopTypeClientServerService_OnLoopActivate
+    alias:
+    - CLoopTypeClientServerService::OnLoopActivate
+  - name: CLoopTypeSimpleService_OnLoopActivate
+    alias:
+    - CLoopTypeSimpleService::OnLoopActivate
+  - name: CLoopTypeClientServerService_HandleInputEvent
+    alias:
+    - CLoopTypeClientServerService::HandleInputEvent
+  - name: ILoopMode_HandleInputEvent
+    alias:
+    - ILoopMode::HandleInputEvent
+  - name: ILoopType_AddEngineService
+    alias:
+    - ILoopType::AddEngineService
+  - name: CLoopTypeBase_DeallocateLoopMode
+    alias:
+    - CLoopTypeBase::DeallocateLoopMode
+  - name: CLoopTypeBase_EngineLoop
+    alias:
+    - CLoopTypeBase::EngineLoop
+  - name: CLoopTypeBase_FrameUpdate
+    alias:
+    - CLoopTypeBase::FrameUpdate
+  - name: CLoopTypeBase_ActivateLoop
+    alias:
+    - CLoopTypeBase::ActivateLoop
+  - name: CLoopTypeBase_AllocateLoopMode
+    alias:
+    - CLoopTypeBase::AllocateLoopMode
+  - name: CLoopTypeBase_DeactivateLoop
+    alias:
+    - CLoopTypeBase::DeactivateLoop
+  - name: CLoopTypeBase_LoopTypeInit
+    alias:
+    - CLoopTypeBase::LoopTypeInit
+  - name: CLoopTypeBase_LoopTypeShutdown
+    alias:
+    - CLoopTypeBase::LoopTypeShutdown
+  - name: CLoopTypeBase_GetClientServerMode
+    alias:
+    - CLoopTypeBase::GetClientServerMode
+  - name: CLoopTypeBase_GetImplType
+    alias:
+    - CLoopTypeBase::GetImplType
+  - name: CLoopTypeBase_AddDependentServices
+    alias:
+    - CLoopTypeBase::AddDependentServices
+  - name: CLoopTypeBase_GenerateServiceDependencies
+    alias:
+    - CLoopTypeBase::GenerateServiceDependencies
+  - name: CLoopTypeBase_GenerateSecondaryDependencies
+    alias:
+    - CLoopTypeBase::GenerateSecondaryDependencies
+  - name: CLoopTypeBase_LoadDependentServices
+    alias:
+    - CLoopTypeBase::LoadDependentServices
+  - name: IEngineService_GetServiceDependencies
+    alias:
+    - IEngineService::GetServiceDependencies
+  - name: IEngineService_GetName
+    alias:
+    - IEngineService::GetName
+  - name: ILoopModeFactory_GetLoopModeType
+    alias:
+    - ILoopModeFactory::GetLoopModeType
+  - name: ILoopModeFactory_Shutdown
+    alias:
+    - ILoopModeFactory::Shutdown
+  - name: CEngineServiceMgr_RegisterEngineService
+    alias:
+    - CEngineServiceMgr::RegisterEngineService
+  - name: CEngineServiceMgr_RegisterLoopMode
+    alias:
+    - CEngineServiceMgr::RegisterLoopMode
+  - name: CEngineServiceMgr_UnregisterLoopMode
+    alias:
+    - CEngineServiceMgr::UnregisterLoopMode
+  - name: CEngineServiceMgr_UnregisterEngineService
+    alias:
+    - CEngineServiceMgr::UnregisterEngineService
+  - name: CEngineServiceMgr_SwitchToLoop
+    alias:
+    - CEngineServiceMgr::SwitchToLoop
+  - name: CEngineServiceMgr_PrintStatus
+    alias:
+    - CEngineServiceMgr::PrintStatus
+  - name: CEngineServiceMgr__MainLoop
+    alias:
+    - CEngineServiceMgr::_MainLoop
+  - name: CEngineServiceMgr_DeactivateLoop
+    alias:
+    - CEngineServiceMgr::DeactivateLoop
+  - name: CEngineServiceMgr_Shutdown
+    alias:
+    - CEngineServiceMgr::Shutdown
+  - name: CEngineServiceMgr_GetActiveLoopClientServerMode
+    alias:
+    - CEngineServiceMgr::GetActiveLoopClientServerMode
+  - name: CEngineServiceMgr_GetEventDispatcher
+    alias:
+    - CEngineServiceMgr::GetEventDispatcher
+  - name: CEngineGameUI_Shutdown
+    alias:
+    - CEngineGameUI::Shutdown
+  - name: IAppSystem_Shutdown
+    alias:
+    - IAppSystem::Shutdown
+  - name: CSplitScreenService_AddSplitScreenUser
+    alias:
+    - CSplitScreenService::AddSplitScreenUser
+  - name: CSplitScreenService_LoadUserConfiguration
+    alias:
+    - CSplitScreenService::LoadUserConfiguration
+  - name: CHLTVClient_ProcessSetConVar
+    alias:
+    - CHLTVClient::ProcessSetConVar
+  - name: CServerSideClientBase_ProcessTick
+    alias:
+    - CServerSideClientBase::ProcessTick
+  - name: CServerSideClientBase_ProcessStringCmd
+    alias:
+    - CServerSideClientBase::ProcessStringCmd
+  - name: CServerSideClientBase_MarkSpawnGroupLoadCompleted
+    alias:
+    - CServerSideClientBase::MarkSpawnGroupLoadCompleted
+  - name: CServerSideClientBase_ProcessSpawnGroup_LoadCompleted
+    alias:
+    - CServerSideClientBase::ProcessSpawnGroup_LoadCompleted
+  - name: CServerSideClientBase_ProcessClientInfo
+    alias:
+    - CServerSideClientBase::ProcessClientInfo
+  - name: CServerSideClientBase_ProcessBaselineAck
+    alias:
+    - CServerSideClientBase::ProcessBaselineAck
+  - name: CServerSideClientBase_ProcessSplitPlayerConnectInternal
+    alias:
+    - CServerSideClientBase::ProcessSplitPlayerConnectInternal
+  - name: CServerSideClientBase_ProcessSplitPlayerConnect
+    alias:
+    - CServerSideClientBase::ProcessSplitPlayerConnect
+  - name: CServerSideClientBase_GetUserIDString
+    alias:
+    - CServerSideClientBase::GetUserIDString
+  - name: CServerSideClientBase_GetNetworkIDString
+    alias:
+    - CServerSideClientBase::GetNetworkIDString
+  - name: CServerSideClientBase_Connect
+    alias:
+    - CServerSideClientBase::Connect
+  - name: CServerSideClientBase_GetPlayerInfo
+    alias:
+    - CServerSideClientBase::GetPlayerInfo
+  - name: CNetworkGameServer_GetPlayerNetworkIDString
+    alias:
+    - CNetworkGameServer::GetPlayerNetworkIDString
+  - name: CNetworkGameServerBase_RemoveClientFromGame
+    alias:
+    - CNetworkGameServerBase::RemoveClientFromGame
+  - name: CEngineServer_GetPlayerNetworkIDString
+    alias:
+    - CEngineServer::GetPlayerNetworkIDString
+  - name: CNetworkGameClientBase_ServerCmd
+    alias:
+    - CNetworkGameClientBase::ServerCmd
+  - name: CNetworkGameClientBase_ProcessSetConVar
+    alias:
+    - CNetworkGameClientBase::ProcessSetConVar
+  - name: CNetworkGameClientBase_SendStringCmd
+    alias:
+    - CNetworkGameClientBase::SendStringCmd
+  - name: CNetworkGameClientBase_StartChangeLevel
+    alias:
+    - CNetworkGameClientBase::StartChangeLevel
+  - name: CNetworkGameClientBase_FinishChangeLevel
+    alias:
+    - CNetworkGameClientBase::FinishChangeLevel
+  - name: CNetworkGameClientBase_DeferActivate
+    alias:
+    - CNetworkGameClientBase::DeferActivate
+  - name: CNetworkGameClientBase_ClockDrift_AdjustFrameTime
+    alias:
+    - CNetworkGameClientBase::ClockDrift_AdjustFrameTime
+  - name: CNetworkGameClientBase_Connect
+    alias:
+    - CNetworkGameClientBase::Connect
+  - name: CNetworkGameClientBase_DisconnectGame
+    alias:
+    - CNetworkGameClientBase::DisconnectGame
+  - name: CNetSupportImpl_Connect
+    alias:
+    - CNetSupportImpl::Connect
+- name: client
+  symbols:
+  - name: CLoopModeGame_RegisterEventMapInternal
+    alias:
+    - CLoopModeGame::RegisterEventMapInternal
+  - name: CLoopModeGame_OnClientPollNetworking
+    alias:
+    - CLoopModeGame::OnClientPollNetworking
+  - name: CLoopModeGame_OnClientAdvanceTick
+    alias:
+    - CLoopModeGame::OnClientAdvanceTick
+  - name: CLoopModeGame_OnClientPostAdvanceTick
+    alias:
+    - CLoopModeGame::OnClientPostAdvanceTick
+  - name: CLoopModeGame_OnClientPreSimulate
+    alias:
+    - CLoopModeGame::OnClientPreSimulate
+  - name: CLoopModeGame_OnClientPreOutput
+    alias:
+    - CLoopModeGame::OnClientPreOutput
+  - name: CLoopModeGame_OnClientPreOutputParallelWithServer
+    alias:
+    - CLoopModeGame::OnClientPreOutputParallelWithServer
+  - name: CLoopModeGame_OnClientPostOutput
+    alias:
+    - CLoopModeGame::OnClientPostOutput
+  - name: CLoopModeGame_OnClientFrameSimulate
+    alias:
+    - CLoopModeGame::OnClientFrameSimulate
+  - name: CLoopModeGame_OnClientAdvanceNonRenderedFrame
+    alias:
+    - CLoopModeGame::OnClientAdvanceNonRenderedFrame
+  - name: CLoopModeGame_OnClientPostSimulate
+    alias:
+    - CLoopModeGame::OnClientPostSimulate
+  - name: CLoopModeGame_OnClientPauseSimulate
+    alias:
+    - CLoopModeGame::OnClientPauseSimulate
+  - name: CLoopModeGame_OnClientSimulate
+    alias:
+    - CLoopModeGame::OnClientSimulate
+  - name: CLoopModeGame_OnPostDataUpdate
+    alias:
+    - CLoopModeGame::OnPostDataUpdate
+  - name: CLoopModeGame_OnPreDataUpdate
+    alias:
+    - CLoopModeGame::OnPreDataUpdate
+  - name: CLoopModeGame_OnFrameBoundary
+    alias:
+    - CLoopModeGame::OnFrameBoundary
+  - name: CLoopModeGame_StaticInit
+    alias:
+    - CLoopModeGame::StaticInit
+  - name: CLoopModeFactory_CLoopModeGame_Init
+    alias:
+    - CLoopModeFactory<CLoopModeGame>::Init
+  - name: CLoopModeFactory_CLoopModeGame_Shutdown
+    alias:
+    - CLoopModeFactory<CLoopModeGame>::Shutdown
+  - name: CLoopModeGame_OnLoopActivate
+    alias:
+    - CLoopModeGame::OnLoopActivate
+  - name: ILoopMode_OnLoopActivate
+    alias:
+    - ILoopMode::OnLoopActivate
+  - name: CLoopModeGame_AddViewsToSceneSystem
+    alias:
+    - CLoopModeGame::AddViewsToSceneSystem
+  - name: ILoopMode_AddViewsToSceneSystem
+    alias:
+    - ILoopMode::AddViewsToSceneSystem
+  - name: CLoopModeGame_LoopInitInternal
+    alias:
+    - CLoopModeGame::LoopInitInternal
+  - name: CLoopModeGame_LoopInit
+    alias:
+    - CLoopModeGame::LoopInit
+  - name: ILoopMode_LoopInit
+    alias:
+    - ILoopMode::LoopInit
+  - name: ILoopMode_LoopShutdown
+    alias:
+    - ILoopMode::LoopShutdown
+  - name: CLoopModeGame_ReceivedServerInfo
+    alias:
+    - CLoopModeGame::ReceivedServerInfo
+  - name: CLoopModeGame_RegisterEventMap
+    alias:
+    - CLoopModeGame::RegisterEventMap
+  - name: ILoopMode_RegisterEventMap
+    alias:
+    - ILoopMode::RegisterEventMap
+  - name: CLoopModeGame_SetWorldSession
+    alias:
+    - CLoopModeGame::SetWorldSession
+  - name: CLoopModeGame_SetGameSystemState
+    alias:
+    - CLoopModeGame::SetGameSystemState
+  - name: CLoopModeGame_LoopShutdown
+    alias:
+    - CLoopModeGame::LoopShutdown
+  - name: IGameSystem_AddByName
+    alias:
+    - IGameSystem::AddByName
+  - name: IGameSystem_Add
+    alias:
+    - IGameSystem::Add
+  - name: IGameSystem_PostInit
+    alias:
+    - IGameSystem::PostInit
+  - name: IGameSystem_InitAllSystems
+    alias:
+    - IGameSystem::InitAllSystems
+  - name: IGameSystem_LoopInitAllSystems
+    alias:
+    - IGameSystem::LoopInitAllSystems
+  - name: IGameSystemFactory_PostInit
+    alias:
+    - IGameSystemFactory::PostInit
+  - name: IGameSystemFactory_GetStaticGameSystem
+    alias:
+    - IGameSystemFactory::GetStaticGameSystem
+  - name: IGameSystemFactory_ShouldAutoAdd
+    alias:
+    - IGameSystemFactory::ShouldAutoAdd
+  - name: IGameSystemFactory_CreateGameSystem
+    alias:
+    - IGameSystemFactory::CreateGameSystem
+  - name: IGameSystemFactory_IsReallocating
+    alias:
+    - IGameSystemFactory::IsReallocating
+  - name: IGameSystem_SetName
+    alias:
+    - IGameSystem::SetName
+  - name: CSpawnGroupMgrGameSystem_DoesGameSystemReallocate
+    alias:
+    - IGameSystem::DoesGameSystemReallocate
+  - name: IGameSystem_DestroyAllGameSystems
+    alias:
+    - IGameSystem::DestroyAllGameSystems
+  - name: IGameSystem_ShutdownAllSystems
+    alias:
+    - IGameSystem::ShutdownAllSystems
+  - name: IGameSystem_LoopDestroyAllSystems
+    alias:
+    - IGameSystem::LoopDestroyAllSystems
+  - name: IGameSystem_LoopPreShutdownAllSystems
+    alias:
+    - IGameSystem::LoopPreShutdownAllSystems
+  - name: IGameSystem_OnClientPollNetworking
+    alias:
+    - IGameSystem::OnClientPollNetworking
+  - name: IGameSystem_OnClientGamePostSimulate
+    alias:
+    - IGameSystem::ClientGamePostSimulate
+  - name: IGameSystem_OnClientPauseSimulate
+    alias:
+    - IGameSystem::OnClientPauseSimulate
+  - name: IGameSystem_OnClientPreUpdate
+    alias:
+    - IGameSystem::OnClientPreUpdate
+  - name: IGameSystem_OnClientPostUpdate
+    alias:
+    - IGameSystem::OnClientPostUpdate
+  - name: IGameSystem_OnClientPostDataUpdate
+    alias:
+    - IGameSystem::OnClientPostDataUpdate
+  - name: IGameSystem_OnGameFrameBoundary
+    alias:
+    - IGameSystem::OnGameFrameBoundary
+  - name: IGameSystem_OnClientAdvanceNonRenderedFrame
+    alias:
+    - IGameSystem::OnClientAdvanceNonRenderedFrame
+  - name: IGameSystem_OnClientFrameSimulate
+    alias:
+    - IGameSystem::OnClientFrameSimulate
+  - name: IGameSystem_OnClientAdvanceTick
+    alias:
+    - IGameSystem::ClientAdvanceTick
+  - name: IGameSystem_OnClientPostAdvanceTick
+    alias:
+    - IGameSystem::ClientPostAdvanceTick
+  - name: IGameSystem_OnClientPostRender
+    alias:
+    - IGameSystem::OnClientPostRender
+  - name: IGameSystem_OnClientPreRender
+    alias:
+    - IGameSystem::OnClientPreRender
+  - name: IGameSystem_OnClientPreRenderAlt
+    alias:
+    - IGameSystem::OnClientPreRenderAlt
+  - name: CSource2Client_OnDisconnect
+    alias:
+    - CSource2Client::OnDisconnect
+  - name: IGameSystem_OnClientDisconnect
+    alias:
+    - IGameSystem::OnClientDisconnect
+  - name: IGameSystem_OnClientPreEntityThink
+    alias:
+    - IGameSystem::OnClientPreEntityThink
+  - name: CSteamworksGameStats_OnReceivedSessionID
+    alias:
+    - CSteamworksGameStats::OnReceivedSessionID
+  - name: IGameSystem_GetName
+    alias:
+    - IGameSystem::GetName
+  - name: IGameSystemFactory_DestroyGameSystem
+    alias:
+    - IGameSystemFactory::DestroyGameSystem
+  - name: IGameSystemFactory_Init
+    alias:
+    - IGameSystemFactory::Init
+  - name: IGameSystemFactory_GetPriority
+    alias:
+    - IGameSystemFactory::GetPriority
+  - name: IGameSystemFactory_Shutdown
+    alias:
+    - IGameSystemFactory::Shutdown
+  - name: IGameSystemFactory_SetGlobalPtr
+    alias:
+    - IGameSystemFactory::SetGlobalPtr
+  - name: CPrediction_PostNetworkDataReceived
+    alias:
+    - CPrediction::PostNetworkDataReceived
+  - name: IEngineServiceMgr_GetActiveLoopClientServerMode
+    alias:
+    - IEngineServiceMgr::GetActiveLoopClientServerMode
+  - name: IEngineServiceMgr_GetEventDispatcher
+    alias:
+    - IEngineServiceMgr::GetEventDispatcher
+  - name: ClientModeCSNormal_Update
+    alias:
+    - ClientModeCSNormal::Update
+  - name: CEntitySystem_ctor
+    alias:
+    - CEntitySystem::CEntitySystem
+  - name: CGameEntitySystem_ctor
+    alias:
+    - CGameEntitySystem::CGameEntitySystem
+  - name: CEntitySystem_Init
+    alias:
+    - CEntitySystem::Init
+  - name: CEntitySystem_PostCreateEntitySystem
+    alias:
+    - CEntitySystem::PostCreateEntitySystem
+  - name: CSource2EntitySystem_StaticInit
+    alias:
+    - CSource2EntitySystem::StaticInit
+  - name: CGameSystemReallocatingFactory_CSource2EntitySystem_Init
+    alias:
+    - CGameSystemReallocatingFactory<CSource2EntitySystem>::Init
+  - name: CGameSystemReallocatingFactory_CSource2EntitySystem_CreateGameSystem
+    alias:
+    - CGameSystemReallocatingFactory<CSource2EntitySystem>::CreateGameSystem
+  - name: CSkeletonInstance_PostDataUpdate
+    alias:
+    - CSkeletonInstance::PostDataUpdate
+  - name: CSkeletonInstance_m_modelState
+    alias:
+    - CSkeletonInstance::m_modelState
+  - name: CSkeletonInstance_m_modelState_m_hModel
+    alias:
+    - CSkeletonInstance::m_modelState.m_hModel
+  - name: CModelState_SetupJointState
+    alias:
+    - CModelState::SetupJointState
+  - name: CModelState_m_nTotalTransformCount
+    alias:
+    - CModelState::m_nTotalTransformCount
+  - name: CModelState_m_nBoneCount
+    alias:
+    - CModelState::m_nBoneCount
+  - name: CModelState_m_nAttachmentCount
+    alias:
+    - CModelState::m_nAttachmentCount
+  - name: IVEngineClient2_GetNetworkClient
+    alias:
+    - IVEngineClient2::GetNetworkClient
+  - name: INetworkClient_GetLocalAddress
+    alias:
+    - INetworkClient::GetLocalAddress
+  - name: INetworkClientService_IsConnected
+    alias:
+    - INetworkClientService::IsConnected
+  - name: INetworkClientService_SendNetMessage
+    alias:
+    - INetworkClientService::SendNetMessage
+  - name: IGameResourceService_SetEntityResourceManifestHandler
+    alias:
+    - IGameResourceService::SetEntityResourceManifestHandler
+  - name: CNetworkSerializerBindingBuildFilter_GetFieldPriority
+    alias:
+    - CNetworkSerializerBindingBuildFilter::GetFieldPriority
+- name: server
+  symbols:
+  - name: CSource2Server_OnStreamEntitiesFromFileCompleted
+    alias:
+    - CSource2Server::OnStreamEntitiesFromFileCompleted
+  - name: CSource2Server_PreWorldUpdate
+    alias:
+    - CSource2Server::PreWorldUpdate
+  - name: CSource2Server_OutOfGameFrameBoundary
+    alias:
+    - CSource2Server::OutOfGameFrameBoundary
+  - name: CGameSystemReallocatingFactory_CSource2EntitySystem_Init
+    alias:
+    - CGameSystemReallocatingFactory<CSource2EntitySystem>::Init
+  - name: CGameSystemReallocatingFactory_CSource2EntitySystem_CreateGameSystem
+    alias:
+    - CGameSystemReallocatingFactory<CSource2EntitySystem>::CreateGameSystem
+  - name: IGameSystemFactory_Init
+    alias:
+    - IGameSystemFactory::Init
+  - name: IGameSystemFactory_Shutdown
+    alias:
+    - IGameSystemFactory::Shutdown
+  - name: IGameSystemFactory_SetGlobalPtr
+    alias:
+    - IGameSystemFactory::SetGlobalPtr
+  - name: CGameSystemReallocatingFactory_CSpawnGroupMgrGameSystem_DestroyGameSystem
+    alias:
+    - CGameSystemReallocatingFactory<CSpawnGroupMgrGameSystem>::Deallocate
+  - name: IGameSystem_SetGameSystemGlobalPtrs
+    alias:
+    - IGameSystem::SetGameSystemGlobalPtrs
+  - name: IGameSystem_vdtor
+    alias:
+    - IGameSystem::~IGameSystem
+  - name: IGameSystem_OnGameInit
+    alias:
+    - IGameSystem::GameInit
+  - name: CMultiplayRules_ctor
+    alias:
+    - CMultiplayRules::CMultiplayRules
+  - name: CGameMoney_OnMoneySpent
+    alias:
+    - CGameMoney::OnMoneySpent
+  - name: CGameMoney_m_DataMap
+    alias:
+    - CGameMoney::m_DataMap
+  - name: CGameMoney_GetDataDescMap
+    alias:
+    - CGameMoney::GetDataDescMap
+  - name: CCSPlayer_UseServices_OnUseImpl
+    alias:
+    - CCSPlayer_UseServices::OnUseImpl
+  - name: CCSPlayer_UseServices_OnUse
+    alias:
+    - CCSPlayer_UseServices::OnUse
+  - name: CCSPlayer_MovementServices_ProcessMovement
+    alias:
+    - CCSPlayer_MovementServices::ProcessMovement
+    - ProcessMovement
+  - name: CCSPlayer_MovementServices_CheckMovingGround
+    alias:
+    - CCSPlayer_MovementServices::CheckMovingGround
+    - CheckMovingGround
+  - name: CCSPlayer_MovementServices_WalkMove
+    alias:
+    - CCSPlayer_MovementServices::WalkMove
+    - WalkMove
+  - name: CCSPlayer_MovementServices_FullWalkMove
+    alias:
+    - CCSPlayer_MovementServices::FullWalkMove
+    - FullWalkMove
+  - name: CCSPlayer_MovementServices_CheckVelocity
+    alias:
+    - CCSPlayer_MovementServices::CheckVelocity
+    - CheckVelocity
+  - name: CCSPlayer_MovementServices_WaterMove
+    alias:
+    - CCSPlayer_MovementServices::WaterMove
+    - WaterMove
+  - name: CCSPlayer_MovementServices_FullWalkMove_SpeedClamp
+    alias:
+    - ServerMovementUnlock
+  - name: CCSPlayer_MovementServices_CheckJumpButton
+    alias:
+    - CCSPlayer_MovementServices::CheckJumpButton
+  - name: CCSPlayer_MovementServices_CheckJumpButton_WaterPatch
+    alias:
+    - CheckJumpButtonWater
+    - FixWaterFloorJump
+  - name: CPlayer_MovementServices_PlayWaterStepSound
+    alias:
+    - CPlayer_MovementServices::PlayWaterStepSound
+  - name: CPlayer_MovementServices_ForceButtons
+    alias:
+    - CPlayer_MovementServices::ForceButtons
+  - name: CPlayer_MovementServices_ForceButtonState
+    alias:
+    - CPlayer_MovementServices::ForceButtonState
+  - name: CPlayer_MovementServices_s_pRunCommandPawn
+    alias:
+    - CPlayer_MovementServices::s_pRunCommandPawn
+  - name: CEntityInstance_m_pEntity
+    alias:
+    - CEntityInstance::m_pEntity
+  - name: CEntityInstance_m_hPrivateScope
+    alias:
+    - CEntityInstance::m_hPrivateScope
+  - name: CEntityInstance_m_CScriptComponent
+    alias:
+    - CEntityInstance::m_CScriptComponent
+  - name: CEntityInstance_m_pKeyValues
+    alias:
+    - CEntityInstance::m_pKeyValues
+  - name: CEntityInstance_m_iszPrivateVScripts
+    alias:
+    - CEntityInstance::m_iszPrivateVScripts
+  - name: CBaseEntity_OnRestore
+    alias:
+    - CBaseEntity::OnRestore
+  - name: CEntityInstance_OnRestore
+    alias:
+    - CEntityInstance::OnRestore
+  - name: CBaseEntity_ctor
+    alias:
+    - CBaseEntity::CBaseEntity
+  - name: CBaseEntity_dtor
+    alias:
+    - CBaseEntity::~CBaseEntity
+  - name: CBaseEntity_vdtor
+    alias:
+    - CBaseEntity::~CBaseEntity (virtual)
+  - name: CEntityInstance_vdtor
+    alias:
+    - CEntityInstance::~CEntityInstance (virtual)
+  - name: CEntitySaveRestoreBlockHandler_PreSave
+    alias:
+    - CEntitySaveRestoreBlockHandler::PreSave
+  - name: CEntitySaveRestoreBlockHandler_SaveInternal
+    alias:
+    - CEntitySaveRestoreBlockHandler::SaveInternal
+  - name: CEntitySaveRestoreBlockHandler_Save
+    alias:
+    - CEntitySaveRestoreBlockHandler::Save
+  - name: CEntitySaveRestoreBlockHandler_Restore
+    alias:
+    - CEntitySaveRestoreBlockHandler::Restore
+  - name: CEntitySaveRestoreBlockHandler_DoRestoreEntity
+    alias:
+    - CEntitySaveRestoreBlockHandler::DoRestoreEntity
+  - name: CEntitySaveRestoreBlockHandler_RestoreEntity
+    alias:
+    - CEntitySaveRestoreBlockHandler::RestoreEntity
+  - name: CreateEntityTransitionList
+    alias:
+    - CreateEntityTransitionList
+  - name: CEntitySaveRestoreBlockHandler_WriteSaveHeaders
+    alias:
+    - CEntitySaveRestoreBlockHandler::WriteSaveHeaders
+  - name: CEntitySaveRestoreBlockHandler_ReadRestoreHeaders
+    alias:
+    - CEntitySaveRestoreBlockHandler::ReadRestoreHeaders
+  - name: CEntity2SaveRestore_StreamEntitiesFromFile
+    alias:
+    - CEntity2SaveRestore::StreamEntitiesFromFile
+  - name: CSaveRestoreBlockSet_PreRestore
+    alias:
+    - CSaveRestoreBlockSet::PreRestore
+  - name: CSaveRestoreBlockSet_PostRestore
+    alias:
+    - CSaveRestoreBlockSet::PostRestore
+  - name: CEntitySaveRestoreBlockHandler_PreRestore
+    alias:
+    - CEntitySaveRestoreBlockHandler::PreRestore
+  - name: CEntitySaveRestoreBlockHandler_PostRestore
+    alias:
+    - CEntitySaveRestoreBlockHandler::PostRestore
+  - name: CEntitySystem_ForceSetInPVSCallsIntoQueue
+    alias:
+    - CEntitySystem::ForceSetInPVSCallsIntoQueue
+  - name: CEntitySystem_ExecuteQueuedSetInPVS
+    alias:
+    - CEntitySystem::ExecuteQueuedSetInPVS
+  - name: CEntitySystem_m_nSuppressDormancyChangeCount
+    alias:
+    - CEntitySystem::m_nSuppressDormancyChangeCount
+  - name: CEntitySystem_m_nExecuteQueuedCreationDepth
+    alias:
+    - CEntitySystem::m_nExecuteQueuedCreationDepth
+  - name: CEntitySystem_m_queuedDormancyChanges
+    alias:
+    - CEntitySystem::m_queuedDormancyChanges
+  - name: CEntitySystem_SetInPVS
+    alias:
+    - CEntitySystem::SetInPVS
+  - name: CEntitySystem_OnSetDormant
+    alias:
+    - CEntitySystem::OnSetDormant
+  - name: CEntitySystem_BuildResourceManifestForEntity
+    alias:
+    - CEntitySystem::BuildResourceManifestForEntity
+  - name: CEntityInstance_ObjectCaps
+    alias:
+    - CEntityInstance::ObjectCaps
+  - name: CEntityInstance_Save
+    alias:
+    - CEntityInstance::Save
+  - name: CEntityInstance_Restore
+    alias:
+    - CEntityInstance::Restore
+  - name: CEntitySaveRestoreBlockHandler_SaveInitEntities
+    alias:
+    - CEntitySaveRestoreBlockHandler::SaveInitEntities
+  - name: CEntityInstance_OnSave
+    alias:
+    - CEntityInstance::OnSave
+  - name: CEntityInstance_RequiredEdictIndex
+    alias:
+    - CEntityInstance::RequiredEdictIndex
+  - name: PolymorphicHelper_t__SetPolymorphicPointer
+    alias:
+    - PolymorphicHelper_t::SetPolymorphicPointer
+  - name: CEntityInstance_AddChangeAccessorPathPolymorphic
+    alias:
+    - CEntityInstance::AddChangeAccessorPathPolymorphic
+  - name: CEntityInstance_AssignChangeAccessorPathIdsPolymorphic
+    alias:
+    - CEntityInstance::AssignChangeAccessorPathIdsPolymorphic
+  - name: CEntityInstance_AddChangeAccessorPath
+    alias:
+    - CEntityInstance::AddChangeAccessorPath
+  - name: CEntityInstance_AssignChangeAccessorPathIds
+    alias:
+    - CEntityInstance::AssignChangeAccessorPathIds
+  - name: CEntityInstance_GetChangeAccessorPathInfo_2
+    alias:
+    - CEntityInstance::GetChangeAccessorPathInfo_2
+  - name: CBaseEntity_GetChangeAccessorPathInfo_2
+    alias:
+    - CBaseEntity::GetChangeAccessorPathInfo_2
+  - name: CBaseEntity_GetChangeAccessorPathInfo_1
+    alias:
+    - CBaseEntity::GetChangeAccessorPathInfo_1
+  - name: CMomentaryRotButton_Use
+    alias:
+    - CMomentaryRotButton::Use
+  - name: CBaseEntity_TakeDamageOld
+    alias:
+    - CBaseEntity::TakeDamageOld
+  - name: CBaseEntity_OnTakeDamage
+    alias:
+    - CBasePlayerPawn::OnTakeDamage
+  - name: CBasePlayerPawn_OnTakeDamage_Alive
+    alias:
+    - CBasePlayerPawn::OnTakeDamage_Alive
+  - name: CBasePlayerPawn_OnTakeDamage_Dying
+    alias:
+    - CBasePlayerPawn::OnTakeDamage_Dying
+  - name: CBasePlayerPawn_OnTakeDamage_Dead
+    alias:
+    - CBasePlayerPawn::OnTakeDamage_Dead
+  - name: CBasePlayerPawn_OnTakeDamage
+    alias:
+    - CBasePlayerPawn::OnTakeDamage
+  - name: CCSPlayerPawn_OnTakeDamage_Alive
+    alias:
+    - CCSPlayerPawn::OnTakeDamage_Alive
+  - name: CCSPlayerPawn_OnTakeDamage_Dying
+    alias:
+    - CCSPlayerPawn::OnTakeDamage_Dying
+  - name: CCSPlayerPawn_OnTakeDamage_Dead
+    alias:
+    - CCSPlayerPawn::OnTakeDamage_Dead
+  - name: CFlashbangProjectile_Spawn
+    alias:
+    - CFlashbangProjectile::Spawn
+  - name: CSmokeGrenadeProjectile_Create
+    alias:
+    - CSmokeGrenadeProjectile::Create
+  - name: CEntitySystem_QueueDestroyEntity
+    alias:
+    - CEntitySystem::QueueDestroyEntity
+  - name: CEntitySystem_ExecuteQueuedDeletion
+    alias:
+    - CEntitySystem::ExecuteQueuedDeletion
+  - name: CEntitySystem_m_nExecuteQueuedDeletionDepth
+    alias:
+    - CEntitySystem::m_nExecuteQueuedDeletionDepth
+  - name: CBaseModelEntity_SetModel
+    alias:
+    - CBaseModelEntity::SetModel
+  - name: CBaseModelEntity_SetRenderAttribute
+    alias:
+    - CBaseModelEntity::SetRenderAttribute
+  - name: CBaseEntity_GetScriptDescInternal
+    alias:
+    - CBaseEntity::GetScriptDescInternal
+  - name: CBaseModelEntity_GetScriptDescInternal
+    alias:
+    - CBaseModelEntity::GetScriptDescInternal
+  - name: CBaseModelEntity_GetModelScale
+    alias:
+    - CBaseModelEntity::GetModelScale
+  - name: CBaseModelEntity_Script_SetModelScale
+    alias:
+    - CBaseModelEntity::Script_SetModelScale
+  - name: CBaseModelEntity_ScriptLookupAttachment
+    alias:
+    - CBaseModelEntity::ScriptLookupAttachment
+  - name: CBaseModelEntity_ScriptGetAttachmentOrigin
+    alias:
+    - CBaseModelEntity::ScriptGetAttachmentOrigin
+  - name: CBaseModelEntity_ScriptGetAttachmentAngles
+    alias:
+    - CBaseModelEntity::ScriptGetAttachmentAngles
+  - name: CBaseModelEntity_ScriptGetAttachmentForward
+    alias:
+    - CBaseModelEntity::ScriptGetAttachmentForward
+  - name: CBaseModelEntity_ScriptSetSize
+    alias:
+    - CBaseModelEntity::ScriptSetSize
+  - name: CBaseModelEntity_ScriptSetModel
+    alias:
+    - CBaseModelEntity::ScriptSetModel
+  - name: CBaseModelEntity_ScriptGetRenderAlpha
+    alias:
+    - CBaseModelEntity::ScriptGetRenderAlpha
+  - name: CBaseModelEntity_ScriptSetRenderAlpha
+    alias:
+    - CBaseModelEntity::ScriptSetRenderAlpha
+  - name: CBaseModelEntity_ScriptSetRenderMode
+    alias:
+    - CBaseModelEntity::ScriptSetRenderMode
+  - name: CBaseModelEntity_ScriptSetRenderColor
+    alias:
+    - CBaseModelEntity::ScriptSetRenderColor
+  - name: CBaseModelEntity_ScriptGetRenderColor
+    alias:
+    - CBaseModelEntity::ScriptGetRenderColor
+  - name: CBaseModelEntity_ScriptSetMaterialGroup
+    alias:
+    - CBaseModelEntity::ScriptSetMaterialGroup
+  - name: CBaseModelEntity_ScriptSetMaterialGroupHash
+    alias:
+    - CBaseModelEntity::ScriptSetMaterialGroupHash
+  - name: CBaseModelEntity_ScriptGetMaterialGroupHash
+    alias:
+    - CBaseModelEntity::ScriptGetMaterialGroupHash
+  - name: CBaseModelEntity_ScriptSetSingleMeshGroup
+    alias:
+    - CBaseModelEntity::ScriptSetSingleMeshGroup
+  - name: CBaseModelEntity_ScriptSetMeshGroupMask
+    alias:
+    - CBaseModelEntity::ScriptSetMeshGroupMask
+  - name: CBaseModelEntity_ScriptGetMeshGroupMask
+    alias:
+    - CBaseModelEntity::ScriptGetMeshGroupMask
+  - name: CBaseModelEntity_ScriptSetBodygroupByName
+    alias:
+    - CBaseModelEntity::ScriptSetBodygroupByName
+  - name: CBaseModelEntity_Script_SetBodygroup
+    alias:
+    - CBaseModelEntity::Script_SetBodygroup
+  - name: CBaseModelEntity_Script_SetSkin
+    alias:
+    - CBaseModelEntity::Script_SetSkin
+  - name: CEntityInstance_NetworkUpdateState_thunk
+    alias:
+    - CEntityInstance::NetworkUpdateState_thunk
+  - name: CBaseEntity_SetGravityScale
+    alias:
+    - CBaseEntity::SetGravityScale
+  - name: CTriggerGravity_GravityTouch
+    alias:
+    - CTriggerGravity::GravityTouch
+  - name: CTriggerGravity_GetTouchFunction
+    alias:
+    - CTriggerGravity::GetTouchFunction
+  - name: CBasePlayerController_HandleCommand_JoinTeam
+    alias:
+    - CBasePlayerController::HandleCommand_JoinTeam
+  - name: CBasePlayerController_SetPlayerName
+    alias:
+    - CBasePlayerController::SetPlayerName
+  - name: CBasePlayerController_ProcessUsercmds
+    alias:
+    - ProcessUsercmds
+  - name: CBasePlayerController_SetPawn
+    alias:
+    - CBasePlayerController::SetPawn
+  - name: CBasePlayerController_GetPawn
+    alias:
+    - CBasePlayerController::GetPawn
+  - name: CBasePlayerController_Connect
+    alias:
+    - CBasePlayerController::Connect
+  - name: CSource2GameClients_ClientDisconnect
+    alias:
+    - CSource2GameClients::ClientDisconnect
+  - name: CSource2GameClients_ClientPutInServer
+    alias:
+    - CSource2GameClients::ClientPutInServer
+  - name: CSource2GameClients_ClientConnect
+    alias:
+    - CSource2GameClients::ClientConnect
+  - name: CSource2GameClients_ClientActive
+    alias:
+    - CSource2GameClients::ClientActive
+  - name: CSource2GameClients_ClientFullyConnect
+    alias:
+    - CSource2GameClients::ClientFullyConnect
+  - name: CSource2GameClients_ClientCommand
+    alias:
+    - CSource2GameClients::ClientCommand
+  - name: CSource2GameClients_ProcessUsercmds
+    alias:
+    - CSource2GameClients::ProcessUsercmds
+  - name: CSource2GameClients_GetBugReportInfo
+    alias:
+    - CSource2GameClients::GetBugReportInfo
+  - name: CSource2GameClients_ClientDiagnostic
+    alias:
+    - CSource2GameClients::ClientDiagnostic
+  - name: CSource2GameClients_SendHLTVStatusMessage
+    alias:
+    - CSource2GameClients::SendHLTVStatusMessage
+  - name: CSource2GameClients_OnClientConnected
+    alias:
+    - CSource2GameClients::OnClientConnected
+  - name: CGameRules_FindPickerEntity
+    alias:
+    - CGameRules::FindPickerEntity
+  - name: CCSGameRules_FindPickerEntity
+    alias:
+    - CCSGameRules::FindPickerEntity
+  - name: CCSGameRules_TerminateRound
+    alias:
+    - CCSGameRules::TerminateRound
+    - CGameRules::TerminateRound
+    - CGameRules_TerminateRound
+  - name: CCSGameRules_GoToIntermission
+    alias:
+    - CCSGameRules::GoToIntermission
+  - name: CEntityInstance_AcceptInput
+    alias:
+    - CEntityInstance::AcceptInput
+    - AcceptInput
+  - name: CEntityIdentity_AcceptInput
+    alias:
+    - CEntityIdentity::AcceptInput
+  - name: CEntityIdentity_AcceptInputInternal
+    alias:
+    - CEntityIdentity::AcceptInputInternal
+  - name: CEntityInstance_ScriptAcceptInput
+    alias:
+    - CEntityInstance::ScriptAcceptInput
+  - name: CEntityIdentity_SetEntityName
+    alias:
+    - CEntityIdentity::SetEntityName
+  - name: CEntitySystem_RemoveEntityFromNameMap
+    alias:
+    - CEntitySystem::RemoveEntityFromNameMap
+  - name: CEntitySystem_AddEntityToNameMap
+    alias:
+    - CEntitySystem::AddEntityToNameMap
+  - name: ScriptBinding_Entity_SetEntityName
+    alias:
+    - Entity::SetEntityName
+  - name: CBtActionCoordinatedBuy_Update
+    alias:
+    - CBtActionCoordinatedBuy::Update
+  - name: CCSPlayer_ItemServices_CanAcquire
+    alias:
+    - CCSPlayer_ItemServices::CanAcquire
+  - name: CCSPlayer_ItemServices_GiveDefaultItems
+    alias:
+    - CCSPlayer_ItemServices::GiveDefaultItems
+  - name: CCSPlayer_ItemServices_GiveNamedItem
+    alias:
+    - CCSPlayer_ItemServices::GiveNamedItem
+  - name: CCSPlayer_ItemServices_GiveNamedItemBool
+    alias:
+    - CCSPlayer_ItemServices::GiveNamedItemBool
+  - name: CCSPlayer_WeaponServices_CanUse
+    alias:
+    - CCSPlayer_WeaponServices::CanUse
+  - name: CCSPlayer_WeaponServices_PickupItem
+    alias:
+    - CCSPlayer_WeaponServices::PickupItem
+  - name: CCSPlayer_WeaponServices_EquipWeapon
+    alias:
+    - CCSPlayer_WeaponServices::EquipWeapon
+  - name: CCSPlayer_WeaponServices_Weapon_GetSlot
+    alias:
+    - CCSPlayer_WeaponServices_Weapon_GetSlot
+  - name: CCSPlayerController_ChangeTeam
+    alias:
+    - CCSPlayerController::ChangeTeam
+  - name: CCSPlayerController_GetThinkFunction
+    alias:
+    - CCSPlayerController::GetThinkFunction
+  - name: CCSPlayerController_PlayerForceTeamThink
+    alias:
+    - PlayerForceTeamThink
+    - CCSPlayerController::PlayerForceTeamThink
+  - name: CCSPlayerController_ResetForceTeamThink
+    alias:
+    - ResetForceTeamThink
+    - CCSPlayerController::ResetForceTeamThink
+  - name: CCSPlayerController_ResourceDataThink
+    alias:
+    - ResourceDataThink
+    - CCSPlayerController::ResourceDataThink
+  - name: CCSPlayerController_InventoryUpdateThink
+    alias:
+    - InventoryUpdateThink
+    - CCSPlayerController::InventoryUpdateThink
+  - name: g_CCSPlayerController_PlayerForceTeamThink
+    alias:
+    - g_CCSPlayerController::PlayerForceTeamThink
+  - name: g_CCSPlayerController_ResetForceTeamThink
+    alias:
+    - g_CCSPlayerController::ResetForceTeamThink
+  - name: g_CCSPlayerController_ResourceDataThink
+    alias:
+    - g_CCSPlayerController::ResourceDataThink
+  - name: g_CCSPlayerController_InventoryUpdateThink
+    alias:
+    - g_CCSPlayerController::InventoryUpdateThink
+  - name: CCSGameRules__sm_mapGcBanInformation
+    alias:
+    - CCSGameRules::sm_mapGcBanInformation
+  - name: CCSGameRules_BeginRound
+    alias:
+    - CCSGameRules::BeginRound
+  - name: CCSGameRules_PlayerSpawn
+    alias:
+    - CCSGameRules::PlayerSpawn
+  - name: CBasePlayerController_Respawn
+    alias:
+    - CBasePlayerController::Respawn
+  - name: CCSPlayerController_Respawn
+    alias:
+    - CCSPlayerController::Respawn
+  - name: CCSPlayerController_Connect
+    alias:
+    - CCSPlayerController::Connect
+  - name: CCSPlayerController_SwitchTeam
+    alias:
+    - CCSPlayerController::SwitchTeam
+  - name: CCSPlayerPawnBase_OnSetDormant
+    alias:
+    - CCSPlayerPawnBase::OnSetDormant
+  - name: CCSPlayerPawnBase_CheckForIdle
+    alias:
+    - CCSPlayerPawnBase::CheckForIdle
+  - name: CCSPlayerPawnBase_CheckForIdleInternal
+    alias:
+    - CCSPlayerPawnBase::CheckForIdleInternal
+  - name: CCSPlayerPawn_PostThink
+    alias:
+    - CCSPlayerPawnBase::PostThink
+    - CCSPlayerPawn::PostThink
+    - CCSPlayerPawnBase_PostThink
+    - CCSPlayerPawn_PostThink
+    - PostThink
+  - name: CCSPlayerPawn_OnSwitchWeapons
+    alias:
+    - CCSPlayerPawn::OnSwitchWeapons
+  - name: CCSPlayerPawn_ProcessSuicideAsKillReward
+    alias:
+    - CCSPlayerPawn::ProcessSuicideAsKillReward
+  - name: CGameRules_ClientSettingsChanged
+    alias:
+    - CGameRules::ClientSettingsChanged
+  - name: CGameRulesGameSystem_OnGameInit
+    alias:
+    - CGameRulesGameSystem::GameInit
+  - name: CGameRulesGameSystem_OnGameShutdown
+    alias:
+    - CGameRulesGameSystem::GameShutdown
+  - name: IGameSystem_OnGameShutdown
+    alias:
+    - IGameSystem::GameShutdown
+  - name: IGameSystem_OnGamePostInit
+    alias:
+    - IGameSystem::GamePostInit
+  - name: IGameSystem_OnGamePreShutdown
+    alias:
+    - IGameSystem::GamePreShutdown
+  - name: CMultiplayRules_ClientDisconnected
+    alias:
+    - CMultiplayRules::ClientDisconnected
+  - name: CSource2Server_Init
+    alias:
+    - CSource2Server::Init
+  - name: CSource2Server_ApplyGameSettings
+    alias:
+    - CSource2Server::ApplyGameSettings
+  - name: CSource2Server_WriteSignonMessages
+    alias:
+    - CSource2Server::WriteSignonMessages
+  - name: CSource2Server_GameCreateNetworkStringTables
+    alias:
+    - CSource2Server::GameCreateNetworkStringTables
+  - name: CSource2Server_GetMatchmakingGameData
+    alias:
+    - CSource2Server::GetMatchmakingGameData
+  - name: CSource2Server_GameServerSteamAPIActivated
+    alias:
+    - CSource2Server::GameServerSteamAPIActivated
+  - name: CSource2Server_GameServerSteamAPIDeactivated
+    alias:
+    - CSource2Server::GameServerSteamAPIDeactivated
+  - name: CSource2Server_OnHostNameChanged
+    alias:
+    - CSource2Server::OnHostNameChanged
+  - name: CSource2Server_GetLevelsFromSaveFile
+    alias:
+    - CSource2Server::GetLevelsFromSaveFile
+  - name: CSource2Server_ServerConVarChanged
+    alias:
+    - CSource2Server::ServerConVarChanged
+  - name: CSource2Server_Save
+    alias:
+    - CSource2Server::Save
+  - name: CSource2Server_Connect
+    alias:
+    - CSource2Server::Connect
+  - name: CSource2Server_PreShutdown
+    alias:
+    - CSource2Server::PreShutdown
+  - name: IAppSystem_Connect
+    alias:
+    - IAppSystem::Connect
+  - name: IAppSystem_PreShutdown
+    alias:
+    - IAppSystem::PreShutdown
+  - name: IVEngineServer2_ServerCommand
+    alias:
+    - IVEngineServer2::ServerCommand
+  - name: IVEngineServer2_IsDedicatedServer
+    alias:
+    - IVEngineServer2::IsDedicatedServer
+  - name: CSource2Server_Shutdown
+    alias:
+    - CSource2Server::Shutdown
+  - name: CGameEventManager_Shutdown
+    alias:
+    - CGameEventManager::Shutdown
+  - name: CLoopModeRegistry_UnregisterLoopModes
+    alias:
+    - CLoopModeRegistry::UnregisterLoopModes
+  - name: CEngineServiceRegistry_UnregisterEngineServices
+    alias:
+    - CEngineServiceRegistry::UnregisterEngineServices
+  - name: IEngineServiceMgr_UnregisterLoopMode
+    alias:
+    - IEngineServiceMgr::UnregisterLoopMode
+  - name: IEngineServiceMgr_UnregisterEngineService
+    alias:
+    - IEngineServiceMgr::UnregisterEngineService
+  - name: CSource2Server_GameFrame
+    alias:
+    - CSource2Server::GameFrame
+  - name: CGameEventManager_Init
+    alias:
+    - CGameEventManager::Init
+  - name: CTakeDamageInfo_HitGroupInfo
+    alias:
+    - CTakeDamageInfo::HitGroupInfo
+    - CTakeDamageInfo::HitGroup
+    - CTakeDamageInfo_HitGroup
+  - name: CEntitySystem_RegisterEntityClass
+    alias:
+    - CEntitySystem::RegisterEntityClass
+  - name: CEntitySystem_CreateEntityByName
+    alias:
+    - CEntitySystem::CreateEntityByName
+  - name: CEntitySystem_CreateEntity
+    alias:
+    - CEntitySystem::CreateEntity
+  - name: CEntitySystem_AddEntityToEntityDataBase
+    alias:
+    - CEntitySystem::AddEntityToEntityDataBase
+  - name: CEntitySystem_OnAddEntity
+    alias:
+    - CEntitySystem::OnAddEntity
+  - name: CEntitySystem_OnEntityParentChanged
+    alias:
+    - CEntitySystem::OnEntityParentChanged
+  - name: CEntitySystem_PrecacheEntity
+    alias:
+    - CEntitySystem::PrecacheEntity
+  - name: CEntitySystem_InvokePrecacheCallback
+    alias:
+    - CEntitySystem::InvokePrecacheCallback
+  - name: CEntitySystem_DestroyEntity
+    alias:
+    - CEntitySystem::DestroyEntity
+  - name: CConcreteEntityList_AllocEntity
+    alias:
+    - CConcreteEntityList::AllocEntity
+  - name: CEntitySystem_ConstructEntity
+    alias:
+    - CEntitySystem::ConstructEntity
+  - name: CEntitySystem_DoConstructEntity
+    alias:
+    - CEntitySystem::DoConstructEntity
+  - name: CEntitySystem_GetSpawnGroupWorldId
+    alias:
+    - CEntitySystem::GetSpawnGroupWorldId
+  - name: CEntitySystem_FindClassByDesignName
+    alias:
+    - CEntitySystem::FindClassByDesignName
+  - name: CEntitySystem_m_EntityList
+    alias:
+    - CEntitySystem::m_EntityList
+  - name: CEntitySystem_m_entityNames
+    alias:
+    - CEntitySystem::m_entityNames
+  - name: CEntitySystem_m_entityComponentHelpers
+    alias:
+    - CEntitySystem::m_entityComponentHelpers
+  - name: CEntitySystem_m_DataDescKeyUnserializers
+    alias:
+    - CEntitySystem::m_DataDescKeyUnserializers
+  - name: CEntitySystem_m_EntityPostSpawnCallback
+    alias:
+    - CEntitySystem::m_EntityPostSpawnCallback
+  - name: CEntityIdentity_FreeAttributes
+    alias:
+    - CEntityIdentity::FreeAttributes
+  - name: CConcreteEntityList_FreeEntity
+    alias:
+    - CConcreteEntityList::FreeEntity
+  - name: UTIL_CreateEntityByName
+    alias:
+    - CreateEntityByName
+  - name: CBaseEntity_DispatchSpawn
+    alias:
+    - CBaseEntity::DispatchSpawn
+    - DispatchSpawn
+  - name: CEntitySystem_QueueSpawnEntity
+    alias:
+    - CEntitySystem::QueueSpawnEntity
+  - name: CEntitySystem_HelperExecuteQueuedSpawn
+    alias:
+    - CEntitySystem::HelperExecuteQueuedSpawn
+  - name: CEntitySystem_SortEntities
+    alias:
+    - CEntitySystem::SortEntities
+  - name: CGameEntitySystem_SortEntities
+    alias:
+    - CGameEntitySystem::SortEntities
+  - name: CEntitySystem_InstallCreationWrapperCallbacks
+    alias:
+    - CEntitySystem::InstallCreationWrapperCallbacks
+  - name: CEntitySystem_ExecuteQueuedCreation
+    alias:
+    - CEntitySystem::ExecuteQueuedCreation
+  - name: CEntitySystem_ExecuteQueuedActivates
+    alias:
+    - CEntitySystem::ExecuteQueuedActivates
+  - name: CEntitySystem_ExecuteQueuedPostDataUpdateAndActivates
+    alias:
+    - CEntitySystem::ExecuteQueuedPostDataUpdateAndActivates
+  - name: CEntitySystem_Activate
+    alias:
+    - CEntitySystem::Activate
+  - name: CEntitySystem_PostDataUpdate
+    alias:
+    - CEntitySystem::PostDataUpdate
+  - name: CBaseEntity_NetworkStateChangedLog
+    alias:
+    - CBaseEntity::NetworkStateChangedLog
+  - name: CBaseEntity_NetworkStateChanged
+    alias:
+    - CBaseEntity::NetworkStateChanged
+  - name: CBaseEntity_FullEdictChanged
+    alias:
+    - CBaseEntity::FullEdictChanged
+  - name: CBaseEntity_m_NetworkTransmitComponent
+    alias:
+    - CBaseEntity::m_NetworkTransmitComponent
+  - name: CNetworkTransmitComponent_StateChanged
+    alias:
+    - CNetworkTransmitComponent::StateChanged
+  - name: CNetworkTransmitComponent_m_nStateFlags
+    alias:
+    - CNetworkTransmitComponent::m_nStateFlags
+  - name: CInferno_InfernoThink
+    alias:
+    - CInferno::InfernoThink
+  - name: CPhysExplosion_Activate
+    alias:
+    - CPhysExplosion::Activate
+  - name: CPhysExplosion_Explode
+    alias:
+    - CPhysExplosion::Explode
+  - name: UTIL_SayTextFilter2
+    alias:
+    - UTIL_SayText2Filter
+  - name: CCSWeaponBase_ItemPostFrame_ProcessReloadAction
+    alias:
+    - CCSWeaponBase::ItemPostFrame::ProcessReloadAction
+  - name: CCSPlayer_WeaponServices_HandleDropWeapon
+    alias:
+    - CCSPlayer_WeaponServices::HandleDropWeapon
+  - name: CCSPlayer_UseServices_BumpWeapon
+    alias:
+    - CCSPlayer_UseServices::BumpWeapon
+  - name: CCSPlayerPawn_HandleDropWeapon
+    alias:
+    - CCSPlayerPawn::HandleDropWeapon
+  - name: CCSPlayerPawn_ClientCommand
+    alias:
+    - CCSPlayerPawn::ClientCommand
+  - name: CCSPlayerPawn_SprayPaint
+    alias:
+    - CCSPlayerPawn::SprayPaint
+  - name: CEntitySpawner_CPlayerSprayDecal_Spawn
+    alias:
+    - CEntitySpawner<CPlayerSprayDecal>::Spawn
+  - name: CEntityKeyValuesAllocator_GetTempBuffer
+    alias:
+    - CEntityKeyValuesAllocator::GetTempBuffer
+  - name: CEntityKeyValues_LoadFromContext
+    alias:
+    - CEntityKeyValues::LoadFromContext
+  - name: CEntityKeyValues_Initialized
+    alias:
+    - CEntityKeyValues::Initialized
+  - name: CEntitySystem_m_nEntityKeyValuesAllocatorRefCount
+    alias:
+    - CEntitySystem::m_nEntityKeyValuesAllocatorRefCount
+  - name: CEntitySystem_AddRefKeyValues
+    alias:
+    - CEntitySystem::AddRefKeyValues
+  - name: CEntitySystem_ReleaseKeyValues
+    alias:
+    - CEntitySystem::ReleaseKeyValues
+  - name: CCSPlayerController_HandleCommandDrop
+    alias:
+    - CCSPlayerController::HandleCommandDrop
+  - name: IGameSystem_InitAllSystems
+    alias:
+    - IGameSystem::InitAllSystems
+  - name: IGameSystem_LoopInitAllSystems
+    alias:
+    - IGameSystem::LoopInitAllSystems
+  - name: IGameSystem_LoopPostInitAllSystems
+    alias:
+    - IGameSystem::LoopPostInitAllSystems
+  - name: IGameSystem_PostInit
+    alias:
+    - IGameSystem::PostInit
+  - name: IGameSystemFactory_PostInit
+    alias:
+    - IGameSystemFactory::PostInit
+  - name: IGameSystemFactory_GetStaticGameSystem
+    alias:
+    - IGameSystemFactory::GetStaticGameSystem
+  - name: IGameSystem_InitAllSystems_pFirst
+    alias:
+    - IGameSystem::InitAllSystems::pFirst
+    - IGameSystem::InitAllSystems->pFirst
+  - name: IGameSystem_LoopPostInitAllSystems_pEventDispatcher
+    alias:
+    - IGameSystem::LoopPostInitAllSystems::pEventDispatcher
+    - IGameSystem::LoopPostInitAllSystems->pEventDispatcher
+  - name: IGameSystem_LoopDestroyAllSystems_s_GameSystems
+    alias:
+    - IGameSystem::LoopDestroyAllSystems::s_GameSystems
+    - IGameSystem::LoopDestroyAllSystems->s_GameSystems
+  - name: CSource2GameEntities_CheckTransmit
+    alias:
+    - CSource2GameEntities::CheckTransmit
+    - ISource2GameEntities::CheckTransmit
+    - ISource2GameEntities_CheckTransmit
+    - CheckTransmit
+  - name: CBaseEntity_EmitSoundFilter
+    alias:
+    - CBaseEntity::EmitSoundFilter
+  - name: CBaseEntity_ScriptInputKill
+    alias:
+    - CBaseEntity::ScriptInputKill
+  - name: CBaseEntity_ScriptGetForward
+    alias:
+    - CBaseEntity::ScriptGetForward
+  - name: CBaseEntity_ScriptGetRight
+    alias:
+    - CBaseEntity::ScriptGetRight
+  - name: CBaseEntity_ScriptGetLeft
+    alias:
+    - CBaseEntity::ScriptGetLeft
+  - name: CBaseEntity_ScriptGetUp
+    alias:
+    - CBaseEntity::ScriptGetUp
+  - name: CBaseEntity_ScriptGetModelName
+    alias:
+    - CBaseEntity::ScriptGetModelName
+  - name: CBaseEntity_ScriptGetMoveParent
+    alias:
+    - CBaseEntity::ScriptGetMoveParent
+  - name: CBaseEntity_ScriptGetRootMoveParent
+    alias:
+    - CBaseEntity::ScriptGetRootMoveParent
+  - name: CBaseEntity_ScriptFirstMoveChild
+    alias:
+    - CBaseEntity::ScriptFirstMoveChild
+  - name: CBaseEntity_ScriptNextMovePeer
+    alias:
+    - CBaseEntity::ScriptNextMovePeer
+  - name: CBaseEntity_ScriptGetOwnerEntity
+    alias:
+    - CBaseEntity::ScriptGetOwnerEntity
+  - name: CBaseEntity_Script_GetChildren
+    alias:
+    - CBaseEntity::Script_GetChildren
+  - name: CBaseEntity_ScriptSetParent
+    alias:
+    - CBaseEntity::ScriptSetParent
+  - name: CBaseEntity_ScriptEyePosition
+    alias:
+    - CBaseEntity::ScriptEyePosition
+  - name: CBaseEntity_ScriptSetAngles
+    alias:
+    - CBaseEntity::ScriptSetAngles
+  - name: CBaseEntity_ScriptSetAbsAngles
+    alias:
+    - CBaseEntity::ScriptSetAbsAngles
+  - name: CBaseEntity_ScriptGetAngles
+    alias:
+    - CBaseEntity::ScriptGetAngles
+  - name: CBaseEntity_ScriptEyeAngles
+    alias:
+    - CBaseEntity::ScriptEyeAngles
+  - name: CBaseEntity_ScriptSetOrigin
+    alias:
+    - CBaseEntity::ScriptSetOrigin
+  - name: CBaseEntity_ScriptSetLocalAngles
+    alias:
+    - CBaseEntity::ScriptSetLocalAngles
+  - name: CBaseEntity_ScriptGetLocalAngles
+    alias:
+    - CBaseEntity::ScriptGetLocalAngles
+  - name: CBaseEntity_ScriptSetLocalOrigin
+    alias:
+    - CBaseEntity::ScriptSetLocalOrigin
+  - name: CBaseEntity_ScriptGetLocalOrigin
+    alias:
+    - CBaseEntity::ScriptGetLocalOrigin
+  - name: CBaseEntity_ScriptTransformPointEntityToWorld
+    alias:
+    - CBaseEntity::ScriptTransformPointEntityToWorld
+  - name: CBaseEntity_ScriptTransformPointWorldToEntity
+    alias:
+    - CBaseEntity::ScriptTransformPointWorldToEntity
+  - name: CBaseEntity_ScriptSetForward
+    alias:
+    - CBaseEntity::ScriptSetForward
+  - name: CBaseEntity_ScriptGetBoundingMins
+    alias:
+    - CBaseEntity::ScriptGetBoundingMins
+  - name: CBaseEntity_ScriptGetBoundingMaxs
+    alias:
+    - CBaseEntity::ScriptGetBoundingMaxs
+  - name: CBaseEntity_ScriptGetBounds
+    alias:
+    - CBaseEntity::ScriptGetBounds
+  - name: CBaseEntity_ScriptGetLocalAngularVelocity_OBSOLETE
+    alias:
+    - CBaseEntity::ScriptGetLocalAngularVelocity_OBSOLETE
+  - name: CBaseEntity_ScriptSetLocalAngularVelocity_OBSOLETE
+    alias:
+    - CBaseEntity::ScriptSetLocalAngularVelocity_OBSOLETE
+  - name: CBaseEntity_ScriptAddEffects
+    alias:
+    - CBaseEntity::ScriptAddEffects
+  - name: CBaseEntity_ScriptRemoveEffects
+    alias:
+    - CBaseEntity::ScriptRemoveEffects
+  - name: CBaseEntity_ScriptSetAttributeFloatValue
+    alias:
+    - CBaseEntity::ScriptSetAttributeFloatValue
+  - name: CBaseEntity_ScriptGetAttributeFloatValue
+    alias:
+    - CBaseEntity::ScriptGetAttributeFloatValue
+  - name: CBaseEntity_ScriptSetAttributeIntValue
+    alias:
+    - CBaseEntity::ScriptSetAttributeIntValue
+  - name: CBaseEntity_ScriptGetAttributeIntValue
+    alias:
+    - CBaseEntity::ScriptGetAttributeIntValue
+  - name: CBaseEntity_ScriptHasAttribute
+    alias:
+    - CBaseEntity::ScriptHasAttribute
+  - name: CBaseEntity_ScriptDeleteAttribute
+    alias:
+    - CBaseEntity::ScriptDeleteAttribute
+  - name: CBaseEntity_GetScriptOwnerEntity
+    alias:
+    - CBaseEntity::GetScriptOwnerEntity
+  - name: CBaseEntity_SetScriptOwnerEntity
+    alias:
+    - CBaseEntity::SetScriptOwnerEntity
+  - name: CBaseEntity_ScriptSetEntityName
+    alias:
+    - CBaseEntity::ScriptSetEntityName
+  - name: CBaseEntity_ScriptGetMass
+    alias:
+    - CBaseEntity::ScriptGetMass
+  - name: CBaseEntity_ScriptSetMass
+    alias:
+    - CBaseEntity::ScriptSetMass
+  - name: CBaseEntity_ScriptGetSpawnGroupHandle
+    alias:
+    - CBaseEntity::ScriptGetSpawnGroupHandle
+  - name: CBaseEntity_GetAbsAngles
+    alias:
+    - CBaseEntity::GetAbsAngles
+  - name: CBaseEntity_Script_GetTeamNumber
+    alias:
+    - CBaseEntity::Script_GetTeamNumber
+  - name: CBaseEntity_Script_FollowEntity
+    alias:
+    - CBaseEntity::Script_FollowEntity
+  - name: CBaseEntity_Script_FollowEntityMerge
+    alias:
+    - CBaseEntity::Script_FollowEntityMerge
+  - name: CBaseEntity_Script_Trigger
+    alias:
+    - CBaseEntity::Script_Trigger
+  - name: CBaseEntity_Script_SetContextThink
+    alias:
+    - CBaseEntity::Script_SetContextThink
+  - name: CBaseEntity_AddContextForScript
+    alias:
+    - CBaseEntity::AddContextForScript
+  - name: CBaseEntity_AddContextForScriptNumeric
+    alias:
+    - CBaseEntity::AddContextForScriptNumeric
+  - name: CBaseEntity_GetContextForScript
+    alias:
+    - CBaseEntity::GetContextForScript
+  - name: CBaseEntity_ScriptGatherCriteria
+    alias:
+    - CBaseEntity::ScriptGatherCriteria
+  - name: CBaseEntity_Script_TakeDamage
+    alias:
+    - CBaseEntity::Script_TakeDamage
+  - name: CBaseEntity_SetGravityScale
+    alias:
+    - CBaseEntity::SetGravityScale
+  - name: CBaseEntity_SetAbsVelocity
+    alias:
+    - CBaseEntity::SetAbsVelocity
+  - name: CBaseEntity_GetAbsVelocity
+    alias:
+    - CBaseEntity::GetAbsVelocity
+  - name: CBaseEntity_Script_ApplyLocalAngularVelocityImpulse
+    alias:
+    - CBaseEntity::Script_ApplyLocalAngularVelocityImpulse
+  - name: CBaseEntity_GetLocalAngularVelocity_OBSOLETE
+    alias:
+    - CBaseEntity::GetLocalAngularVelocity_OBSOLETE
+  - name: CBaseEntity_ScriptEmitSoundParams
+    alias:
+    - CBaseEntity::ScriptEmitSoundParams
+    - CBaseEntity::EmitSoundParams
+    - CBaseEntity_EmitSoundParams
+  - name: CBaseEntity_ScriptStopSound
+    alias:
+    - CBaseEntity::ScriptStopSound
+  - name: CBaseEntity_ScriptSoundDuration
+    alias:
+    - CBaseEntity::ScriptSoundDuration
+  - name: CBaseEntity_ScriptGetAbsOrigin
+    alias:
+    - CBaseEntity::ScriptGetAbsOrigin
+  - name: CBaseEntity_Precache
+    alias:
+    - CBaseEntity::Precache
+    - Precache
+  - name: CEnvEntityIgniter_Precache
+    alias:
+    - CEnvEntityIgniter::Precache
+  - name: CEnvShake_Spawn
+    alias:
+    - CEnvShake::Spawn
+  - name: CBaseEntity_SetMoveType
+    alias:
+    - CBaseEntity::SetMoveType
+  - name: CBasePlayerPawn_CommitSuicide
+    alias:
+    - CBasePlayerPawn::CommitSuicide
+    - CommitSuicide
+  - name: CBaseCombatCharacter_OnKilled
+    alias:
+    - CBaseCombatCharacter::OnKilled
+  - name: CCSPlayerPawn_Event_KilledOther
+    alias:
+    - CCSPlayerPawn::Event_KilledOther
+  - name: CCSPlayerPawn_Event_Killed
+    alias:
+    - CCSPlayerPawn::Event_Killed
+  - name: CBasePlayerPawn_Event_Killed
+    alias:
+    - CBasePlayerPawn::Event_Killed
+  - name: ScriptBinding_CSPlayerPawn_DestroyWeapon
+    alias:
+    - CSPlayerPawn::DestroyWeapon
+  - name: CBasePlayerPawn_RemovePlayerItem
+    alias:
+    - CBasePlayerPawn::RemovePlayerItem
+  - name: CBasePlayerPawn_DropActivePlayerWeapon
+    alias:
+    - CBasePlayerPawn::DropActivePlayerWeapon
+  - name: CBasePlayerPawn_GetEyePosition
+    alias:
+    - CBasePlayerPawn::GetEyePosition
+  - name: CBaseEntity_GetEyePosition
+    alias:
+    - CBaseEntity::GetEyePosition
+  - name: CCSBotManager_BotPlaceCommand
+    alias:
+    - CCSBotManager::BotPlace
+  - name: CBasePlayerPawn_EyeVectors
+    alias:
+    - CBasePlayerPawn::EyeVectors
+  - name: CBasePlayerPawn_GetEyeAngles
+    alias:
+    - CBasePlayerPawn::GetEyeAngles
+  - name: CBaseEntity_GetEyeAngles
+    alias:
+    - CBaseEntity::GetEyeAngles
+  - name: CCSBot_Upkeep
+    alias:
+    - CCSBot::Upkeep
+  - name: CCSBot_SetState
+    alias:
+    - CCSBot::SetState
+  - name: CCSBot_UpdatePathMovement
+    alias:
+    - CCSBot::UpdatePathMovement
+  - name: CCSBot_PrintIfWatched
+    alias:
+    - CCSBot::PrintIfWatched
+  - name: HideState_OnUpdate
+    alias:
+    - HideState::OnUpdate
+  - name: CCSBot_Attack
+    alias:
+    - CCSBot::Attack
+  - name: CCSBot_MoveTo
+    alias:
+    - CCSBot::MoveTo
+  - name: CCSBot_InhibitLookAround
+    alias:
+    - CCSBot::InhibitLookAround
+  - name: CCSBot_SetDisposition
+    alias:
+    - CCSBot::SetDisposition
+  - name: CCSBot_Idle
+    alias:
+    - CCSBot::Idle
+  - name: CCSBot_ComputePath
+    alias:
+    - CCSBot::ComputePath
+  - name: CBaseEntity_IsAlive
+    alias:
+    - CBaseEntity::IsAlive
+  - name: CBaseEntity_SetOwner
+    alias:
+    - CBaseEntity::SetOwner
+  - name: CBaseEntity_CollisionRulesChanged
+    alias:
+    - CBaseEntity::CollisionRulesChanged
+    - CollisionRulesChanged
+  - name: CBaseEntity_Use
+    alias:
+    - CBaseEntity::Use
+  - name: CGameSceneNode_PostSpawnKeyValues
+    alias:
+    - CGameSceneNode::PostSpawnKeyValues
+  - name: CBaseEntity_Spawn
+    alias:
+    - CBaseEntity::Spawn
+    - Spawn
+  - name: CBaseEntity_SpawnRadius
+    alias:
+    - CBaseEntity::SpawnRadius
+  - name: CCSPlayer_ItemServices_DropActivePlayerWeapon
+    alias:
+    - CCSPlayer_ItemServices::DropActivePlayerWeapon
+  - name: CCSPlayer_WeaponServices_DropWeapon
+    alias:
+    - CCSPlayer_WeaponServices::DropWeapon
+  - name: CCSPlayer_ItemServices_RemoveWeapons
+    alias:
+    - CCSPlayer_ItemServices::RemoveWeapons
+  - name: CCSPlayer_WeaponServices_SelectItem
+    alias:
+    - CCSPlayer_WeaponServices::SelectItem
+  - name: CEntFireOutputAutoCompletionFunctor_FireOutput
+    alias:
+    - CEntFireOutputAutoCompletionFunctor::FireOutput
+  - name: CEntityInstance_FindOutputsByName
+    alias:
+    - CEntityInstance::FindOutputsByName
+  - name: CEntityInstance_ScriptEntityIO
+    alias:
+    - CEntityInstance::ScriptEntityIO
+  - name: CEntityIOOutput_FireOutputInternal
+    alias:
+    - CEntityIOOutput::FireOutputInternal
+  - name: CEntitySystem_AddEntityIOEvent
+    alias:
+    - CEntitySystem::AddEntityIOEvent
+  - name: CEntitySystem_AddEntityIOEvent2
+    alias:
+    - CEntitySystem::AddEntityIOEvent2
+  - name: CEntitySystem_AddEntityIOEventBuildStruct
+    alias:
+    - CEntitySystem::AddEntityIOEventBuildStruct
+  - name: CEntitySystem_AddEntityIOEventToQueue
+    alias:
+    - CEntitySystem::AddEntityIOEventToQueue
+  - name: CEntitySystem_m_EventQueue
+    alias:
+    - CEntitySystem::m_EventQueue
+  - name: CGameEntitySystem_FindEntityByClassName
+    alias:
+    - CGameEntitySystem::FindEntityByClassName
+  - name: CGameEntitySystem_FindEntityByName
+    alias:
+    - CGameEntitySystem::FindEntityByName
+  - name: CGameEntitySystem_OnAddEntity
+    alias:
+    - CGameEntitySystem::OnAddEntity
+  - name: CGameEntitySystem_BuildResourceManifest_ManifestNameOrGroupName
+    alias:
+    - CGameEntitySystem::BuildResourceManifest_ManifestNameOrGroupName
+  - name: CGameEntitySystem_BuildResourceManifest_KeyValuesVectors
+    alias:
+    - CGameEntitySystem::BuildResourceManifest_KeyValuesVectors
+  - name: CGameEntitySystem_FindEntityProcedural
+    alias:
+    - CGameEntitySystem::FindEntityProcedural
+  - name: CGameEntitySystem_Spawn
+    alias:
+    - CGameEntitySystem::Spawn
+  - name: CEntitySystem_Spawn
+    alias:
+    - CEntitySystem::Spawn
+  - name: CBodyGameSystem_SpawnDependencyIsland
+    alias:
+    - CBodyGameSystem::SpawnDependencyIsland
+  - name: CGameEntitySystem_CheckGlobalState
+    alias:
+    - CGameEntitySystem::CheckGlobalState
+  - name: IGameSystem_OnBuildGameSessionManifest
+    alias:
+    - IGameSystem::BuildGameSessionManifest
+  - name: IGameSystem_OnServerPreEntityThink
+    alias:
+    - IGameSystem::OnServerPreEntityThink
+  - name: IGameSystem_OnServerPostEntityThink
+    alias:
+    - IGameSystem::OnServerPostEntityThink
+  - name: IGameSystem_OnServerPreClientUpdate
+    alias:
+    - IGameSystem::ServerPreClientUpdate
+  - name: IGameSystem_OnServerAdvanceTick
+    alias:
+    - IGameSystem::ServerAdvanceTick
+  - name: IGameSystem_OnServerGamePostSimulate
+    alias:
+    - IGameSystem::ServerGamePostSimulate
+  - name: IGameSystem_OnServerPostAdvanceTick
+    alias:
+    - IGameSystem::ServerPostAdvanceTick
+  - name: IGameSystem_OnServerPreBeginAsyncPostTickWork
+    alias:
+    - IGameSystem::OnServerPreBeginAsyncPostTickWork
+  - name: IGameSystem_OnServerBeginAsyncPostTickWork
+    alias:
+    - IGameSystem::OnServerBeginAsyncPostTickWork
+  - name: IGameSystem_OnServerPreEndAsyncPostTickWork
+    alias:
+    - IGameSystem::OnServerPreEndAsyncPostTickWork
+  - name: IGameSystem_OnServerPostEndAsyncPostTickWork
+    alias:
+    - IGameSystem::OnServerPostEndAsyncPostTickWork
+  - name: IGameSystem_OnSaveGame
+    alias:
+    - IGameSystem::OnSaveGame
+  - name: IGameSystem_OnRestoreGame
+    alias:
+    - IGameSystem::OnRestoreGame
+  - name: IGameSystem_OnOutOfGameFrameBoundary
+    alias:
+    - IGameSystem::OnOutOfGameFrameBoundary
+  - name: CSource2GameClients_StartHLTVServer
+    alias:
+    - CSource2GameClients::StartHLTVServer
+  - name: LegacyGameEventListener
+    alias:
+    - GetLegacyGameEventListener
+  - name: CPhysicsGameSystem_ProcessContactEvents
+    alias:
+    - CPhysicsGameSystem::ProcessContactEvents
+  - name: CBaseEntity_PhysicsDispatchStartTouch
+    alias:
+    - CBaseEntity::PhysicsDispatchStartTouch
+  - name: CBaseEntity_PhysicsNotifyOtherOfEndTouch
+    alias:
+    - CBaseEntity::PhysicsNotifyOtherOfEndTouch
+  - name: CBaseEntity_PhysicsDispatchTouch
+    alias:
+    - CBaseEntity::PhysicsDispatchTouch
+  - name: CBaseEntity_StartTouch
+    alias:
+    - CBaseEntity::StartTouch
+    - StartTouch
+  - name: CBaseEntity_Touch
+    alias:
+    - CBaseEntity::Touch
+    - Touch
+  - name: CBaseEntity_EndTouch
+    alias:
+    - CBaseEntity::EndTouch
+    - EndTouch
+  - name: IVPhys2World_GetTouchingList
+    alias:
+    - IVPhys2World::GetTouchingList
+    - CVPhys2World::GetTouchingList
+  - name: CTriggerPush_Touch
+    alias:
+    - CTriggerPush::Touch
+    - TriggerPush_Touch
+  - name: CPhysBox_Use
+    alias:
+    - CPhysBox::Use
+  - name: CBaseEntity_SetGroundEntity
+    alias:
+    - SetGroundEntity
+  - name: CBaseEntity_GetHammerUniqueId
+    alias:
+    - CBaseEntity::GetHammerUniqueId
+    - GetHammerUniqueId
+  - name: CBaseEntity_IsPlayerPawn
+    alias:
+    - CBaseEntity::IsPlayerPawn
+    - IsEntityPawn
+    - IsPlayerPawn
+  - name: CBaseEntity_IsPlayerController
+    alias:
+    - CBaseEntity::IsPlayerController
+    - IsEntityController
+    - IsPlayerController
+  - name: CBaseTrigger_StartTouch
+    alias:
+    - CBaseTrigger::StartTouch
+  - name: CBaseTrigger_EndTouch
+    alias:
+    - CBaseTrigger::EndTouch
+  - name: CBaseTrigger_PassesTriggerFilters
+    alias:
+    - CBaseTrigger::PassesTriggerFilters
+    - PassesTriggerFilters
+  - name: CBaseAnimGraph_GetAnimationController
+    alias:
+    - CBaseAnimGraph::GetAnimationController
+  - name: CBaseAnimGraph_m_skeletonInstance
+    alias:
+    - CBaseAnimGraph::m_skeletonInstance
+  - name: CGameSceneNode_PreInstanceSpawn
+    alias:
+    - CGameSceneNode::PreInstanceSpawn
+  - name: CGameSceneNode_GetSkeletonInstance
+    alias:
+    - CGameSceneNode::GetSkeletonInstance
+  - name: CSkeletonInstance_m_animationController
+    alias:
+    - CSkeletonInstance::m_animationController
+  - name: CSkeletonInstance_PostDataUpdate
+    alias:
+    - CSkeletonInstance::PostDataUpdate
+  - name: CGameSceneNode_PostDataUpdate
+    alias:
+    - CGameSceneNode::PostDataUpdate
+  - name: CGameSceneNode_UpdateEntityForHierarchyChange
+    alias:
+    - CGameSceneNode::UpdateEntityForHierarchyChange
+  - name: CPointTeleportAPI_TeleportEntityInternal
+    alias:
+    - CPointTeleportAPI::TeleportEntityInternal
+  - name: CBaseEntity_Teleport
+    alias:
+    - CBaseEntity::Teleport
+  - name: CPointTeleport_Activate
+    alias:
+    - CPointTeleport::Activate
+  - name: CBaseEntity_Activate
+    alias:
+    - CBaseEntity::Activate
+    - Activate
+  - name: CBaseEntity_DrawDebugTextOverlays
+    alias:
+    - CBaseEntity::DrawDebugTextOverlays
+  - name: CRagdollProp_DrawEntityDebugOverlays
+    alias:
+    - CRagdollProp::DrawEntityDebugOverlays
+  - name: CBaseEntity_ReloadPrivateScripts
+    alias:
+    - CBaseEntity::ReloadPrivateScripts
+  - name: CCheckTransmitInfo_m_nPlayerSlot
+    alias:
+    - CCheckTransmitInfo::m_nPlayerSlot
+    - CheckTransmitPlayerSlot
+  - name: CDedicatedServerWorkshopManager_SwitchToWorkshopMapGroup
+    alias:
+    - CDedicatedServerWorkshopManager::SwitchToWorkshopMapGroup
+  - name: IGameTypes_CreateWorkshopMapGroup
+    alias:
+    - IGameTypes::CreateWorkshopMapGroup
+  - name: CSpawnGroupMgrGameSystem_GetSpawnGroups
+    alias:
+    - CSpawnGroupMgrGameSystem::GetSpawnGroups
+    - GetSpawnGroups
+  - name: CSpawnGroupMgrGameSystem_DumpSpawnGroups
+    alias:
+    - CSpawnGroupMgrGameSystem::DumpSpawnGroups
+    - DumpSpawnGroups
+  - name: CSpawnGroupMgrGameSystem_SpawnGroupSpawnEntitiesInternal
+    alias:
+    - CSpawnGroupMgrGameSystem::SpawnGroupSpawnEntitiesInternal
+    - SpawnGroupSpawnEntitiesInternal
+  - name: IGameSystem_OnPreSpawnGroupLoad
+    alias:
+    - IGameSystem::OnPreSpawnGroupLoad
+  - name: IGameSystem_OnPostSpawnGroupLoad
+    alias:
+    - IGameSystem::OnPostSpawnGroupLoad
+  - name: CSpawnGroupMgrGameSystem_SpawnGroupShutdown
+    alias:
+    - CSpawnGroupMgrGameSystem::SpawnGroupShutdown
+    - SpawnGroupShutdown
+  - name: CSpawnGroupMgrGameSystem_SpawnGroupActuallyShutdown
+    alias:
+    - CSpawnGroupMgrGameSystem::SpawnGroupActuallyShutdown
+    - SpawnGroupActuallyShutdown
+  - name: IGameSystem_OnPreSpawnGroupUnload
+    alias:
+    - IGameSystem::OnPreSpawnGroupUnload
+  - name: IGameSystem_OnPostSpawnGroupUnload
+    alias:
+    - IGameSystem::OnPostSpawnGroupUnload
+  - name: CLoadingSpawnGroup_CreateEntityToSpawn
+    alias:
+    - CLoadingSpawnGroup::CreateEntityToSpawn
+  - name: CSpawnGroupMgrGameSystem_OnSpawnGroupPrecache
+    alias:
+    - CSpawnGroupMgrGameSystem::OnSpawnGroupPrecache
+    - SpawnGroupPrecache
+  - name: CSpawnGroupMgrGameSystem_AllocateSpawnGroup
+    alias:
+    - CSpawnGroupMgrGameSystem::AllocateSpawnGroup
+  - name: CSpawnGroupMgrGameSystem_ReleaseSpawnGroup
+    alias:
+    - CSpawnGroupMgrGameSystem::ReleaseSpawnGroup
+  - name: CSpawnGroupMgrGameSystem_SpawnGroupInit
+    alias:
+    - CSpawnGroupMgrGameSystem::SpawnGroupInit
+  - name: CSpawnGroupMgrGameSystem_CreateLoadingSpawnGroup
+    alias:
+    - CSpawnGroupMgrGameSystem::CreateLoadingSpawnGroup
+  - name: CSpawnGroupMgrGameSystem_CreateLoadingSpawnGroupForSaveFile
+    alias:
+    - CSpawnGroupMgrGameSystem::CreateLoadingSpawnGroupForSaveFile
+  - name: CSpawnGroupMgrGameSystem_SpawnGroupSpawnEntities
+    alias:
+    - CSpawnGroupMgrGameSystem::SpawnGroupSpawnEntities
+  - name: CSpawnGroupMgrGameSystem_SetActiveSpawnGroup
+    alias:
+    - CSpawnGroupMgrGameSystem::SetActiveSpawnGroup
+  - name: CSpawnGroupMgrGameSystem_UnloadSpawnGroup
+    alias:
+    - CSpawnGroupMgrGameSystem::UnloadSpawnGroup
+  - name: CSpawnGroupMgrGameSystem_SaveGame_Start
+    alias:
+    - CSpawnGroupMgrGameSystem::SaveGame_Start
+  - name: IGameSystem_OnSpawnGroupPrecache
+    alias:
+    - IGameSystem::OnSpawnGroupPrecache
+  - name: IGameSystem_OnSpawnGroupUncache
+    alias:
+    - IGameSystem::OnSpawnGroupUncache
+  - name: CBaseFilter_InputTestActivator
+    alias:
+    - CBaseFilter::InputTestActivator
+  - name: CGamePlayerEquip_InputTriggerForAllPlayers
+    alias:
+    - CGamePlayerEquip::InputTriggerForAllPlayers
+  - name: CGamePlayerEquip_InputTriggerForActivatedPlayer
+    alias:
+    - CGamePlayerEquip::InputTriggerForActivatedPlayer
+  - name: CNavMesh_GetNearestNavArea
+    alias:
+    - CNavMesh::GetNearestNavArea
+  - name: CCSBotManager_AddBot
+    alias:
+    - CCSBotManager::AddBot
+  - name: BotAdd_CommandHandler
+    alias:
+    - CCSBotManager::BotAddCommand
+  - name: BotKill_CommandHandler
+    alias:
+    - CCSBotManager::BotKillCommand
+  - name: EntInfo_CommandHandler
+    alias:
+    - CC_Ent_Info
+  - name: CEntitySystem_DestroyEntityImmediate
+    alias:
+    - CEntitySystem::DestroyEntityImmediate
+  - name: CEntitySystem_OnRemoveEntityFromDatabase
+    alias:
+    - CEntitySystem::OnRemoveEntityFromDatabase
+  - name: CEntitySystem_DoDestructEntity
+    alias:
+    - CEntitySystem::DoDestructEntity
+  - name: CEntitySystem_UpdateOnRemove
+    alias:
+    - CEntitySystem::UpdateOnRemove
+  - name: ClientPrintToController
+    alias:
+    - ClientPrint
+  - name: CCSBotManager_AddBot_BotNavIgnore
+    alias:
+    - BotNavIgnore
+  - name: CEnvHudHint_API_ShowHudHint
+    alias:
+    - CEnvHudHint_API::ShowHudHint
+  - name: UTIL_GetPlayerControllerForEntity
+    alias:
+    - UTIL_GetPlayerControllerForEntity
+  - name: CEntitySystem_ctor
+    alias:
+    - CEntitySystem::CEntitySystem
+  - name: CGameEntitySystem_ctor
+    alias:
+    - CGameEntitySystem::CGameEntitySystem
+  - name: CEntitySystem_RegisterAccessor
+    alias:
+    - CEntitySystem::RegisterAccessor
+  - name: CEntitySystem_Init
+    alias:
+    - CEntitySystem::Init
+  - name: CEntitySystem_ProcessEntityRegistration
+    alias:
+    - CEntitySystem::ProcessEntityRegistration
+  - name: CEntitySystem_PostCreateEntitySystem
+    alias:
+    - CEntitySystem::PostCreateEntitySystem
+  - name: CSource2EntitySystem_StaticInit
+    alias:
+    - CSource2EntitySystem::StaticInit
+  - name: CSpawnGroupEntityFilterRegistrar_RegisterSpawnGroupEntityFilters
+    alias:
+    - CSpawnGroupEntityFilterRegistrar::RegisterSpawnGroupEntityFilters
+  - name: CGameEntitySystem_m_spawnGroupEntityFilters
+    alias:
+    - CGameEntitySystem::m_spawnGroupEntityFilters
+  - name: CGameEntitySystem_m_pEntity2Networkables
+    alias:
+    - CGameEntitySystem::m_pEntity2Networkables
+  - name: CEntity2NetworkClasses_ServerClass_InitEntity2NetworkClasses
+    alias:
+    - CEntity2NetworkClasses<ServerClass>::InitEntity2NetworkClasses
+  - name: CEntitySystem_m_Symbols
+    alias:
+    - CEntitySystem::m_Symbols
+  - name: CEntitySystem_m_pNetworkFieldChangedEventQueue
+    alias:
+    - CEntitySystem::m_pNetworkFieldChangedEventQueue
+  - name: CEntitySystem_m_pNetworkFieldScratchData
+    alias:
+    - CEntitySystem::m_pNetworkFieldScratchData
+  - name: CEntitySystem_m_pFieldChangeLimitSpew
+    alias:
+    - CEntitySystem::m_pFieldChangeLimitSpew
+  - name: CEntitySystem_m_ComponentUnserializerInfoAllocator
+    alias:
+    - CEntitySystem::m_ComponentUnserializerInfoAllocator
+  - name: CEntitySystem_m_EntityMaterialAttributes
+    alias:
+    - CEntitySystem::m_EntityMaterialAttributes
+  - name: CEntitySystem_m_flChangeCallbackSpewThreshold
+    alias:
+    - CEntitySystem::m_flChangeCallbackSpewThreshold
+  - name: CEntitySystem_ClearEntityDatabase
+    alias:
+    - CEntitySystem::ClearEntityDatabase
+  - name: INetworkMessages_SetNetworkSerializationContextData
+    alias:
+    - INetworkMessages::SetNetworkSerializationContextData
+  - name: CFlattenedSerializers_CreateFieldChangedEventQueue
+    alias:
+    - CFlattenedSerializers::CreateFieldChangedEventQueue
+  - name: INetworkMessages_RegisterSchemaTypeOverride
+    alias:
+    - INetworkMessages::RegisterSchemaTypeOverride
+  - name: PolymorphicHelper_t__SetPolymorphicPointer
+    alias:
+    - PolymorphicHelper_t::SetPolymorphicPointer
+  - name: CSceneEntity_GetScriptDesc
+    alias:
+    - CSceneEntity::GetScriptDesc
+  - name: CEntityInstance_GetScriptDesc
+    alias:
+    - CEntityInstance::GetScriptDesc
+  - name: CEntityInstance_Spawn
+    alias:
+    - CEntityInstance::Spawn
+  - name: CEntityInstance_Activate
+    alias:
+    - CEntityInstance::Activate
+  - name: CEntityInstance_Precache
+    alias:
+    - CEntityInstance::Precache
+  - name: CEntityInstance_GetDataDescMap
+    alias:
+    - CEntityInstance::GetDataDescMap
+  - name: CEntityInstance_ReloadPrivateScripts
+    alias:
+    - CEntityInstance::ReloadPrivateScripts
+  - name: CEntityInstance_ValidatePrivateScriptScope
+    alias:
+    - CEntityInstance::ValidatePrivateScriptScope
+  - name: CEntityInstance_NetworkStateChanged
+    alias:
+    - CEntityInstance::NetworkStateChanged
+  - name: CEntityInstance_FullEdictChanged
+    alias:
+    - CEntityInstance::FullEdictChanged
+  - name: CEntityInstance_NetworkUpdateState
+    alias:
+    - CEntityInstance::NetworkUpdateState
+  - name: CEntityInstance_NetworkStateChangedLog
+    alias:
+    - CEntityInstance::NetworkStateChangedLog
+  - name: CEntityInstance_DrawDebugTextOverlays
+    alias:
+    - CEntityInstance::DrawDebugTextOverlays
+  - name: CEntityInstance_DrawEntityDebugOverlays
+    alias:
+    - CEntityInstance::DrawEntityDebugOverlays
+  - name: CEntityInstance_PostDataUpdateDelta
+    alias:
+    - CEntityInstance::PostDataUpdateDelta
+  - name: CEntityInstance_PreDataUpdate
+    alias:
+    - CEntityInstance::PreDataUpdate
+  - name: CEntityInstance_PostDataUpdate
+    alias:
+    - CEntityInstance::PostDataUpdate
+  - name: CEntityInstance_PostDataUpdatePreserve
+    alias:
+    - CEntityInstance::PostDataUpdatePreserve
+  - name: CEntityInstance_Connect
+    alias:
+    - CEntityInstance::Connect
+  - name: CEntityInstance_UpdateOnRemove
+    alias:
+    - CEntityInstance::UpdateOnRemove
+  - name: CEntityInstance_Disconnect
+    alias:
+    - CEntityInstance::Disconnect
+  - name: CEntityInstance_AddedToEntityDatabase
+    alias:
+    - CEntityInstance::AddedToEntityDatabase
+  - name: CEntityInstance_OnSetDormant
+    alias:
+    - CEntityInstance::OnSetDormant
+  - name: CEntityInstance_Schema_DynamicBinding
+    alias:
+    - CEntityInstance::Schema_DynamicBinding
+  - name: CEntitySystem_OnRemoveEntity
+    alias:
+    - CEntitySystem::OnRemoveEntity
+  - name: CEntityComponentHelperT_Free
+    alias:
+    - CEntityComponentHelperT::Free
+  - name: CScriptedSequence_SynchronizeSequence
+    alias:
+    - CScriptedSequence::SynchronizeSequence
+  - name: CNetworkUtlVectorEmbedded_NetworkStateChanged_m_vecRenderAttributes
+    alias:
+    - CNetworkUtlVectorEmbedded<CRenderAttribute>::NetworkStateChanged_m_vecRenderAttributes
+  - name: CNetworkUtlVectorEmbedded_NetworkStateChanged_m_perRoundStats
+    alias:
+    - CNetworkUtlVectorEmbedded<CSPerRoundStats_t>::NetworkStateChanged_m_perRoundStats
+  - name: CUtlVectorEmbeddedNetworkVar_CSPerRoundStats_t_NetworkVar_m_perRoundStats_SetCount
+    alias:
+    - CUtlVectorEmbeddedNetworkVar<CSPerRoundStats_t, NetworkVar>::SetCount
+  - name: CNetworkUtlVectorEmbedded_TryLateResolve_m_vecRenderAttributes
+    alias:
+    - CNetworkUtlVectorEmbedded<CRenderAttribute>::TryLateResolve
+  - name: INetworkMessages_GetLoggingChannel
+    alias:
+    - INetworkMessages::GetLoggingChannel
+  - name: CPhysicsEntitySolver_PhysEnableEntityCollisions
+    alias:
+    - CPhysicsEntitySolver::PhysEnableEntityCollisions
+  - name: CLoopModeGame_StaticInit
+    alias:
+    - CLoopModeGame::StaticInit
+  - name: CLoopModeFactory_CLoopModeGame_Init
+    alias:
+    - CLoopModeFactory<CLoopModeGame>::Init
+  - name: CLoopModeFactory_CLoopModeGame_Shutdown
+    alias:
+    - CLoopModeFactory<CLoopModeGame>::Shutdown
+  - name: CLoopModeGame_OnLoopActivate
+    alias:
+    - CLoopModeGame::OnLoopActivate
+  - name: ILoopMode_OnLoopActivate
+    alias:
+    - ILoopMode::OnLoopActivate
+  - name: CLoopModeGame_AddViewsToSceneSystem
+    alias:
+    - CLoopModeGame::AddViewsToSceneSystem
+  - name: ILoopMode_AddViewsToSceneSystem
+    alias:
+    - ILoopMode::AddViewsToSceneSystem
+  - name: CLoopModeGame_LoopInitInternal
+    alias:
+    - CLoopModeGame::LoopInitInternal
+  - name: CLoopModeGame_LoopInit
+    alias:
+    - CLoopModeGame::LoopInit
+  - name: ILoopMode_LoopInit
+    alias:
+    - ILoopMode::LoopInit
+  - name: ILoopMode_LoopShutdown
+    alias:
+    - ILoopMode::LoopShutdown
+  - name: CLoopModeGame_RegisterEventMapInternal
+    alias:
+    - CLoopModeGame::RegisterEventMapInternal
+  - name: CLoopModeGame_OnServerAdvanceTick
+    alias:
+    - CLoopModeGame::OnServerAdvanceTick
+  - name: CLoopModeGame_OnServerBeginSimulate
+    alias:
+    - CLoopModeGame::OnServerBeginSimulate
+  - name: CLoopModeGame_OnServerPostSimulate
+    alias:
+    - CLoopModeGame::OnServerPostSimulate
+  - name: CLoopModeGame_OnServerPostAdvanceTick
+    alias:
+    - CLoopModeGame::OnServerPostAdvanceTick
+  - name: CLoopModeGame_OnServerBeginAsyncPostTickWork
+    alias:
+    - CLoopModeGame::OnServerBeginAsyncPostTickWork
+  - name: CLoopModeGame_OnServerEndAsyncPostTickWork
+    alias:
+    - CLoopModeGame::OnServerEndAsyncPostTickWork
+  - name: CLoopModeGame_OnFrameBoundary
+    alias:
+    - CLoopModeGame::OnFrameBoundary
+  - name: CLoopModeGame_ReceivedServerInfo
+    alias:
+    - CLoopModeGame::ReceivedServerInfo
+  - name: CLoopModeGame_SetWorldSession
+    alias:
+    - CLoopModeGame::SetWorldSession
+  - name: CLoopModeGame_SetGameSystemState
+    alias:
+    - CLoopModeGame::SetGameSystemState
+  - name: IGameSystem_DestroyAllGameSystems
+    alias:
+    - IGameSystem::DestroyAllGameSystems
+  - name: IGameSystem_ShutdownAllSystems
+    alias:
+    - IGameSystem::ShutdownAllSystems
+  - name: IGameSystem_LoopDestroyAllSystems
+    alias:
+    - IGameSystem::LoopDestroyAllSystems
+  - name: IGameSystem_LoopPreShutdownAllSystems
+    alias:
+    - IGameSystem::LoopPreShutdownAllSystems
+  - name: CLoopModeGame_Shutdown
+    alias:
+    - CLoopModeGame::Shutdown
+  - name: CLoopModeGame_LoopShutdown
+    alias:
+    - CLoopModeGame::LoopShutdown
+  - name: CLoopModeGame_ShutdownServer
+    alias:
+    - CLoopModeGame::ShutdownServer
+  - name: CLoopModeGame_OnLoopDeactivate
+    alias:
+    - CLoopModeGame::OnLoopDeactivate
+  - name: ILoopMode_OnLoopDeactivate
+    alias:
+    - ILoopMode::OnLoopDeactivate
+  - name: CPlayerCommandQueue_ctor
+    alias:
+    - CPlayerCommandQueue::CPlayerCommandQueue
+  - name: IGameResourceService_SetEntityResourceManifestHandler
+    alias:
+    - IGameResourceService::SetEntityResourceManifestHandler
+  - name: CNetworkSerializerBindingBuildFilter_GetFieldPriority
+    alias:
+    - CNetworkSerializerBindingBuildFilter::GetFieldPriority
+  - name: CEntitySystem_FindComponentTypeByName
+    alias:
+    - CEntitySystem::FindComponentTypeByName
+- name: networksystem
+  symbols:
+  - name: INetworkMessages_GetFieldChangeCallbackOrderCount
+    alias:
+    - INetworkMessages::GetFieldChangeCallbackOrderCount
+  - name: INetworkMessages_GetFieldChangeCallbackPriorities
+    alias:
+    - INetworkMessages::GetFieldChangeCallbackPriorities

--- a/gamesymbols/14168b.metadata.yaml
+++ b/gamesymbols/14168b.metadata.yaml
@@ -1,0 +1,2879 @@
+modules:
+- name: networksystem
+  symbols:
+  - name: CNetworkMessages_RegisterNetworkCategory
+    alias:
+    - CNetworkMessages::RegisterNetworkCategory
+  - name: CNetworkMessages_AssociateNetMessageWithChannelCategoryAbstract
+    alias:
+    - CNetworkMessages::AssociateNetMessageWithChannelCategoryAbstract
+  - name: CNetworkMessages_FindOrCreateNetMessage
+    alias:
+    - CNetworkMessages::FindOrCreateNetMessage
+  - name: CNetworkMessages_SerializeInternal
+    alias:
+    - CNetworkMessages::SerializeInternal
+  - name: CNetworkMessages_UnserializeMessageInternal
+    alias:
+    - CNetworkMessages::UnserializeMessageInternal
+  - name: CNetworkMessages_SerializeMessageInternal
+    alias:
+    - CNetworkMessages::SerializeMessageInternal
+  - name: CNetworkMessages_UnserializeFromStream
+    alias:
+    - CNetworkMessages::UnserializeFromStream
+  - name: CNetworkMessages_AllocateAndCopyConstructNetMessageAbstract
+    alias:
+    - CNetworkMessages::AllocateAndCopyConstructNetMessageAbstract
+  - name: CNetworkMessages_DeallocateNetMessageAbstract
+    alias:
+    - CNetworkMessages::DeallocateNetMessageAbstract
+  - name: CNetworkMessages_RegisterNetworkFieldSerializer
+    alias:
+    - CNetworkMessages::RegisterNetworkFieldSerializer
+  - name: CNetworkMessages_RegisterNetworkArrayFieldSerializer
+    alias:
+    - CNetworkMessages::RegisterNetworkArrayFieldSerializer
+  - name: CNetworkMessages_AssociateNetMessageGroupIdWithChannelCategory
+    alias:
+    - CNetworkMessages::AssociateNetMessageGroupIdWithChannelCategory
+  - name: CNetworkMessages_RegisterNetworkFieldChangeCallbackInternal
+    alias:
+    - CNetworkMessages::RegisterNetworkFieldChangeCallbackInternal
+  - name: CNetworkMessages_AllowAdditionalMessageRegistration
+    alias:
+    - CNetworkMessages::AllowAdditionalMessageRegistration
+  - name: CNetworkMessages_IsAdditionalMessageRegistrationAllowed
+    alias:
+    - CNetworkMessages::IsAdditionalMessageRegistrationAllowed
+  - name: CNetworkMessages_RegisterFieldChangeCallbackPriority
+    alias:
+    - CNetworkMessages::RegisterFieldChangeCallbackPriority
+  - name: CNetworkMessages_ComputeOrderForPriority
+    alias:
+    - CNetworkMessages::ComputeOrderForPriority
+  - name: CNetworkMessages_dtor
+    alias:
+    - CNetworkMessages::~CNetworkMessages
+  - name: CNetworkMessages_GetIsForServer
+    alias:
+    - CNetworkMessages::GetIsForServer
+  - name: CNetworkMessages_GetNetworkSerializationContextData
+    alias:
+    - CNetworkMessages::GetNetworkSerializationContextData
+  - name: CNetChan_ParseMessagesDemoInternal
+    alias:
+    - CNetChan::ParseMessagesDemoInternal
+  - name: CNetChan_ParseNetMessageShowFilter
+    alias:
+    - CNetChan::ParseNetMessageShowFilter
+  - name: CNetworkMessages_FindNetworkMessagePartial
+    alias:
+    - CNetworkMessages::FindNetworkMessagePartial
+  - name: CNetworkMessages_FindNetworkMessage
+    alias:
+    - CNetworkMessages::FindNetworkMessage
+  - name: CNetworkMessages_FindNetworkGroup
+    alias:
+    - CNetworkMessages::FindNetworkGroup
+  - name: CNetworkSystem_SendNetworkStats
+    alias:
+    - CNetworkSystem::SendNetworkStats
+  - name: CNetworkMessages_GetNetworkGroupCount
+    alias:
+    - CNetworkMessages::GetNetworkGroupCount
+  - name: CNetworkMessages_GetNetworkGroupName
+    alias:
+    - CNetworkMessages::GetNetworkGroupName
+  - name: CNetworkMessages_GetNetworkGroupColor
+    alias:
+    - CNetworkMessages::GetNetworkGroupColor
+  - name: CNetworkMessages_ConfirmAllMessageHandlersInstalled
+    alias:
+    - CNetworkMessages::ConfirmAllMessageHandlersInstalled
+- name: engine
+  symbols:
+  - name: CServerSideClient_IsHearingClient
+    alias:
+    - IsHearingClient
+  - name: CGameResourceService_BuildResourceManifest
+    alias:
+    - CGameResourceService::BuildResourceManifest
+    - BuildResourceManifest
+  - name: CGameResourceService_m_pEntitySystem
+    alias:
+    - GameEntitySystem
+  - name: CGameResourceService_LoadGameResourceManifestNamed
+    alias:
+    - CGameResourceService::LoadGameResourceManifestNamed
+  - name: CGameResourceService_LoadGameResourceManifestGroup
+    alias:
+    - CGameResourceService::LoadGameResourceManifestGroup
+  - name: CGameResourceService_GetResourceManifestDebugName
+    alias:
+    - CGameResourceService::GetResourceManifestDebugName
+  - name: CGameResourceService_PrecacheEntitiesAndConfirmResourcesAreLoaded
+    alias:
+    - CGameResourceService::PrecacheEntitiesAndConfirmResourcesAreLoaded
+  - name: CGameResourceService_LoadGameResourceManifest_IEntityResourceManifest
+    alias:
+    - CGameResourceService::LoadGameResourceManifest
+  - name: CGameResourceService_DescribeContents
+    alias:
+    - CGameResourceService::DescribeContents
+  - name: CGameResourceService_AppendToGameResourceManifest
+    alias:
+    - CGameResourceService::AppendToGameResourceManifest
+  - name: CGameResourceService_RegisterEventMap
+    alias:
+    - CGameResourceService::RegisterEventMap
+  - name: IEntityResourceManifestBuilder_BuildResourceManifest_ManifestNameOrGroupName
+    alias:
+    - IEntityResourceManifestBuilder::BuildResourceManifest
+  - name: CServerSideClientBase_ClientPrintf
+    alias:
+    - CServerSideClientBase::ClientPrintf
+    - ClientPrintf
+  - name: CNetworkGameServer_ClientList
+    alias:
+    - CNetworkGameServer::ClientList
+  - name: CNetworkGameServerBase_SendPeerList
+    alias:
+    - CNetworkGameServerBase::SendPeerList
+  - name: CNetworkGameServerBase_ConnectClient
+    alias:
+    - CNetworkGameServerBase::ConnectClient
+  - name: CNetworkGameServerBase_ServerSimulateInternal
+    alias:
+    - CNetworkGameServerBase::ServerSimulateInternal
+  - name: CNetworkGameServerBase_ServerSimulate
+    alias:
+    - CNetworkGameServerBase::ServerSimulate
+  - name: CNetworkGameServerBase_ServerPollNetworking
+    alias:
+    - CNetworkGameServerBase::ServerPollNetworking
+  - name: CNetworkGameServerBase_BroadcastMessage
+    alias:
+    - CNetworkGameServerBase::BroadcastMessage
+  - name: CNetworkGameServerBase_BroadcastPrintf
+    alias:
+    - CNetworkGameServerBase::BroadcastPrintf
+  - name: CNetworkGameServerBase_ReserveServerForQueuedGame
+    alias:
+    - CNetworkGameServerBase::ReserveServerForQueuedGame
+  - name: CNetworkGameServerBase_FinishChangeLevel
+    alias:
+    - CNetworkGameServerBase::FinishChangeLevel
+  - name: CNetworkGameServerBase_StartChangeLevel
+    alias:
+    - CNetworkGameServerBase::StartChangeLevel
+  - name: CNetworkGameServerBase_SetServerState
+    alias:
+    - CNetworkGameServerBase::SetServerState
+  - name: CNetworkGameServer_GetFreeClient
+    alias:
+    - CNetworkGameServer::GetFreeClient
+    - GetFreeClient
+  - name: CNetworkGameServerBase_CreateFakeClient
+    alias:
+    - CNetworkGameServerBase::CreateFakeClient
+  - name: CNetworkGameServerBase_UserInfoChanged
+    alias:
+    - CNetworkGameServerBase::UserInfoChanged
+  - name: CNetworkGameServerBase_GetPlayerNetworkIDString
+    alias:
+    - CNetworkGameServerBase::GetPlayerNetworkIDString
+  - name: CNetworkGameServerBase_StartHLTVMaster
+    alias:
+    - CNetworkGameServerBase::StartHLTVMaster
+  - name: CNetworkGameServerBase_RegisterLoadingSpawnGroups
+    alias:
+    - CNetworkGameServerBase::RegisterLoadingSpawnGroups
+  - name: CNetworkServerSpawnGroupCreatePrerequisites_Init
+    alias:
+    - CNetworkServerSpawnGroupCreatePrerequisites::Init
+  - name: CNetworkGameServerBase_LoadSpawnGroup
+    alias:
+    - CNetworkGameServerBase::LoadSpawnGroup
+  - name: CNetworkGameServerBase_SpawnGroupThink
+    alias:
+    - CNetworkGameServerBase::SpawnGroupThink
+  - name: CNetworkGameServerBase_PrintSpawnGroupStatus
+    alias:
+    - CNetworkGameServerBase::PrintSpawnGroupStatus
+  - name: CNetworkGameServerBase_AsyncUnloadSpawnGroup
+    alias:
+    - CNetworkGameServerBase::AsyncUnloadSpawnGroup
+  - name: CNetworkGameServerBase_AsyncUnloadSpawnGroupInternal
+    alias:
+    - CNetworkGameServerBase::AsyncUnloadSpawnGroupInternal
+  - name: CNetworkGameServer_PrepareForAssetLoad
+    alias:
+    - CNetworkGameServer::PrepareForAssetLoad
+  - name: CNetworkGameServerBase_IsSaveRestoreAllowed
+    alias:
+    - CNetworkGameServerBase::IsSaveRestoreAllowed
+  - name: CNetworkGameServerBase_Init
+    alias:
+    - CNetworkGameServerBase::Init
+  - name: CNetworkGameServerBase_Shutdown
+    alias:
+    - CNetworkGameServerBase::Shutdown
+  - name: CNetworkGameServerBase_ShutdownInternal
+    alias:
+    - CNetworkGameServerBase::ShutdownInternal
+  - name: CNetworkGameServer_ActivateServer
+    alias:
+    - CNetworkGameServer::ActivateServer
+  - name: CNetworkGameServer_DirectUpdate
+    alias:
+    - CNetworkGameServer::DirectUpdate
+  - name: CNetworkGameServer_Init
+    alias:
+    - CNetworkGameServer::Init
+  - name: CNetworkGameServer_Shutdown
+    alias:
+    - CNetworkGameServer::Shutdown
+  - name: CNetworkGameServer_SpawnServer
+    alias:
+    - CNetworkGameServer::SpawnServer
+  - name: CNetworkGameServerBase_GetMaxClients
+    alias:
+    - CNetworkGameServerBase::GetMaxClients
+  - name: CNetworkGameServerBase_SetMaxClients
+    alias:
+    - CNetworkGameServerBase::SetMaxClients
+  - name: CNetworkGameServerBase_CheckTimeouts
+    alias:
+    - CNetworkGameServerBase::CheckTimeouts
+  - name: CNetworkGameServerBase_OnKickById
+    alias:
+    - CNetworkGameServerBase::OnKickById
+  - name: CNetworkGameServerBase_OnKickByName
+    alias:
+    - CNetworkGameServerBase::OnKickByName
+  - name: CNetworkGameClient_SendMovePacket
+    alias:
+    - CNetworkGameClient::SendMovePacket
+    - SendMovePacket
+  - name: CNetworkGameClient_SendMove
+    alias:
+    - CNetworkGameClient::SendMove
+    - SendMove
+  - name: INetworkMessages_Serialize
+    alias:
+    - INetworkMessages::Serialize
+  - name: CDemoRecorder_ParseMessage
+    alias:
+    - CDemoRecorder::ParseMessage
+  - name: CDemoRecorder_WriteSpawnGroups
+    alias:
+    - CDemoRecorder::WriteSpawnGroups
+  - name: INetworkMessages_SerializeAbstract
+    alias:
+    - INetworkMessages::SerializeAbstract
+  - name: INetworkMessages_GetNetMessageInfo
+    alias:
+    - INetworkMessages::GetNetMessageInfo
+  - name: INetworkMessages_FindNetworkMessageById
+    alias:
+    - INetworkMessages::FindNetworkMessageById
+  - name: CNetChan_ProcessMessages
+    alias:
+    - CNetChan::ProcessMessages
+  - name: CNetChan_ParseMessagesDemo
+    alias:
+    - CNetChan::ParseMessagesDemo
+  - name: CNetworkGameClient_ProcessPacketEntitiesInternal
+    alias:
+    - CNetworkGameClient::ProcessPacketEntitiesInternal
+  - name: CNetworkGameClient_ProcessPacketEntities
+    alias:
+    - CNetworkGameClient::ProcessPacketEntities
+    - ProcessPacketEntities
+  - name: CNetworkGameClient_RecordEntityBandwidth
+    alias:
+    - CNetworkGameClient::RecordEntityBandwidth
+    - RecordEntityBandwidth
+  - name: CNetworkGameClient_PrintNetStats
+    alias:
+    - CNetworkGameClient::PrintNetStats
+  - name: CMsgSource2NetworkFlowQuality_PrintStats
+    alias:
+    - CMsgSource2NetworkFlowQuality::PrintStats
+  - name: CNetworkGameClient_DisconnectGame
+    alias:
+    - CNetworkGameClient::DisconnectGame
+  - name: INetworkMessages_FindNetworkGroup
+    alias:
+    - INetworkMessages::FindNetworkGroup
+  - name: INetworkClientService_IsActive
+    alias:
+    - INetworkClientService::IsActive
+  - name: INetworkClientService_IsConnected
+    alias:
+    - INetworkClientService::IsConnected
+  - name: CNetworkClientService_ReceivedServerInfo
+    alias:
+    - CNetworkClientService::ReceivedServerInfo
+  - name: CNetworkClientService_SplitScreenConnect
+    alias:
+    - CNetworkClientService::SplitScreenConnect
+  - name: CNetworkClientService_SendNetMessage
+    alias:
+    - CNetworkClientService::SendNetMessage
+  - name: CNetworkClientService_SendStringCmd
+    alias:
+    - CNetworkClientService::SendStringCmd
+  - name: CNetworkClientService_StartChangeLevel
+    alias:
+    - CNetworkClientService::StartChangeLevel
+  - name: CNetworkClientService_FinishChangeLevel
+    alias:
+    - CNetworkClientService::FinishChangeLevel
+  - name: CNetworkClientService_PrintConnectionStatus
+    alias:
+    - CNetworkClientService::PrintConnectionStatus
+  - name: CNetworkClientService_OnStatus
+    alias:
+    - CNetworkClientService::OnStatus
+  - name: CNetworkClientService_ServerCmd
+    alias:
+    - CNetworkClientService::ServerCmd
+  - name: CNetworkClientService_GetDisconnectReason
+    alias:
+    - CNetworkClientService::GetDisconnectReason
+  - name: CNetworkClientService_PrintSpawnGroupStatus
+    alias:
+    - CNetworkClientService::PrintSpawnGroupStatus
+  - name: CNetworkClientService_IsActive
+    alias:
+    - CNetworkClientService::IsActive
+  - name: CNetworkClientService_IsConnected
+    alias:
+    - CNetworkClientService::IsConnected
+  - name: CNetworkClientService_ClockDriftAdjustFrameTime
+    alias:
+    - CNetworkClientService::ClockDriftAdjustFrameTime
+  - name: CNetworkClientService_Init
+    alias:
+    - CNetworkClientService::Init
+  - name: CNetworkClientService_Shutdown
+    alias:
+    - CNetworkClientService::Shutdown
+  - name: CNetworkClientService_DisconnectGameNow
+    alias:
+    - CNetworkClientService::DisconnectGameNow
+  - name: CGameClientConnectPrerequisite_ctor
+    alias:
+    - CGameClientConnectPrerequisite::CGameClientConnectPrerequisite
+  - name: CNetworkClientService_AddClientPrerequisites
+    alias:
+    - CNetworkClientService::AddClientPrerequisites
+  - name: CNetworkClientService_AllocateRemoteConnectionClient
+    alias:
+    - CNetworkClientService::AllocateRemoteConnectionClient
+  - name: CNetworkServerService_Init
+    alias:
+    - CNetworkServerService::Init
+  - name: CNetworkServerService_StartupServer
+    alias:
+    - CNetworkServerService::StartupServer
+  - name: CNetworkServerService_RegisterEventMapInternal
+    alias:
+    - CNetworkServerService::RegisterEventMapInternal
+  - name: CNetworkServerService_OnServerAdvanceTick
+    alias:
+    - CNetworkServerService::OnServerAdvanceTick
+  - name: CNetworkServerService_OnServerPollNetworking
+    alias:
+    - CNetworkServerService::OnServerPollNetworking
+  - name: CNetworkServerService_OnServerProcessNetworking
+    alias:
+    - CNetworkServerService::OnServerProcessNetworking
+  - name: CNetworkServerService_OnServerBeginSimulate
+    alias:
+    - CNetworkServerService::OnServerBeginSimulate
+  - name: CNetworkServerService_OnServerEndSimulate
+    alias:
+    - CNetworkServerService::OnServerEndSimulate
+  - name: CNetworkServerService_OnServerPostSimulate
+    alias:
+    - CNetworkServerService::OnServerPostSimulate
+  - name: CNetworkServerService_OnServerPostAdvanceTick
+    alias:
+    - CNetworkServerService::OnServerPostAdvanceTick
+  - name: CNetworkServerService_OnFrameBoundary
+    alias:
+    - CNetworkServerService::OnFrameBoundary
+  - name: CNetworkServerService_OnClientPollNetworking
+    alias:
+    - CNetworkServerService::OnClientPollNetworking
+  - name: CNetworkServerService_OnSimpleLoopFrameUpdate
+    alias:
+    - CNetworkServerService::OnSimpleLoopFrameUpdate
+  - name: CNetworkServerService_OnKickByIdHLTV
+    alias:
+    - CNetworkServerService::OnKickByIdHLTV
+  - name: CNetworkServerService_DisconnectGameNow
+    alias:
+    - CNetworkServerService::DisconnectGameNow
+  - name: INetworkGameServer_GetMaxClients
+    alias:
+    - INetworkGameServer::GetMaxClients
+  - name: INetworkGameServer_PreWorldUpdate
+    alias:
+    - INetworkGameServer::PreWorldUpdate
+  - name: CNetworkGameServer_PreWorldUpdate
+    alias:
+    - CNetworkGameServer::PreWorldUpdate
+  - name: INetworkGameServer_ServerEndSimulate
+    alias:
+    - INetworkGameServer::ServerEndSimulate
+  - name: CNetworkGameServerBase_ServerEndSimulate
+    alias:
+    - CNetworkGameServerBase::ServerEndSimulate
+  - name: INetworkGameServer_ServerPostSimulate
+    alias:
+    - INetworkGameServer::ServerPostSimulate
+  - name: CNetworkGameServerBase_ServerPostSimulate
+    alias:
+    - CNetworkGameServerBase::ServerPostSimulate
+  - name: INetworkGameServer_ServerAdvanceTick
+    alias:
+    - INetworkGameServer::ServerAdvanceTick
+  - name: CNetworkGameServerBase_ServerAdvanceTick
+    alias:
+    - CNetworkGameServerBase::ServerAdvanceTick
+  - name: INetworkGameServer_ServerProcessNetworking
+    alias:
+    - INetworkGameServer::ServerProcessNetworking
+  - name: CNetworkGameServerBase_ServerProcessNetworking
+    alias:
+    - CNetworkGameServerBase::ServerProcessNetworking
+  - name: INetworkGameServer_GetTimescale
+    alias:
+    - INetworkGameServer::GetTimescale
+  - name: CNetworkGameServerBase_GetTimescale
+    alias:
+    - CNetworkGameServerBase::GetTimescale
+  - name: ISource2Server_PreWorldUpdate
+    alias:
+    - ISource2Server::PreWorldUpdate
+  - name: ISource2Server_OutOfGameFrameBoundary
+    alias:
+    - ISource2Server::OutOfGameFrameBoundary
+  - name: INetworkMessages_SetIsForServer
+    alias:
+    - INetworkMessages::SetIsForServer
+  - name: CEngineClient_DumpNetStats
+    alias:
+    - CEngineClient::DumpNetStats
+  - name: CEngineServer_DumpNetStats
+    alias:
+    - CEngineServer::DumpNetStats
+  - name: CEngineServer_ClientPrintf
+    alias:
+    - CEngineServer::ClientPrintf
+  - name: CEngineServer_GetFrameTimeAmnesty
+    alias:
+    - CEngineServer::GetFrameTimeAmnesty
+  - name: CEngineServer_ShowFrameTimeReport
+    alias:
+    - CEngineServer::ShowFrameTimeReport
+  - name: CEngineServer_SetFrameTimeAmnesty
+    alias:
+    - CEngineServer::SetFrameTimeAmnesty
+  - name: CEngineServer_GetSteamUniverse
+    alias:
+    - CEngineServer::GetSteamUniverse
+  - name: CEngineServer_ChangeLevel
+    alias:
+    - CEngineServer::ChangeLevel
+  - name: CMapListService_IsMapValid
+    alias:
+    - CMapListService::IsMapValid
+    - IMapListService::IsMapValid
+  - name: CEngineServer_IsMapValid
+    alias:
+    - CEngineServer::IsMapValid
+  - name: CEngineServer_PrecacheGeneric
+    alias:
+    - CEngineServer::PrecacheGeneric
+  - name: CEngineServer_ClientCommand
+    alias:
+    - CEngineServer::ClientCommand
+  - name: CEngineServer_GetClientConVarValue
+    alias:
+    - CEngineServer::GetClientConVarValue
+  - name: CEngineServer_SetFakeClientConVarValue
+    alias:
+    - CEngineServer::SetFakeClientConVarValue
+  - name: CEngineServer_CreateFakeClient
+    alias:
+    - CEngineServer::CreateFakeClient
+  - name: CEngineServer_GetPlayerInfo
+    alias:
+    - CEngineServer::GetPlayerInfo
+  - name: CEngineServer_ClientCommandKeyValues
+    alias:
+    - CEngineServer::ClientCommandKeyValues
+  - name: CLog_Print
+    alias:
+    - CLog::Print
+  - name: CEngineServer_LogPrint
+    alias:
+    - CEngineServer::LogPrint
+  - name: CEngineServer_KickClient
+    alias:
+    - CEngineServer::KickClient
+  - name: CEngineServer_IsDedicatedServer
+    alias:
+    - CEngineServer::IsDedicatedServer
+  - name: CEngineServer_ServerCommand
+    alias:
+    - CEngineServer::ServerCommand
+  - name: CLoopTypeClientSimple_ActivateEngineServices
+    alias:
+    - CLoopTypeClientServer::ActivateEngineServices
+  - name: CLoopTypeClientServer_LoopTypeInit
+    alias:
+    - CLoopTypeClientServer::LoopTypeInit
+  - name: CLoopTypeClientServer_AdvanceTime
+    alias:
+    - CLoopTypeClientServer::AdvanceTime
+  - name: CLoopTypeClientServer_Update
+    alias:
+    - CLoopTypeClientServer::Update
+  - name: CLoopTypeClientServer_ActivateLoop
+    alias:
+    - CLoopTypeClientServer::ActivateLoop
+  - name: CLoopTypeClientServer_AllocateLoopMode
+    alias:
+    - CLoopTypeClientServer::AllocateLoopMode
+  - name: CLoopTypeClientServer_WritePerfStats
+    alias:
+    - CLoopTypeClientServer::WritePerfStats
+  - name: CLoopTypeClientServer_DeactivateLoop
+    alias:
+    - CLoopTypeClientServer::DeactivateLoop
+  - name: CLoopTypeClientServer_OutputListeners
+    alias:
+    - CLoopTypeClientServer::OutputListeners
+  - name: CLoopTypeSimple_FrameUpdate
+    alias:
+    - CLoopTypeSimple::FrameUpdate
+  - name: CLoopTypeClientServerService_OnLoopActivate
+    alias:
+    - CLoopTypeClientServerService::OnLoopActivate
+  - name: CLoopTypeSimpleService_OnLoopActivate
+    alias:
+    - CLoopTypeSimpleService::OnLoopActivate
+  - name: CLoopTypeClientServerService_HandleInputEvent
+    alias:
+    - CLoopTypeClientServerService::HandleInputEvent
+  - name: ILoopMode_HandleInputEvent
+    alias:
+    - ILoopMode::HandleInputEvent
+  - name: ILoopType_AddEngineService
+    alias:
+    - ILoopType::AddEngineService
+  - name: CLoopTypeBase_DeallocateLoopMode
+    alias:
+    - CLoopTypeBase::DeallocateLoopMode
+  - name: CLoopTypeBase_EngineLoop
+    alias:
+    - CLoopTypeBase::EngineLoop
+  - name: CLoopTypeBase_FrameUpdate
+    alias:
+    - CLoopTypeBase::FrameUpdate
+  - name: CLoopTypeBase_ActivateLoop
+    alias:
+    - CLoopTypeBase::ActivateLoop
+  - name: CLoopTypeBase_AllocateLoopMode
+    alias:
+    - CLoopTypeBase::AllocateLoopMode
+  - name: CLoopTypeBase_DeactivateLoop
+    alias:
+    - CLoopTypeBase::DeactivateLoop
+  - name: CLoopTypeBase_LoopTypeInit
+    alias:
+    - CLoopTypeBase::LoopTypeInit
+  - name: CLoopTypeBase_LoopTypeShutdown
+    alias:
+    - CLoopTypeBase::LoopTypeShutdown
+  - name: CLoopTypeBase_GetClientServerMode
+    alias:
+    - CLoopTypeBase::GetClientServerMode
+  - name: CLoopTypeBase_GetImplType
+    alias:
+    - CLoopTypeBase::GetImplType
+  - name: CLoopTypeBase_AddDependentServices
+    alias:
+    - CLoopTypeBase::AddDependentServices
+  - name: CLoopTypeBase_GenerateServiceDependencies
+    alias:
+    - CLoopTypeBase::GenerateServiceDependencies
+  - name: CLoopTypeBase_GenerateSecondaryDependencies
+    alias:
+    - CLoopTypeBase::GenerateSecondaryDependencies
+  - name: CLoopTypeBase_LoadDependentServices
+    alias:
+    - CLoopTypeBase::LoadDependentServices
+  - name: IEngineService_GetServiceDependencies
+    alias:
+    - IEngineService::GetServiceDependencies
+  - name: IEngineService_GetName
+    alias:
+    - IEngineService::GetName
+  - name: ILoopModeFactory_GetLoopModeType
+    alias:
+    - ILoopModeFactory::GetLoopModeType
+  - name: ILoopModeFactory_Shutdown
+    alias:
+    - ILoopModeFactory::Shutdown
+  - name: CEngineServiceMgr_RegisterEngineService
+    alias:
+    - CEngineServiceMgr::RegisterEngineService
+  - name: CEngineServiceMgr_RegisterLoopMode
+    alias:
+    - CEngineServiceMgr::RegisterLoopMode
+  - name: CEngineServiceMgr_UnregisterLoopMode
+    alias:
+    - CEngineServiceMgr::UnregisterLoopMode
+  - name: CEngineServiceMgr_UnregisterEngineService
+    alias:
+    - CEngineServiceMgr::UnregisterEngineService
+  - name: CEngineServiceMgr_SwitchToLoop
+    alias:
+    - CEngineServiceMgr::SwitchToLoop
+  - name: CEngineServiceMgr_PrintStatus
+    alias:
+    - CEngineServiceMgr::PrintStatus
+  - name: CEngineServiceMgr__MainLoop
+    alias:
+    - CEngineServiceMgr::_MainLoop
+  - name: CEngineServiceMgr_DeactivateLoop
+    alias:
+    - CEngineServiceMgr::DeactivateLoop
+  - name: CEngineServiceMgr_Shutdown
+    alias:
+    - CEngineServiceMgr::Shutdown
+  - name: CEngineServiceMgr_GetActiveLoopClientServerMode
+    alias:
+    - CEngineServiceMgr::GetActiveLoopClientServerMode
+  - name: CEngineServiceMgr_GetEventDispatcher
+    alias:
+    - CEngineServiceMgr::GetEventDispatcher
+  - name: CEngineGameUI_Shutdown
+    alias:
+    - CEngineGameUI::Shutdown
+  - name: IAppSystem_Shutdown
+    alias:
+    - IAppSystem::Shutdown
+  - name: CSplitScreenService_AddSplitScreenUser
+    alias:
+    - CSplitScreenService::AddSplitScreenUser
+  - name: CSplitScreenService_LoadUserConfiguration
+    alias:
+    - CSplitScreenService::LoadUserConfiguration
+  - name: CHLTVClient_ProcessSetConVar
+    alias:
+    - CHLTVClient::ProcessSetConVar
+  - name: CServerSideClientBase_ProcessTick
+    alias:
+    - CServerSideClientBase::ProcessTick
+  - name: CServerSideClientBase_ProcessStringCmd
+    alias:
+    - CServerSideClientBase::ProcessStringCmd
+  - name: CServerSideClientBase_MarkSpawnGroupLoadCompleted
+    alias:
+    - CServerSideClientBase::MarkSpawnGroupLoadCompleted
+  - name: CServerSideClientBase_ProcessSpawnGroup_LoadCompleted
+    alias:
+    - CServerSideClientBase::ProcessSpawnGroup_LoadCompleted
+  - name: CServerSideClientBase_ProcessClientInfo
+    alias:
+    - CServerSideClientBase::ProcessClientInfo
+  - name: CServerSideClientBase_ProcessBaselineAck
+    alias:
+    - CServerSideClientBase::ProcessBaselineAck
+  - name: CServerSideClientBase_ProcessSplitPlayerConnectInternal
+    alias:
+    - CServerSideClientBase::ProcessSplitPlayerConnectInternal
+  - name: CServerSideClientBase_ProcessSplitPlayerConnect
+    alias:
+    - CServerSideClientBase::ProcessSplitPlayerConnect
+  - name: CServerSideClientBase_GetUserIDString
+    alias:
+    - CServerSideClientBase::GetUserIDString
+  - name: CServerSideClientBase_GetNetworkIDString
+    alias:
+    - CServerSideClientBase::GetNetworkIDString
+  - name: CServerSideClientBase_Connect
+    alias:
+    - CServerSideClientBase::Connect
+  - name: CServerSideClientBase_GetPlayerInfo
+    alias:
+    - CServerSideClientBase::GetPlayerInfo
+  - name: CNetworkGameServer_GetPlayerNetworkIDString
+    alias:
+    - CNetworkGameServer::GetPlayerNetworkIDString
+  - name: CNetworkGameServerBase_RemoveClientFromGame
+    alias:
+    - CNetworkGameServerBase::RemoveClientFromGame
+  - name: CEngineServer_GetPlayerNetworkIDString
+    alias:
+    - CEngineServer::GetPlayerNetworkIDString
+  - name: CNetworkGameClientBase_ServerCmd
+    alias:
+    - CNetworkGameClientBase::ServerCmd
+  - name: CNetworkGameClientBase_ProcessSetConVar
+    alias:
+    - CNetworkGameClientBase::ProcessSetConVar
+  - name: CNetworkGameClientBase_SendStringCmd
+    alias:
+    - CNetworkGameClientBase::SendStringCmd
+  - name: CNetworkGameClientBase_StartChangeLevel
+    alias:
+    - CNetworkGameClientBase::StartChangeLevel
+  - name: CNetworkGameClientBase_FinishChangeLevel
+    alias:
+    - CNetworkGameClientBase::FinishChangeLevel
+  - name: CNetworkGameClientBase_DeferActivate
+    alias:
+    - CNetworkGameClientBase::DeferActivate
+  - name: CNetworkGameClientBase_ClockDrift_AdjustFrameTime
+    alias:
+    - CNetworkGameClientBase::ClockDrift_AdjustFrameTime
+  - name: CNetworkGameClientBase_Connect
+    alias:
+    - CNetworkGameClientBase::Connect
+  - name: CNetworkGameClientBase_DisconnectGame
+    alias:
+    - CNetworkGameClientBase::DisconnectGame
+  - name: CNetSupportImpl_Connect
+    alias:
+    - CNetSupportImpl::Connect
+- name: client
+  symbols:
+  - name: CLoopModeGame_RegisterEventMapInternal
+    alias:
+    - CLoopModeGame::RegisterEventMapInternal
+  - name: CLoopModeGame_OnClientPollNetworking
+    alias:
+    - CLoopModeGame::OnClientPollNetworking
+  - name: CLoopModeGame_OnClientAdvanceTick
+    alias:
+    - CLoopModeGame::OnClientAdvanceTick
+  - name: CLoopModeGame_OnClientPostAdvanceTick
+    alias:
+    - CLoopModeGame::OnClientPostAdvanceTick
+  - name: CLoopModeGame_OnClientPreSimulate
+    alias:
+    - CLoopModeGame::OnClientPreSimulate
+  - name: CLoopModeGame_OnClientPreOutput
+    alias:
+    - CLoopModeGame::OnClientPreOutput
+  - name: CLoopModeGame_OnClientPreOutputParallelWithServer
+    alias:
+    - CLoopModeGame::OnClientPreOutputParallelWithServer
+  - name: CLoopModeGame_OnClientPostOutput
+    alias:
+    - CLoopModeGame::OnClientPostOutput
+  - name: CLoopModeGame_OnClientFrameSimulate
+    alias:
+    - CLoopModeGame::OnClientFrameSimulate
+  - name: CLoopModeGame_OnClientAdvanceNonRenderedFrame
+    alias:
+    - CLoopModeGame::OnClientAdvanceNonRenderedFrame
+  - name: CLoopModeGame_OnClientPostSimulate
+    alias:
+    - CLoopModeGame::OnClientPostSimulate
+  - name: CLoopModeGame_OnClientPauseSimulate
+    alias:
+    - CLoopModeGame::OnClientPauseSimulate
+  - name: CLoopModeGame_OnClientSimulate
+    alias:
+    - CLoopModeGame::OnClientSimulate
+  - name: CLoopModeGame_OnPostDataUpdate
+    alias:
+    - CLoopModeGame::OnPostDataUpdate
+  - name: CLoopModeGame_OnPreDataUpdate
+    alias:
+    - CLoopModeGame::OnPreDataUpdate
+  - name: CLoopModeGame_OnFrameBoundary
+    alias:
+    - CLoopModeGame::OnFrameBoundary
+  - name: CLoopModeGame_StaticInit
+    alias:
+    - CLoopModeGame::StaticInit
+  - name: CLoopModeFactory_CLoopModeGame_Init
+    alias:
+    - CLoopModeFactory<CLoopModeGame>::Init
+  - name: CLoopModeFactory_CLoopModeGame_Shutdown
+    alias:
+    - CLoopModeFactory<CLoopModeGame>::Shutdown
+  - name: CLoopModeGame_OnLoopActivate
+    alias:
+    - CLoopModeGame::OnLoopActivate
+  - name: ILoopMode_OnLoopActivate
+    alias:
+    - ILoopMode::OnLoopActivate
+  - name: CLoopModeGame_AddViewsToSceneSystem
+    alias:
+    - CLoopModeGame::AddViewsToSceneSystem
+  - name: ILoopMode_AddViewsToSceneSystem
+    alias:
+    - ILoopMode::AddViewsToSceneSystem
+  - name: CLoopModeGame_LoopInitInternal
+    alias:
+    - CLoopModeGame::LoopInitInternal
+  - name: CLoopModeGame_LoopInit
+    alias:
+    - CLoopModeGame::LoopInit
+  - name: ILoopMode_LoopInit
+    alias:
+    - ILoopMode::LoopInit
+  - name: ILoopMode_LoopShutdown
+    alias:
+    - ILoopMode::LoopShutdown
+  - name: CLoopModeGame_ReceivedServerInfo
+    alias:
+    - CLoopModeGame::ReceivedServerInfo
+  - name: CLoopModeGame_RegisterEventMap
+    alias:
+    - CLoopModeGame::RegisterEventMap
+  - name: ILoopMode_RegisterEventMap
+    alias:
+    - ILoopMode::RegisterEventMap
+  - name: CLoopModeGame_SetWorldSession
+    alias:
+    - CLoopModeGame::SetWorldSession
+  - name: CLoopModeGame_SetGameSystemState
+    alias:
+    - CLoopModeGame::SetGameSystemState
+  - name: CLoopModeGame_LoopShutdown
+    alias:
+    - CLoopModeGame::LoopShutdown
+  - name: IGameSystem_AddByName
+    alias:
+    - IGameSystem::AddByName
+  - name: IGameSystem_Add
+    alias:
+    - IGameSystem::Add
+  - name: IGameSystem_PostInit
+    alias:
+    - IGameSystem::PostInit
+  - name: IGameSystem_InitAllSystems
+    alias:
+    - IGameSystem::InitAllSystems
+  - name: IGameSystem_LoopInitAllSystems
+    alias:
+    - IGameSystem::LoopInitAllSystems
+  - name: IGameSystemFactory_PostInit
+    alias:
+    - IGameSystemFactory::PostInit
+  - name: IGameSystemFactory_GetStaticGameSystem
+    alias:
+    - IGameSystemFactory::GetStaticGameSystem
+  - name: IGameSystemFactory_ShouldAutoAdd
+    alias:
+    - IGameSystemFactory::ShouldAutoAdd
+  - name: IGameSystemFactory_CreateGameSystem
+    alias:
+    - IGameSystemFactory::CreateGameSystem
+  - name: IGameSystemFactory_IsReallocating
+    alias:
+    - IGameSystemFactory::IsReallocating
+  - name: IGameSystem_SetName
+    alias:
+    - IGameSystem::SetName
+  - name: CSpawnGroupMgrGameSystem_DoesGameSystemReallocate
+    alias:
+    - IGameSystem::DoesGameSystemReallocate
+  - name: IGameSystem_DestroyAllGameSystems
+    alias:
+    - IGameSystem::DestroyAllGameSystems
+  - name: IGameSystem_ShutdownAllSystems
+    alias:
+    - IGameSystem::ShutdownAllSystems
+  - name: IGameSystem_LoopDestroyAllSystems
+    alias:
+    - IGameSystem::LoopDestroyAllSystems
+  - name: IGameSystem_LoopPreShutdownAllSystems
+    alias:
+    - IGameSystem::LoopPreShutdownAllSystems
+  - name: IGameSystem_OnClientPollNetworking
+    alias:
+    - IGameSystem::OnClientPollNetworking
+  - name: IGameSystem_OnClientGamePostSimulate
+    alias:
+    - IGameSystem::ClientGamePostSimulate
+  - name: IGameSystem_OnClientPauseSimulate
+    alias:
+    - IGameSystem::OnClientPauseSimulate
+  - name: IGameSystem_OnClientPreUpdate
+    alias:
+    - IGameSystem::OnClientPreUpdate
+  - name: IGameSystem_OnClientPostUpdate
+    alias:
+    - IGameSystem::OnClientPostUpdate
+  - name: IGameSystem_OnClientPostDataUpdate
+    alias:
+    - IGameSystem::OnClientPostDataUpdate
+  - name: IGameSystem_OnGameFrameBoundary
+    alias:
+    - IGameSystem::OnGameFrameBoundary
+  - name: IGameSystem_OnClientAdvanceNonRenderedFrame
+    alias:
+    - IGameSystem::OnClientAdvanceNonRenderedFrame
+  - name: IGameSystem_OnClientFrameSimulate
+    alias:
+    - IGameSystem::OnClientFrameSimulate
+  - name: IGameSystem_OnClientAdvanceTick
+    alias:
+    - IGameSystem::ClientAdvanceTick
+  - name: IGameSystem_OnClientPostAdvanceTick
+    alias:
+    - IGameSystem::ClientPostAdvanceTick
+  - name: IGameSystem_OnClientPostRender
+    alias:
+    - IGameSystem::OnClientPostRender
+  - name: IGameSystem_OnClientPreRender
+    alias:
+    - IGameSystem::OnClientPreRender
+  - name: IGameSystem_OnClientPreRenderAlt
+    alias:
+    - IGameSystem::OnClientPreRenderAlt
+  - name: CSource2Client_OnDisconnect
+    alias:
+    - CSource2Client::OnDisconnect
+  - name: IGameSystem_OnClientDisconnect
+    alias:
+    - IGameSystem::OnClientDisconnect
+  - name: IGameSystem_OnClientPreEntityThink
+    alias:
+    - IGameSystem::OnClientPreEntityThink
+  - name: CSteamworksGameStats_OnReceivedSessionID
+    alias:
+    - CSteamworksGameStats::OnReceivedSessionID
+  - name: IGameSystem_GetName
+    alias:
+    - IGameSystem::GetName
+  - name: IGameSystemFactory_DestroyGameSystem
+    alias:
+    - IGameSystemFactory::DestroyGameSystem
+  - name: IGameSystemFactory_Init
+    alias:
+    - IGameSystemFactory::Init
+  - name: IGameSystemFactory_GetPriority
+    alias:
+    - IGameSystemFactory::GetPriority
+  - name: IGameSystemFactory_Shutdown
+    alias:
+    - IGameSystemFactory::Shutdown
+  - name: IGameSystemFactory_SetGlobalPtr
+    alias:
+    - IGameSystemFactory::SetGlobalPtr
+  - name: CPrediction_PostNetworkDataReceived
+    alias:
+    - CPrediction::PostNetworkDataReceived
+  - name: IEngineServiceMgr_GetActiveLoopClientServerMode
+    alias:
+    - IEngineServiceMgr::GetActiveLoopClientServerMode
+  - name: IEngineServiceMgr_GetEventDispatcher
+    alias:
+    - IEngineServiceMgr::GetEventDispatcher
+  - name: ClientModeCSNormal_Update
+    alias:
+    - ClientModeCSNormal::Update
+  - name: CEntitySystem_ctor
+    alias:
+    - CEntitySystem::CEntitySystem
+  - name: CGameEntitySystem_ctor
+    alias:
+    - CGameEntitySystem::CGameEntitySystem
+  - name: CEntitySystem_Init
+    alias:
+    - CEntitySystem::Init
+  - name: CEntitySystem_PostCreateEntitySystem
+    alias:
+    - CEntitySystem::PostCreateEntitySystem
+  - name: CSource2EntitySystem_StaticInit
+    alias:
+    - CSource2EntitySystem::StaticInit
+  - name: CGameSystemReallocatingFactory_CSource2EntitySystem_Init
+    alias:
+    - CGameSystemReallocatingFactory<CSource2EntitySystem>::Init
+  - name: CGameSystemReallocatingFactory_CSource2EntitySystem_CreateGameSystem
+    alias:
+    - CGameSystemReallocatingFactory<CSource2EntitySystem>::CreateGameSystem
+  - name: CSkeletonInstance_PostDataUpdate
+    alias:
+    - CSkeletonInstance::PostDataUpdate
+  - name: CSkeletonInstance_m_modelState
+    alias:
+    - CSkeletonInstance::m_modelState
+  - name: CSkeletonInstance_m_modelState_m_hModel
+    alias:
+    - CSkeletonInstance::m_modelState.m_hModel
+  - name: CModelState_SetupJointState
+    alias:
+    - CModelState::SetupJointState
+  - name: CModelState_m_nTotalTransformCount
+    alias:
+    - CModelState::m_nTotalTransformCount
+  - name: CModelState_m_nBoneCount
+    alias:
+    - CModelState::m_nBoneCount
+  - name: CModelState_m_nAttachmentCount
+    alias:
+    - CModelState::m_nAttachmentCount
+  - name: IVEngineClient2_GetNetworkClient
+    alias:
+    - IVEngineClient2::GetNetworkClient
+  - name: INetworkClient_GetLocalAddress
+    alias:
+    - INetworkClient::GetLocalAddress
+  - name: INetworkClientService_IsConnected
+    alias:
+    - INetworkClientService::IsConnected
+  - name: INetworkClientService_SendNetMessage
+    alias:
+    - INetworkClientService::SendNetMessage
+  - name: IGameResourceService_SetEntityResourceManifestHandler
+    alias:
+    - IGameResourceService::SetEntityResourceManifestHandler
+  - name: CNetworkSerializerBindingBuildFilter_GetFieldPriority
+    alias:
+    - CNetworkSerializerBindingBuildFilter::GetFieldPriority
+- name: server
+  symbols:
+  - name: CSource2Server_OnStreamEntitiesFromFileCompleted
+    alias:
+    - CSource2Server::OnStreamEntitiesFromFileCompleted
+  - name: CSource2Server_PreWorldUpdate
+    alias:
+    - CSource2Server::PreWorldUpdate
+  - name: CSource2Server_OutOfGameFrameBoundary
+    alias:
+    - CSource2Server::OutOfGameFrameBoundary
+  - name: CGameSystemReallocatingFactory_CSource2EntitySystem_Init
+    alias:
+    - CGameSystemReallocatingFactory<CSource2EntitySystem>::Init
+  - name: CGameSystemReallocatingFactory_CSource2EntitySystem_CreateGameSystem
+    alias:
+    - CGameSystemReallocatingFactory<CSource2EntitySystem>::CreateGameSystem
+  - name: IGameSystemFactory_Init
+    alias:
+    - IGameSystemFactory::Init
+  - name: IGameSystemFactory_Shutdown
+    alias:
+    - IGameSystemFactory::Shutdown
+  - name: IGameSystemFactory_SetGlobalPtr
+    alias:
+    - IGameSystemFactory::SetGlobalPtr
+  - name: CGameSystemReallocatingFactory_CSpawnGroupMgrGameSystem_DestroyGameSystem
+    alias:
+    - CGameSystemReallocatingFactory<CSpawnGroupMgrGameSystem>::Deallocate
+  - name: IGameSystem_SetGameSystemGlobalPtrs
+    alias:
+    - IGameSystem::SetGameSystemGlobalPtrs
+  - name: IGameSystem_vdtor
+    alias:
+    - IGameSystem::~IGameSystem
+  - name: IGameSystem_OnGameInit
+    alias:
+    - IGameSystem::GameInit
+  - name: CMultiplayRules_ctor
+    alias:
+    - CMultiplayRules::CMultiplayRules
+  - name: CGameMoney_OnMoneySpent
+    alias:
+    - CGameMoney::OnMoneySpent
+  - name: CGameMoney_m_DataMap
+    alias:
+    - CGameMoney::m_DataMap
+  - name: CGameMoney_GetDataDescMap
+    alias:
+    - CGameMoney::GetDataDescMap
+  - name: CCSPlayer_UseServices_OnUseImpl
+    alias:
+    - CCSPlayer_UseServices::OnUseImpl
+  - name: CCSPlayer_UseServices_OnUse
+    alias:
+    - CCSPlayer_UseServices::OnUse
+  - name: CCSPlayer_MovementServices_ProcessMovement
+    alias:
+    - CCSPlayer_MovementServices::ProcessMovement
+    - ProcessMovement
+  - name: CCSPlayer_MovementServices_CheckMovingGround
+    alias:
+    - CCSPlayer_MovementServices::CheckMovingGround
+    - CheckMovingGround
+  - name: CCSPlayer_MovementServices_WalkMove
+    alias:
+    - CCSPlayer_MovementServices::WalkMove
+    - WalkMove
+  - name: CCSPlayer_MovementServices_FullWalkMove
+    alias:
+    - CCSPlayer_MovementServices::FullWalkMove
+    - FullWalkMove
+  - name: CCSPlayer_MovementServices_CheckVelocity
+    alias:
+    - CCSPlayer_MovementServices::CheckVelocity
+    - CheckVelocity
+  - name: CCSPlayer_MovementServices_WaterMove
+    alias:
+    - CCSPlayer_MovementServices::WaterMove
+    - WaterMove
+  - name: CCSPlayer_MovementServices_FullWalkMove_SpeedClamp
+    alias:
+    - ServerMovementUnlock
+  - name: CCSPlayer_MovementServices_CheckJumpButton
+    alias:
+    - CCSPlayer_MovementServices::CheckJumpButton
+  - name: CCSPlayer_MovementServices_CheckJumpButton_WaterPatch
+    alias:
+    - CheckJumpButtonWater
+    - FixWaterFloorJump
+  - name: CPlayer_MovementServices_PlayWaterStepSound
+    alias:
+    - CPlayer_MovementServices::PlayWaterStepSound
+  - name: CPlayer_MovementServices_ForceButtons
+    alias:
+    - CPlayer_MovementServices::ForceButtons
+  - name: CPlayer_MovementServices_ForceButtonState
+    alias:
+    - CPlayer_MovementServices::ForceButtonState
+  - name: CPlayer_MovementServices_s_pRunCommandPawn
+    alias:
+    - CPlayer_MovementServices::s_pRunCommandPawn
+  - name: CEntityInstance_m_pEntity
+    alias:
+    - CEntityInstance::m_pEntity
+  - name: CEntityInstance_m_hPrivateScope
+    alias:
+    - CEntityInstance::m_hPrivateScope
+  - name: CEntityInstance_m_CScriptComponent
+    alias:
+    - CEntityInstance::m_CScriptComponent
+  - name: CEntityInstance_m_pKeyValues
+    alias:
+    - CEntityInstance::m_pKeyValues
+  - name: CEntityInstance_m_iszPrivateVScripts
+    alias:
+    - CEntityInstance::m_iszPrivateVScripts
+  - name: CBaseEntity_OnRestore
+    alias:
+    - CBaseEntity::OnRestore
+  - name: CEntityInstance_OnRestore
+    alias:
+    - CEntityInstance::OnRestore
+  - name: CBaseEntity_ctor
+    alias:
+    - CBaseEntity::CBaseEntity
+  - name: CBaseEntity_dtor
+    alias:
+    - CBaseEntity::~CBaseEntity
+  - name: CBaseEntity_vdtor
+    alias:
+    - CBaseEntity::~CBaseEntity (virtual)
+  - name: CEntityInstance_vdtor
+    alias:
+    - CEntityInstance::~CEntityInstance (virtual)
+  - name: CEntitySaveRestoreBlockHandler_PreSave
+    alias:
+    - CEntitySaveRestoreBlockHandler::PreSave
+  - name: CEntitySaveRestoreBlockHandler_SaveInternal
+    alias:
+    - CEntitySaveRestoreBlockHandler::SaveInternal
+  - name: CEntitySaveRestoreBlockHandler_Save
+    alias:
+    - CEntitySaveRestoreBlockHandler::Save
+  - name: CEntitySaveRestoreBlockHandler_Restore
+    alias:
+    - CEntitySaveRestoreBlockHandler::Restore
+  - name: CEntitySaveRestoreBlockHandler_DoRestoreEntity
+    alias:
+    - CEntitySaveRestoreBlockHandler::DoRestoreEntity
+  - name: CEntitySaveRestoreBlockHandler_RestoreEntity
+    alias:
+    - CEntitySaveRestoreBlockHandler::RestoreEntity
+  - name: CreateEntityTransitionList
+    alias:
+    - CreateEntityTransitionList
+  - name: CEntitySaveRestoreBlockHandler_WriteSaveHeaders
+    alias:
+    - CEntitySaveRestoreBlockHandler::WriteSaveHeaders
+  - name: CEntitySaveRestoreBlockHandler_ReadRestoreHeaders
+    alias:
+    - CEntitySaveRestoreBlockHandler::ReadRestoreHeaders
+  - name: CEntity2SaveRestore_StreamEntitiesFromFile
+    alias:
+    - CEntity2SaveRestore::StreamEntitiesFromFile
+  - name: CSaveRestoreBlockSet_PreRestore
+    alias:
+    - CSaveRestoreBlockSet::PreRestore
+  - name: CSaveRestoreBlockSet_PostRestore
+    alias:
+    - CSaveRestoreBlockSet::PostRestore
+  - name: CEntitySaveRestoreBlockHandler_PreRestore
+    alias:
+    - CEntitySaveRestoreBlockHandler::PreRestore
+  - name: CEntitySaveRestoreBlockHandler_PostRestore
+    alias:
+    - CEntitySaveRestoreBlockHandler::PostRestore
+  - name: CEntitySystem_ForceSetInPVSCallsIntoQueue
+    alias:
+    - CEntitySystem::ForceSetInPVSCallsIntoQueue
+  - name: CEntitySystem_ExecuteQueuedSetInPVS
+    alias:
+    - CEntitySystem::ExecuteQueuedSetInPVS
+  - name: CEntitySystem_m_nSuppressDormancyChangeCount
+    alias:
+    - CEntitySystem::m_nSuppressDormancyChangeCount
+  - name: CEntitySystem_m_nExecuteQueuedCreationDepth
+    alias:
+    - CEntitySystem::m_nExecuteQueuedCreationDepth
+  - name: CEntitySystem_m_queuedDormancyChanges
+    alias:
+    - CEntitySystem::m_queuedDormancyChanges
+  - name: CEntitySystem_SetInPVS
+    alias:
+    - CEntitySystem::SetInPVS
+  - name: CEntitySystem_OnSetDormant
+    alias:
+    - CEntitySystem::OnSetDormant
+  - name: CEntitySystem_BuildResourceManifestForEntity
+    alias:
+    - CEntitySystem::BuildResourceManifestForEntity
+  - name: CEntityInstance_ObjectCaps
+    alias:
+    - CEntityInstance::ObjectCaps
+  - name: CEntityInstance_Save
+    alias:
+    - CEntityInstance::Save
+  - name: CEntityInstance_Restore
+    alias:
+    - CEntityInstance::Restore
+  - name: CEntitySaveRestoreBlockHandler_SaveInitEntities
+    alias:
+    - CEntitySaveRestoreBlockHandler::SaveInitEntities
+  - name: CEntityInstance_OnSave
+    alias:
+    - CEntityInstance::OnSave
+  - name: CEntityInstance_RequiredEdictIndex
+    alias:
+    - CEntityInstance::RequiredEdictIndex
+  - name: PolymorphicHelper_t__SetPolymorphicPointer
+    alias:
+    - PolymorphicHelper_t::SetPolymorphicPointer
+  - name: CEntityInstance_AddChangeAccessorPathPolymorphic
+    alias:
+    - CEntityInstance::AddChangeAccessorPathPolymorphic
+  - name: CEntityInstance_AssignChangeAccessorPathIdsPolymorphic
+    alias:
+    - CEntityInstance::AssignChangeAccessorPathIdsPolymorphic
+  - name: CEntityInstance_AddChangeAccessorPath
+    alias:
+    - CEntityInstance::AddChangeAccessorPath
+  - name: CEntityInstance_AssignChangeAccessorPathIds
+    alias:
+    - CEntityInstance::AssignChangeAccessorPathIds
+  - name: CEntityInstance_GetChangeAccessorPathInfo_2
+    alias:
+    - CEntityInstance::GetChangeAccessorPathInfo_2
+  - name: CBaseEntity_GetChangeAccessorPathInfo_2
+    alias:
+    - CBaseEntity::GetChangeAccessorPathInfo_2
+  - name: CBaseEntity_GetChangeAccessorPathInfo_1
+    alias:
+    - CBaseEntity::GetChangeAccessorPathInfo_1
+  - name: CMomentaryRotButton_Use
+    alias:
+    - CMomentaryRotButton::Use
+  - name: CBaseEntity_TakeDamageOld
+    alias:
+    - CBaseEntity::TakeDamageOld
+  - name: CBaseEntity_OnTakeDamage
+    alias:
+    - CBasePlayerPawn::OnTakeDamage
+  - name: CBasePlayerPawn_OnTakeDamage_Alive
+    alias:
+    - CBasePlayerPawn::OnTakeDamage_Alive
+  - name: CBasePlayerPawn_OnTakeDamage_Dying
+    alias:
+    - CBasePlayerPawn::OnTakeDamage_Dying
+  - name: CBasePlayerPawn_OnTakeDamage_Dead
+    alias:
+    - CBasePlayerPawn::OnTakeDamage_Dead
+  - name: CBasePlayerPawn_OnTakeDamage
+    alias:
+    - CBasePlayerPawn::OnTakeDamage
+  - name: CCSPlayerPawn_OnTakeDamage_Alive
+    alias:
+    - CCSPlayerPawn::OnTakeDamage_Alive
+  - name: CCSPlayerPawn_OnTakeDamage_Dying
+    alias:
+    - CCSPlayerPawn::OnTakeDamage_Dying
+  - name: CCSPlayerPawn_OnTakeDamage_Dead
+    alias:
+    - CCSPlayerPawn::OnTakeDamage_Dead
+  - name: CFlashbangProjectile_Spawn
+    alias:
+    - CFlashbangProjectile::Spawn
+  - name: CSmokeGrenadeProjectile_Create
+    alias:
+    - CSmokeGrenadeProjectile::Create
+  - name: CEntitySystem_QueueDestroyEntity
+    alias:
+    - CEntitySystem::QueueDestroyEntity
+  - name: CEntitySystem_ExecuteQueuedDeletion
+    alias:
+    - CEntitySystem::ExecuteQueuedDeletion
+  - name: CEntitySystem_m_nExecuteQueuedDeletionDepth
+    alias:
+    - CEntitySystem::m_nExecuteQueuedDeletionDepth
+  - name: CBaseModelEntity_SetModel
+    alias:
+    - CBaseModelEntity::SetModel
+  - name: CBaseModelEntity_SetRenderAttribute
+    alias:
+    - CBaseModelEntity::SetRenderAttribute
+  - name: CBaseEntity_GetScriptDescInternal
+    alias:
+    - CBaseEntity::GetScriptDescInternal
+  - name: CBaseModelEntity_GetScriptDescInternal
+    alias:
+    - CBaseModelEntity::GetScriptDescInternal
+  - name: CBaseModelEntity_GetModelScale
+    alias:
+    - CBaseModelEntity::GetModelScale
+  - name: CBaseModelEntity_Script_SetModelScale
+    alias:
+    - CBaseModelEntity::Script_SetModelScale
+  - name: CBaseModelEntity_ScriptLookupAttachment
+    alias:
+    - CBaseModelEntity::ScriptLookupAttachment
+  - name: CBaseModelEntity_ScriptGetAttachmentOrigin
+    alias:
+    - CBaseModelEntity::ScriptGetAttachmentOrigin
+  - name: CBaseModelEntity_ScriptGetAttachmentAngles
+    alias:
+    - CBaseModelEntity::ScriptGetAttachmentAngles
+  - name: CBaseModelEntity_ScriptGetAttachmentForward
+    alias:
+    - CBaseModelEntity::ScriptGetAttachmentForward
+  - name: CBaseModelEntity_ScriptSetSize
+    alias:
+    - CBaseModelEntity::ScriptSetSize
+  - name: CBaseModelEntity_ScriptSetModel
+    alias:
+    - CBaseModelEntity::ScriptSetModel
+  - name: CBaseModelEntity_ScriptGetRenderAlpha
+    alias:
+    - CBaseModelEntity::ScriptGetRenderAlpha
+  - name: CBaseModelEntity_ScriptSetRenderAlpha
+    alias:
+    - CBaseModelEntity::ScriptSetRenderAlpha
+  - name: CBaseModelEntity_ScriptSetRenderMode
+    alias:
+    - CBaseModelEntity::ScriptSetRenderMode
+  - name: CBaseModelEntity_ScriptSetRenderColor
+    alias:
+    - CBaseModelEntity::ScriptSetRenderColor
+  - name: CBaseModelEntity_ScriptGetRenderColor
+    alias:
+    - CBaseModelEntity::ScriptGetRenderColor
+  - name: CBaseModelEntity_ScriptSetMaterialGroup
+    alias:
+    - CBaseModelEntity::ScriptSetMaterialGroup
+  - name: CBaseModelEntity_ScriptSetMaterialGroupHash
+    alias:
+    - CBaseModelEntity::ScriptSetMaterialGroupHash
+  - name: CBaseModelEntity_ScriptGetMaterialGroupHash
+    alias:
+    - CBaseModelEntity::ScriptGetMaterialGroupHash
+  - name: CBaseModelEntity_ScriptSetSingleMeshGroup
+    alias:
+    - CBaseModelEntity::ScriptSetSingleMeshGroup
+  - name: CBaseModelEntity_ScriptSetMeshGroupMask
+    alias:
+    - CBaseModelEntity::ScriptSetMeshGroupMask
+  - name: CBaseModelEntity_ScriptGetMeshGroupMask
+    alias:
+    - CBaseModelEntity::ScriptGetMeshGroupMask
+  - name: CBaseModelEntity_ScriptSetBodygroupByName
+    alias:
+    - CBaseModelEntity::ScriptSetBodygroupByName
+  - name: CBaseModelEntity_Script_SetBodygroup
+    alias:
+    - CBaseModelEntity::Script_SetBodygroup
+  - name: CBaseModelEntity_Script_SetSkin
+    alias:
+    - CBaseModelEntity::Script_SetSkin
+  - name: CEntityInstance_NetworkUpdateState_thunk
+    alias:
+    - CEntityInstance::NetworkUpdateState_thunk
+  - name: CBaseEntity_SetGravityScale
+    alias:
+    - CBaseEntity::SetGravityScale
+  - name: CTriggerGravity_GravityTouch
+    alias:
+    - CTriggerGravity::GravityTouch
+  - name: CTriggerGravity_GetTouchFunction
+    alias:
+    - CTriggerGravity::GetTouchFunction
+  - name: CBasePlayerController_HandleCommand_JoinTeam
+    alias:
+    - CBasePlayerController::HandleCommand_JoinTeam
+  - name: CBasePlayerController_SetPlayerName
+    alias:
+    - CBasePlayerController::SetPlayerName
+  - name: CBasePlayerController_ProcessUsercmds
+    alias:
+    - ProcessUsercmds
+  - name: CBasePlayerController_SetPawn
+    alias:
+    - CBasePlayerController::SetPawn
+  - name: CBasePlayerController_GetPawn
+    alias:
+    - CBasePlayerController::GetPawn
+  - name: CBasePlayerController_Connect
+    alias:
+    - CBasePlayerController::Connect
+  - name: CSource2GameClients_ClientDisconnect
+    alias:
+    - CSource2GameClients::ClientDisconnect
+  - name: CSource2GameClients_ClientPutInServer
+    alias:
+    - CSource2GameClients::ClientPutInServer
+  - name: CSource2GameClients_ClientConnect
+    alias:
+    - CSource2GameClients::ClientConnect
+  - name: CSource2GameClients_ClientActive
+    alias:
+    - CSource2GameClients::ClientActive
+  - name: CSource2GameClients_ClientFullyConnect
+    alias:
+    - CSource2GameClients::ClientFullyConnect
+  - name: CSource2GameClients_ClientCommand
+    alias:
+    - CSource2GameClients::ClientCommand
+  - name: CSource2GameClients_ProcessUsercmds
+    alias:
+    - CSource2GameClients::ProcessUsercmds
+  - name: CSource2GameClients_GetBugReportInfo
+    alias:
+    - CSource2GameClients::GetBugReportInfo
+  - name: CSource2GameClients_ClientDiagnostic
+    alias:
+    - CSource2GameClients::ClientDiagnostic
+  - name: CSource2GameClients_SendHLTVStatusMessage
+    alias:
+    - CSource2GameClients::SendHLTVStatusMessage
+  - name: CSource2GameClients_OnClientConnected
+    alias:
+    - CSource2GameClients::OnClientConnected
+  - name: CGameRules_FindPickerEntity
+    alias:
+    - CGameRules::FindPickerEntity
+  - name: CCSGameRules_FindPickerEntity
+    alias:
+    - CCSGameRules::FindPickerEntity
+  - name: CCSGameRules_TerminateRound
+    alias:
+    - CCSGameRules::TerminateRound
+    - CGameRules::TerminateRound
+    - CGameRules_TerminateRound
+  - name: CCSGameRules_GoToIntermission
+    alias:
+    - CCSGameRules::GoToIntermission
+  - name: CEntityInstance_AcceptInput
+    alias:
+    - CEntityInstance::AcceptInput
+    - AcceptInput
+  - name: CEntityIdentity_AcceptInput
+    alias:
+    - CEntityIdentity::AcceptInput
+  - name: CEntityIdentity_AcceptInputInternal
+    alias:
+    - CEntityIdentity::AcceptInputInternal
+  - name: CEntityInstance_ScriptAcceptInput
+    alias:
+    - CEntityInstance::ScriptAcceptInput
+  - name: CEntityIdentity_SetEntityName
+    alias:
+    - CEntityIdentity::SetEntityName
+  - name: CEntitySystem_RemoveEntityFromNameMap
+    alias:
+    - CEntitySystem::RemoveEntityFromNameMap
+  - name: CEntitySystem_AddEntityToNameMap
+    alias:
+    - CEntitySystem::AddEntityToNameMap
+  - name: ScriptBinding_Entity_SetEntityName
+    alias:
+    - Entity::SetEntityName
+  - name: CBtActionCoordinatedBuy_Update
+    alias:
+    - CBtActionCoordinatedBuy::Update
+  - name: CCSPlayer_ItemServices_CanAcquire
+    alias:
+    - CCSPlayer_ItemServices::CanAcquire
+  - name: CCSPlayer_ItemServices_GiveDefaultItems
+    alias:
+    - CCSPlayer_ItemServices::GiveDefaultItems
+  - name: CCSPlayer_ItemServices_GiveNamedItem
+    alias:
+    - CCSPlayer_ItemServices::GiveNamedItem
+  - name: CCSPlayer_ItemServices_GiveNamedItemBool
+    alias:
+    - CCSPlayer_ItemServices::GiveNamedItemBool
+  - name: CCSPlayer_WeaponServices_CanUse
+    alias:
+    - CCSPlayer_WeaponServices::CanUse
+  - name: CCSPlayer_WeaponServices_PickupItem
+    alias:
+    - CCSPlayer_WeaponServices::PickupItem
+  - name: CCSPlayer_WeaponServices_EquipWeapon
+    alias:
+    - CCSPlayer_WeaponServices::EquipWeapon
+  - name: CCSPlayer_WeaponServices_Weapon_GetSlot
+    alias:
+    - CCSPlayer_WeaponServices_Weapon_GetSlot
+  - name: CCSPlayerController_ChangeTeam
+    alias:
+    - CCSPlayerController::ChangeTeam
+  - name: CCSPlayerController_GetThinkFunction
+    alias:
+    - CCSPlayerController::GetThinkFunction
+  - name: CCSPlayerController_PlayerForceTeamThink
+    alias:
+    - PlayerForceTeamThink
+    - CCSPlayerController::PlayerForceTeamThink
+  - name: CCSPlayerController_ResetForceTeamThink
+    alias:
+    - ResetForceTeamThink
+    - CCSPlayerController::ResetForceTeamThink
+  - name: CCSPlayerController_ResourceDataThink
+    alias:
+    - ResourceDataThink
+    - CCSPlayerController::ResourceDataThink
+  - name: CCSPlayerController_InventoryUpdateThink
+    alias:
+    - InventoryUpdateThink
+    - CCSPlayerController::InventoryUpdateThink
+  - name: g_CCSPlayerController_PlayerForceTeamThink
+    alias:
+    - g_CCSPlayerController::PlayerForceTeamThink
+  - name: g_CCSPlayerController_ResetForceTeamThink
+    alias:
+    - g_CCSPlayerController::ResetForceTeamThink
+  - name: g_CCSPlayerController_ResourceDataThink
+    alias:
+    - g_CCSPlayerController::ResourceDataThink
+  - name: g_CCSPlayerController_InventoryUpdateThink
+    alias:
+    - g_CCSPlayerController::InventoryUpdateThink
+  - name: CCSGameRules__sm_mapGcBanInformation
+    alias:
+    - CCSGameRules::sm_mapGcBanInformation
+  - name: CCSGameRules_BeginRound
+    alias:
+    - CCSGameRules::BeginRound
+  - name: CCSGameRules_PlayerSpawn
+    alias:
+    - CCSGameRules::PlayerSpawn
+  - name: CBasePlayerController_Respawn
+    alias:
+    - CBasePlayerController::Respawn
+  - name: CCSPlayerController_Respawn
+    alias:
+    - CCSPlayerController::Respawn
+  - name: CCSPlayerController_Connect
+    alias:
+    - CCSPlayerController::Connect
+  - name: CCSPlayerController_SwitchTeam
+    alias:
+    - CCSPlayerController::SwitchTeam
+  - name: CCSPlayerPawnBase_OnSetDormant
+    alias:
+    - CCSPlayerPawnBase::OnSetDormant
+  - name: CCSPlayerPawnBase_CheckForIdle
+    alias:
+    - CCSPlayerPawnBase::CheckForIdle
+  - name: CCSPlayerPawnBase_CheckForIdleInternal
+    alias:
+    - CCSPlayerPawnBase::CheckForIdleInternal
+  - name: CCSPlayerPawn_PostThink
+    alias:
+    - CCSPlayerPawnBase::PostThink
+    - CCSPlayerPawn::PostThink
+    - CCSPlayerPawnBase_PostThink
+    - CCSPlayerPawn_PostThink
+    - PostThink
+  - name: CCSPlayerPawn_OnSwitchWeapons
+    alias:
+    - CCSPlayerPawn::OnSwitchWeapons
+  - name: CCSPlayerPawn_ProcessSuicideAsKillReward
+    alias:
+    - CCSPlayerPawn::ProcessSuicideAsKillReward
+  - name: CGameRules_ClientSettingsChanged
+    alias:
+    - CGameRules::ClientSettingsChanged
+  - name: CGameRulesGameSystem_OnGameInit
+    alias:
+    - CGameRulesGameSystem::GameInit
+  - name: CGameRulesGameSystem_OnGameShutdown
+    alias:
+    - CGameRulesGameSystem::GameShutdown
+  - name: IGameSystem_OnGameShutdown
+    alias:
+    - IGameSystem::GameShutdown
+  - name: IGameSystem_OnGamePostInit
+    alias:
+    - IGameSystem::GamePostInit
+  - name: IGameSystem_OnGamePreShutdown
+    alias:
+    - IGameSystem::GamePreShutdown
+  - name: CMultiplayRules_ClientDisconnected
+    alias:
+    - CMultiplayRules::ClientDisconnected
+  - name: CSource2Server_Init
+    alias:
+    - CSource2Server::Init
+  - name: CSource2Server_ApplyGameSettings
+    alias:
+    - CSource2Server::ApplyGameSettings
+  - name: CSource2Server_WriteSignonMessages
+    alias:
+    - CSource2Server::WriteSignonMessages
+  - name: CSource2Server_GameCreateNetworkStringTables
+    alias:
+    - CSource2Server::GameCreateNetworkStringTables
+  - name: CSource2Server_GetMatchmakingGameData
+    alias:
+    - CSource2Server::GetMatchmakingGameData
+  - name: CSource2Server_GameServerSteamAPIActivated
+    alias:
+    - CSource2Server::GameServerSteamAPIActivated
+  - name: CSource2Server_GameServerSteamAPIDeactivated
+    alias:
+    - CSource2Server::GameServerSteamAPIDeactivated
+  - name: CSource2Server_OnHostNameChanged
+    alias:
+    - CSource2Server::OnHostNameChanged
+  - name: CSource2Server_GetLevelsFromSaveFile
+    alias:
+    - CSource2Server::GetLevelsFromSaveFile
+  - name: CSource2Server_ServerConVarChanged
+    alias:
+    - CSource2Server::ServerConVarChanged
+  - name: CSource2Server_Save
+    alias:
+    - CSource2Server::Save
+  - name: CSource2Server_Connect
+    alias:
+    - CSource2Server::Connect
+  - name: CSource2Server_PreShutdown
+    alias:
+    - CSource2Server::PreShutdown
+  - name: IAppSystem_Connect
+    alias:
+    - IAppSystem::Connect
+  - name: IAppSystem_PreShutdown
+    alias:
+    - IAppSystem::PreShutdown
+  - name: IVEngineServer2_ServerCommand
+    alias:
+    - IVEngineServer2::ServerCommand
+  - name: IVEngineServer2_IsDedicatedServer
+    alias:
+    - IVEngineServer2::IsDedicatedServer
+  - name: CSource2Server_Shutdown
+    alias:
+    - CSource2Server::Shutdown
+  - name: CGameEventManager_Shutdown
+    alias:
+    - CGameEventManager::Shutdown
+  - name: CLoopModeRegistry_UnregisterLoopModes
+    alias:
+    - CLoopModeRegistry::UnregisterLoopModes
+  - name: CEngineServiceRegistry_UnregisterEngineServices
+    alias:
+    - CEngineServiceRegistry::UnregisterEngineServices
+  - name: IEngineServiceMgr_UnregisterLoopMode
+    alias:
+    - IEngineServiceMgr::UnregisterLoopMode
+  - name: IEngineServiceMgr_UnregisterEngineService
+    alias:
+    - IEngineServiceMgr::UnregisterEngineService
+  - name: CSource2Server_GameFrame
+    alias:
+    - CSource2Server::GameFrame
+  - name: CGameEventManager_Init
+    alias:
+    - CGameEventManager::Init
+  - name: CTakeDamageInfo_HitGroupInfo
+    alias:
+    - CTakeDamageInfo::HitGroupInfo
+    - CTakeDamageInfo::HitGroup
+    - CTakeDamageInfo_HitGroup
+  - name: CEntitySystem_RegisterEntityClass
+    alias:
+    - CEntitySystem::RegisterEntityClass
+  - name: CEntitySystem_CreateEntityByName
+    alias:
+    - CEntitySystem::CreateEntityByName
+  - name: CEntitySystem_CreateEntity
+    alias:
+    - CEntitySystem::CreateEntity
+  - name: CEntitySystem_AddEntityToEntityDataBase
+    alias:
+    - CEntitySystem::AddEntityToEntityDataBase
+  - name: CEntitySystem_OnAddEntity
+    alias:
+    - CEntitySystem::OnAddEntity
+  - name: CEntitySystem_OnEntityParentChanged
+    alias:
+    - CEntitySystem::OnEntityParentChanged
+  - name: CEntitySystem_PrecacheEntity
+    alias:
+    - CEntitySystem::PrecacheEntity
+  - name: CEntitySystem_InvokePrecacheCallback
+    alias:
+    - CEntitySystem::InvokePrecacheCallback
+  - name: CEntitySystem_DestroyEntity
+    alias:
+    - CEntitySystem::DestroyEntity
+  - name: CConcreteEntityList_AllocEntity
+    alias:
+    - CConcreteEntityList::AllocEntity
+  - name: CEntitySystem_ConstructEntity
+    alias:
+    - CEntitySystem::ConstructEntity
+  - name: CEntitySystem_DoConstructEntity
+    alias:
+    - CEntitySystem::DoConstructEntity
+  - name: CEntitySystem_GetSpawnGroupWorldId
+    alias:
+    - CEntitySystem::GetSpawnGroupWorldId
+  - name: CEntitySystem_FindClassByDesignName
+    alias:
+    - CEntitySystem::FindClassByDesignName
+  - name: CEntitySystem_m_EntityList
+    alias:
+    - CEntitySystem::m_EntityList
+  - name: CEntitySystem_m_entityNames
+    alias:
+    - CEntitySystem::m_entityNames
+  - name: CEntitySystem_m_entityComponentHelpers
+    alias:
+    - CEntitySystem::m_entityComponentHelpers
+  - name: CEntitySystem_m_DataDescKeyUnserializers
+    alias:
+    - CEntitySystem::m_DataDescKeyUnserializers
+  - name: CEntitySystem_m_EntityPostSpawnCallback
+    alias:
+    - CEntitySystem::m_EntityPostSpawnCallback
+  - name: CEntityIdentity_FreeAttributes
+    alias:
+    - CEntityIdentity::FreeAttributes
+  - name: CConcreteEntityList_FreeEntity
+    alias:
+    - CConcreteEntityList::FreeEntity
+  - name: UTIL_CreateEntityByName
+    alias:
+    - CreateEntityByName
+  - name: CBaseEntity_DispatchSpawn
+    alias:
+    - CBaseEntity::DispatchSpawn
+    - DispatchSpawn
+  - name: CEntitySystem_QueueSpawnEntity
+    alias:
+    - CEntitySystem::QueueSpawnEntity
+  - name: CEntitySystem_HelperExecuteQueuedSpawn
+    alias:
+    - CEntitySystem::HelperExecuteQueuedSpawn
+  - name: CEntitySystem_SortEntities
+    alias:
+    - CEntitySystem::SortEntities
+  - name: CGameEntitySystem_SortEntities
+    alias:
+    - CGameEntitySystem::SortEntities
+  - name: CEntitySystem_InstallCreationWrapperCallbacks
+    alias:
+    - CEntitySystem::InstallCreationWrapperCallbacks
+  - name: CEntitySystem_ExecuteQueuedCreation
+    alias:
+    - CEntitySystem::ExecuteQueuedCreation
+  - name: CEntitySystem_ExecuteQueuedActivates
+    alias:
+    - CEntitySystem::ExecuteQueuedActivates
+  - name: CEntitySystem_ExecuteQueuedPostDataUpdateAndActivates
+    alias:
+    - CEntitySystem::ExecuteQueuedPostDataUpdateAndActivates
+  - name: CEntitySystem_Activate
+    alias:
+    - CEntitySystem::Activate
+  - name: CEntitySystem_PostDataUpdate
+    alias:
+    - CEntitySystem::PostDataUpdate
+  - name: CBaseEntity_NetworkStateChangedLog
+    alias:
+    - CBaseEntity::NetworkStateChangedLog
+  - name: CBaseEntity_NetworkStateChanged
+    alias:
+    - CBaseEntity::NetworkStateChanged
+  - name: CBaseEntity_FullEdictChanged
+    alias:
+    - CBaseEntity::FullEdictChanged
+  - name: CBaseEntity_m_NetworkTransmitComponent
+    alias:
+    - CBaseEntity::m_NetworkTransmitComponent
+  - name: CNetworkTransmitComponent_StateChanged
+    alias:
+    - CNetworkTransmitComponent::StateChanged
+  - name: CNetworkTransmitComponent_m_nStateFlags
+    alias:
+    - CNetworkTransmitComponent::m_nStateFlags
+  - name: CInferno_InfernoThink
+    alias:
+    - CInferno::InfernoThink
+  - name: CPhysExplosion_Activate
+    alias:
+    - CPhysExplosion::Activate
+  - name: CPhysExplosion_Explode
+    alias:
+    - CPhysExplosion::Explode
+  - name: UTIL_SayTextFilter2
+    alias:
+    - UTIL_SayText2Filter
+  - name: CCSWeaponBase_ItemPostFrame_ProcessReloadAction
+    alias:
+    - CCSWeaponBase::ItemPostFrame::ProcessReloadAction
+  - name: CCSPlayer_WeaponServices_HandleDropWeapon
+    alias:
+    - CCSPlayer_WeaponServices::HandleDropWeapon
+  - name: CCSPlayer_UseServices_BumpWeapon
+    alias:
+    - CCSPlayer_UseServices::BumpWeapon
+  - name: CCSPlayerPawn_HandleDropWeapon
+    alias:
+    - CCSPlayerPawn::HandleDropWeapon
+  - name: CCSPlayerPawn_ClientCommand
+    alias:
+    - CCSPlayerPawn::ClientCommand
+  - name: CCSPlayerPawn_SprayPaint
+    alias:
+    - CCSPlayerPawn::SprayPaint
+  - name: CEntitySpawner_CPlayerSprayDecal_Spawn
+    alias:
+    - CEntitySpawner<CPlayerSprayDecal>::Spawn
+  - name: CEntityKeyValuesAllocator_GetTempBuffer
+    alias:
+    - CEntityKeyValuesAllocator::GetTempBuffer
+  - name: CEntityKeyValues_LoadFromContext
+    alias:
+    - CEntityKeyValues::LoadFromContext
+  - name: CEntityKeyValues_Initialized
+    alias:
+    - CEntityKeyValues::Initialized
+  - name: CEntitySystem_m_nEntityKeyValuesAllocatorRefCount
+    alias:
+    - CEntitySystem::m_nEntityKeyValuesAllocatorRefCount
+  - name: CEntitySystem_AddRefKeyValues
+    alias:
+    - CEntitySystem::AddRefKeyValues
+  - name: CEntitySystem_ReleaseKeyValues
+    alias:
+    - CEntitySystem::ReleaseKeyValues
+  - name: CCSPlayerController_HandleCommandDrop
+    alias:
+    - CCSPlayerController::HandleCommandDrop
+  - name: IGameSystem_InitAllSystems
+    alias:
+    - IGameSystem::InitAllSystems
+  - name: IGameSystem_LoopInitAllSystems
+    alias:
+    - IGameSystem::LoopInitAllSystems
+  - name: IGameSystem_LoopPostInitAllSystems
+    alias:
+    - IGameSystem::LoopPostInitAllSystems
+  - name: IGameSystem_PostInit
+    alias:
+    - IGameSystem::PostInit
+  - name: IGameSystemFactory_PostInit
+    alias:
+    - IGameSystemFactory::PostInit
+  - name: IGameSystemFactory_GetStaticGameSystem
+    alias:
+    - IGameSystemFactory::GetStaticGameSystem
+  - name: IGameSystem_InitAllSystems_pFirst
+    alias:
+    - IGameSystem::InitAllSystems::pFirst
+    - IGameSystem::InitAllSystems->pFirst
+  - name: IGameSystem_LoopPostInitAllSystems_pEventDispatcher
+    alias:
+    - IGameSystem::LoopPostInitAllSystems::pEventDispatcher
+    - IGameSystem::LoopPostInitAllSystems->pEventDispatcher
+  - name: IGameSystem_LoopDestroyAllSystems_s_GameSystems
+    alias:
+    - IGameSystem::LoopDestroyAllSystems::s_GameSystems
+    - IGameSystem::LoopDestroyAllSystems->s_GameSystems
+  - name: CSource2GameEntities_CheckTransmit
+    alias:
+    - CSource2GameEntities::CheckTransmit
+    - ISource2GameEntities::CheckTransmit
+    - ISource2GameEntities_CheckTransmit
+    - CheckTransmit
+  - name: CBaseEntity_EmitSoundFilter
+    alias:
+    - CBaseEntity::EmitSoundFilter
+  - name: CBaseEntity_ScriptInputKill
+    alias:
+    - CBaseEntity::ScriptInputKill
+  - name: CBaseEntity_ScriptGetForward
+    alias:
+    - CBaseEntity::ScriptGetForward
+  - name: CBaseEntity_ScriptGetRight
+    alias:
+    - CBaseEntity::ScriptGetRight
+  - name: CBaseEntity_ScriptGetLeft
+    alias:
+    - CBaseEntity::ScriptGetLeft
+  - name: CBaseEntity_ScriptGetUp
+    alias:
+    - CBaseEntity::ScriptGetUp
+  - name: CBaseEntity_ScriptGetModelName
+    alias:
+    - CBaseEntity::ScriptGetModelName
+  - name: CBaseEntity_ScriptGetMoveParent
+    alias:
+    - CBaseEntity::ScriptGetMoveParent
+  - name: CBaseEntity_ScriptGetRootMoveParent
+    alias:
+    - CBaseEntity::ScriptGetRootMoveParent
+  - name: CBaseEntity_ScriptFirstMoveChild
+    alias:
+    - CBaseEntity::ScriptFirstMoveChild
+  - name: CBaseEntity_ScriptNextMovePeer
+    alias:
+    - CBaseEntity::ScriptNextMovePeer
+  - name: CBaseEntity_ScriptGetOwnerEntity
+    alias:
+    - CBaseEntity::ScriptGetOwnerEntity
+  - name: CBaseEntity_Script_GetChildren
+    alias:
+    - CBaseEntity::Script_GetChildren
+  - name: CBaseEntity_ScriptSetParent
+    alias:
+    - CBaseEntity::ScriptSetParent
+  - name: CBaseEntity_ScriptEyePosition
+    alias:
+    - CBaseEntity::ScriptEyePosition
+  - name: CBaseEntity_ScriptSetAngles
+    alias:
+    - CBaseEntity::ScriptSetAngles
+  - name: CBaseEntity_ScriptSetAbsAngles
+    alias:
+    - CBaseEntity::ScriptSetAbsAngles
+  - name: CBaseEntity_ScriptGetAngles
+    alias:
+    - CBaseEntity::ScriptGetAngles
+  - name: CBaseEntity_ScriptEyeAngles
+    alias:
+    - CBaseEntity::ScriptEyeAngles
+  - name: CBaseEntity_ScriptSetOrigin
+    alias:
+    - CBaseEntity::ScriptSetOrigin
+  - name: CBaseEntity_ScriptSetLocalAngles
+    alias:
+    - CBaseEntity::ScriptSetLocalAngles
+  - name: CBaseEntity_ScriptGetLocalAngles
+    alias:
+    - CBaseEntity::ScriptGetLocalAngles
+  - name: CBaseEntity_ScriptSetLocalOrigin
+    alias:
+    - CBaseEntity::ScriptSetLocalOrigin
+  - name: CBaseEntity_ScriptGetLocalOrigin
+    alias:
+    - CBaseEntity::ScriptGetLocalOrigin
+  - name: CBaseEntity_ScriptTransformPointEntityToWorld
+    alias:
+    - CBaseEntity::ScriptTransformPointEntityToWorld
+  - name: CBaseEntity_ScriptTransformPointWorldToEntity
+    alias:
+    - CBaseEntity::ScriptTransformPointWorldToEntity
+  - name: CBaseEntity_ScriptSetForward
+    alias:
+    - CBaseEntity::ScriptSetForward
+  - name: CBaseEntity_ScriptGetBoundingMins
+    alias:
+    - CBaseEntity::ScriptGetBoundingMins
+  - name: CBaseEntity_ScriptGetBoundingMaxs
+    alias:
+    - CBaseEntity::ScriptGetBoundingMaxs
+  - name: CBaseEntity_ScriptGetBounds
+    alias:
+    - CBaseEntity::ScriptGetBounds
+  - name: CBaseEntity_ScriptGetLocalAngularVelocity_OBSOLETE
+    alias:
+    - CBaseEntity::ScriptGetLocalAngularVelocity_OBSOLETE
+  - name: CBaseEntity_ScriptSetLocalAngularVelocity_OBSOLETE
+    alias:
+    - CBaseEntity::ScriptSetLocalAngularVelocity_OBSOLETE
+  - name: CBaseEntity_ScriptAddEffects
+    alias:
+    - CBaseEntity::ScriptAddEffects
+  - name: CBaseEntity_ScriptRemoveEffects
+    alias:
+    - CBaseEntity::ScriptRemoveEffects
+  - name: CBaseEntity_ScriptSetAttributeFloatValue
+    alias:
+    - CBaseEntity::ScriptSetAttributeFloatValue
+  - name: CBaseEntity_ScriptGetAttributeFloatValue
+    alias:
+    - CBaseEntity::ScriptGetAttributeFloatValue
+  - name: CBaseEntity_ScriptSetAttributeIntValue
+    alias:
+    - CBaseEntity::ScriptSetAttributeIntValue
+  - name: CBaseEntity_ScriptGetAttributeIntValue
+    alias:
+    - CBaseEntity::ScriptGetAttributeIntValue
+  - name: CBaseEntity_ScriptHasAttribute
+    alias:
+    - CBaseEntity::ScriptHasAttribute
+  - name: CBaseEntity_ScriptDeleteAttribute
+    alias:
+    - CBaseEntity::ScriptDeleteAttribute
+  - name: CBaseEntity_GetScriptOwnerEntity
+    alias:
+    - CBaseEntity::GetScriptOwnerEntity
+  - name: CBaseEntity_SetScriptOwnerEntity
+    alias:
+    - CBaseEntity::SetScriptOwnerEntity
+  - name: CBaseEntity_ScriptSetEntityName
+    alias:
+    - CBaseEntity::ScriptSetEntityName
+  - name: CBaseEntity_ScriptGetMass
+    alias:
+    - CBaseEntity::ScriptGetMass
+  - name: CBaseEntity_ScriptSetMass
+    alias:
+    - CBaseEntity::ScriptSetMass
+  - name: CBaseEntity_ScriptGetSpawnGroupHandle
+    alias:
+    - CBaseEntity::ScriptGetSpawnGroupHandle
+  - name: CBaseEntity_GetAbsAngles
+    alias:
+    - CBaseEntity::GetAbsAngles
+  - name: CBaseEntity_Script_GetTeamNumber
+    alias:
+    - CBaseEntity::Script_GetTeamNumber
+  - name: CBaseEntity_Script_FollowEntity
+    alias:
+    - CBaseEntity::Script_FollowEntity
+  - name: CBaseEntity_Script_FollowEntityMerge
+    alias:
+    - CBaseEntity::Script_FollowEntityMerge
+  - name: CBaseEntity_Script_Trigger
+    alias:
+    - CBaseEntity::Script_Trigger
+  - name: CBaseEntity_Script_SetContextThink
+    alias:
+    - CBaseEntity::Script_SetContextThink
+  - name: CBaseEntity_AddContextForScript
+    alias:
+    - CBaseEntity::AddContextForScript
+  - name: CBaseEntity_AddContextForScriptNumeric
+    alias:
+    - CBaseEntity::AddContextForScriptNumeric
+  - name: CBaseEntity_GetContextForScript
+    alias:
+    - CBaseEntity::GetContextForScript
+  - name: CBaseEntity_ScriptGatherCriteria
+    alias:
+    - CBaseEntity::ScriptGatherCriteria
+  - name: CBaseEntity_Script_TakeDamage
+    alias:
+    - CBaseEntity::Script_TakeDamage
+  - name: CBaseEntity_SetGravityScale
+    alias:
+    - CBaseEntity::SetGravityScale
+  - name: CBaseEntity_SetAbsVelocity
+    alias:
+    - CBaseEntity::SetAbsVelocity
+  - name: CBaseEntity_GetAbsVelocity
+    alias:
+    - CBaseEntity::GetAbsVelocity
+  - name: CBaseEntity_Script_ApplyLocalAngularVelocityImpulse
+    alias:
+    - CBaseEntity::Script_ApplyLocalAngularVelocityImpulse
+  - name: CBaseEntity_GetLocalAngularVelocity_OBSOLETE
+    alias:
+    - CBaseEntity::GetLocalAngularVelocity_OBSOLETE
+  - name: CBaseEntity_ScriptEmitSoundParams
+    alias:
+    - CBaseEntity::ScriptEmitSoundParams
+    - CBaseEntity::EmitSoundParams
+    - CBaseEntity_EmitSoundParams
+  - name: CBaseEntity_ScriptStopSound
+    alias:
+    - CBaseEntity::ScriptStopSound
+  - name: CBaseEntity_ScriptSoundDuration
+    alias:
+    - CBaseEntity::ScriptSoundDuration
+  - name: CBaseEntity_ScriptGetAbsOrigin
+    alias:
+    - CBaseEntity::ScriptGetAbsOrigin
+  - name: CBaseEntity_Precache
+    alias:
+    - CBaseEntity::Precache
+    - Precache
+  - name: CEnvEntityIgniter_Precache
+    alias:
+    - CEnvEntityIgniter::Precache
+  - name: CEnvShake_Spawn
+    alias:
+    - CEnvShake::Spawn
+  - name: CBaseEntity_SetMoveType
+    alias:
+    - CBaseEntity::SetMoveType
+  - name: CBasePlayerPawn_CommitSuicide
+    alias:
+    - CBasePlayerPawn::CommitSuicide
+    - CommitSuicide
+  - name: CBaseCombatCharacter_OnKilled
+    alias:
+    - CBaseCombatCharacter::OnKilled
+  - name: CCSPlayerPawn_Event_KilledOther
+    alias:
+    - CCSPlayerPawn::Event_KilledOther
+  - name: CCSPlayerPawn_Event_Killed
+    alias:
+    - CCSPlayerPawn::Event_Killed
+  - name: CBasePlayerPawn_Event_Killed
+    alias:
+    - CBasePlayerPawn::Event_Killed
+  - name: ScriptBinding_CSPlayerPawn_DestroyWeapon
+    alias:
+    - CSPlayerPawn::DestroyWeapon
+  - name: CBasePlayerPawn_RemovePlayerItem
+    alias:
+    - CBasePlayerPawn::RemovePlayerItem
+  - name: CBasePlayerPawn_DropActivePlayerWeapon
+    alias:
+    - CBasePlayerPawn::DropActivePlayerWeapon
+  - name: CBasePlayerPawn_GetEyePosition
+    alias:
+    - CBasePlayerPawn::GetEyePosition
+  - name: CBaseEntity_GetEyePosition
+    alias:
+    - CBaseEntity::GetEyePosition
+  - name: CCSBotManager_BotPlaceCommand
+    alias:
+    - CCSBotManager::BotPlace
+  - name: CBasePlayerPawn_EyeVectors
+    alias:
+    - CBasePlayerPawn::EyeVectors
+  - name: CBasePlayerPawn_GetEyeAngles
+    alias:
+    - CBasePlayerPawn::GetEyeAngles
+  - name: CBaseEntity_GetEyeAngles
+    alias:
+    - CBaseEntity::GetEyeAngles
+  - name: CCSBot_Upkeep
+    alias:
+    - CCSBot::Upkeep
+  - name: CCSBot_SetState
+    alias:
+    - CCSBot::SetState
+  - name: CCSBot_UpdatePathMovement
+    alias:
+    - CCSBot::UpdatePathMovement
+  - name: CCSBot_PrintIfWatched
+    alias:
+    - CCSBot::PrintIfWatched
+  - name: HideState_OnUpdate
+    alias:
+    - HideState::OnUpdate
+  - name: CCSBot_Attack
+    alias:
+    - CCSBot::Attack
+  - name: CCSBot_MoveTo
+    alias:
+    - CCSBot::MoveTo
+  - name: CCSBot_InhibitLookAround
+    alias:
+    - CCSBot::InhibitLookAround
+  - name: CCSBot_SetDisposition
+    alias:
+    - CCSBot::SetDisposition
+  - name: CCSBot_Idle
+    alias:
+    - CCSBot::Idle
+  - name: CCSBot_ComputePath
+    alias:
+    - CCSBot::ComputePath
+  - name: CBaseEntity_IsAlive
+    alias:
+    - CBaseEntity::IsAlive
+  - name: CBaseEntity_SetOwner
+    alias:
+    - CBaseEntity::SetOwner
+  - name: CBaseEntity_CollisionRulesChanged
+    alias:
+    - CBaseEntity::CollisionRulesChanged
+    - CollisionRulesChanged
+  - name: CBaseEntity_Use
+    alias:
+    - CBaseEntity::Use
+  - name: CGameSceneNode_PostSpawnKeyValues
+    alias:
+    - CGameSceneNode::PostSpawnKeyValues
+  - name: CBaseEntity_Spawn
+    alias:
+    - CBaseEntity::Spawn
+    - Spawn
+  - name: CBaseEntity_SpawnRadius
+    alias:
+    - CBaseEntity::SpawnRadius
+  - name: CCSPlayer_ItemServices_DropActivePlayerWeapon
+    alias:
+    - CCSPlayer_ItemServices::DropActivePlayerWeapon
+  - name: CCSPlayer_WeaponServices_DropWeapon
+    alias:
+    - CCSPlayer_WeaponServices::DropWeapon
+  - name: CCSPlayer_ItemServices_RemoveWeapons
+    alias:
+    - CCSPlayer_ItemServices::RemoveWeapons
+  - name: CCSPlayer_WeaponServices_SelectItem
+    alias:
+    - CCSPlayer_WeaponServices::SelectItem
+  - name: CEntFireOutputAutoCompletionFunctor_FireOutput
+    alias:
+    - CEntFireOutputAutoCompletionFunctor::FireOutput
+  - name: CEntityInstance_FindOutputsByName
+    alias:
+    - CEntityInstance::FindOutputsByName
+  - name: CEntityInstance_ScriptEntityIO
+    alias:
+    - CEntityInstance::ScriptEntityIO
+  - name: CEntityIOOutput_FireOutputInternal
+    alias:
+    - CEntityIOOutput::FireOutputInternal
+  - name: CEntitySystem_AddEntityIOEvent
+    alias:
+    - CEntitySystem::AddEntityIOEvent
+  - name: CEntitySystem_AddEntityIOEvent2
+    alias:
+    - CEntitySystem::AddEntityIOEvent2
+  - name: CEntitySystem_AddEntityIOEventBuildStruct
+    alias:
+    - CEntitySystem::AddEntityIOEventBuildStruct
+  - name: CEntitySystem_AddEntityIOEventToQueue
+    alias:
+    - CEntitySystem::AddEntityIOEventToQueue
+  - name: CEntitySystem_m_EventQueue
+    alias:
+    - CEntitySystem::m_EventQueue
+  - name: CGameEntitySystem_FindEntityByClassName
+    alias:
+    - CGameEntitySystem::FindEntityByClassName
+  - name: CGameEntitySystem_FindEntityByName
+    alias:
+    - CGameEntitySystem::FindEntityByName
+  - name: CGameEntitySystem_OnAddEntity
+    alias:
+    - CGameEntitySystem::OnAddEntity
+  - name: CGameEntitySystem_BuildResourceManifest_ManifestNameOrGroupName
+    alias:
+    - CGameEntitySystem::BuildResourceManifest_ManifestNameOrGroupName
+  - name: CGameEntitySystem_BuildResourceManifest_KeyValuesVectors
+    alias:
+    - CGameEntitySystem::BuildResourceManifest_KeyValuesVectors
+  - name: CGameEntitySystem_FindEntityProcedural
+    alias:
+    - CGameEntitySystem::FindEntityProcedural
+  - name: CGameEntitySystem_Spawn
+    alias:
+    - CGameEntitySystem::Spawn
+  - name: CEntitySystem_Spawn
+    alias:
+    - CEntitySystem::Spawn
+  - name: CBodyGameSystem_SpawnDependencyIsland
+    alias:
+    - CBodyGameSystem::SpawnDependencyIsland
+  - name: CGameEntitySystem_CheckGlobalState
+    alias:
+    - CGameEntitySystem::CheckGlobalState
+  - name: IGameSystem_OnBuildGameSessionManifest
+    alias:
+    - IGameSystem::BuildGameSessionManifest
+  - name: IGameSystem_OnServerPreEntityThink
+    alias:
+    - IGameSystem::OnServerPreEntityThink
+  - name: IGameSystem_OnServerPostEntityThink
+    alias:
+    - IGameSystem::OnServerPostEntityThink
+  - name: IGameSystem_OnServerPreClientUpdate
+    alias:
+    - IGameSystem::ServerPreClientUpdate
+  - name: IGameSystem_OnServerAdvanceTick
+    alias:
+    - IGameSystem::ServerAdvanceTick
+  - name: IGameSystem_OnServerGamePostSimulate
+    alias:
+    - IGameSystem::ServerGamePostSimulate
+  - name: IGameSystem_OnServerPostAdvanceTick
+    alias:
+    - IGameSystem::ServerPostAdvanceTick
+  - name: IGameSystem_OnServerPreBeginAsyncPostTickWork
+    alias:
+    - IGameSystem::OnServerPreBeginAsyncPostTickWork
+  - name: IGameSystem_OnServerBeginAsyncPostTickWork
+    alias:
+    - IGameSystem::OnServerBeginAsyncPostTickWork
+  - name: IGameSystem_OnServerPreEndAsyncPostTickWork
+    alias:
+    - IGameSystem::OnServerPreEndAsyncPostTickWork
+  - name: IGameSystem_OnServerPostEndAsyncPostTickWork
+    alias:
+    - IGameSystem::OnServerPostEndAsyncPostTickWork
+  - name: IGameSystem_OnSaveGame
+    alias:
+    - IGameSystem::OnSaveGame
+  - name: IGameSystem_OnRestoreGame
+    alias:
+    - IGameSystem::OnRestoreGame
+  - name: IGameSystem_OnOutOfGameFrameBoundary
+    alias:
+    - IGameSystem::OnOutOfGameFrameBoundary
+  - name: CSource2GameClients_StartHLTVServer
+    alias:
+    - CSource2GameClients::StartHLTVServer
+  - name: LegacyGameEventListener
+    alias:
+    - GetLegacyGameEventListener
+  - name: CPhysicsGameSystem_ProcessContactEvents
+    alias:
+    - CPhysicsGameSystem::ProcessContactEvents
+  - name: CBaseEntity_PhysicsDispatchStartTouch
+    alias:
+    - CBaseEntity::PhysicsDispatchStartTouch
+  - name: CBaseEntity_PhysicsNotifyOtherOfEndTouch
+    alias:
+    - CBaseEntity::PhysicsNotifyOtherOfEndTouch
+  - name: CBaseEntity_PhysicsDispatchTouch
+    alias:
+    - CBaseEntity::PhysicsDispatchTouch
+  - name: CBaseEntity_StartTouch
+    alias:
+    - CBaseEntity::StartTouch
+    - StartTouch
+  - name: CBaseEntity_Touch
+    alias:
+    - CBaseEntity::Touch
+    - Touch
+  - name: CBaseEntity_EndTouch
+    alias:
+    - CBaseEntity::EndTouch
+    - EndTouch
+  - name: IVPhys2World_GetTouchingList
+    alias:
+    - IVPhys2World::GetTouchingList
+    - CVPhys2World::GetTouchingList
+  - name: CTriggerPush_Touch
+    alias:
+    - CTriggerPush::Touch
+    - TriggerPush_Touch
+  - name: CPhysBox_Use
+    alias:
+    - CPhysBox::Use
+  - name: CBaseEntity_SetGroundEntity
+    alias:
+    - SetGroundEntity
+  - name: CBaseEntity_GetHammerUniqueId
+    alias:
+    - CBaseEntity::GetHammerUniqueId
+    - GetHammerUniqueId
+  - name: CBaseEntity_IsPlayerPawn
+    alias:
+    - CBaseEntity::IsPlayerPawn
+    - IsEntityPawn
+    - IsPlayerPawn
+  - name: CBaseEntity_IsPlayerController
+    alias:
+    - CBaseEntity::IsPlayerController
+    - IsEntityController
+    - IsPlayerController
+  - name: CBaseTrigger_StartTouch
+    alias:
+    - CBaseTrigger::StartTouch
+  - name: CBaseTrigger_EndTouch
+    alias:
+    - CBaseTrigger::EndTouch
+  - name: CBaseTrigger_PassesTriggerFilters
+    alias:
+    - CBaseTrigger::PassesTriggerFilters
+    - PassesTriggerFilters
+  - name: CBaseAnimGraph_GetAnimationController
+    alias:
+    - CBaseAnimGraph::GetAnimationController
+  - name: CBaseAnimGraph_m_skeletonInstance
+    alias:
+    - CBaseAnimGraph::m_skeletonInstance
+  - name: CGameSceneNode_PreInstanceSpawn
+    alias:
+    - CGameSceneNode::PreInstanceSpawn
+  - name: CGameSceneNode_GetSkeletonInstance
+    alias:
+    - CGameSceneNode::GetSkeletonInstance
+  - name: CSkeletonInstance_m_animationController
+    alias:
+    - CSkeletonInstance::m_animationController
+  - name: CSkeletonInstance_PostDataUpdate
+    alias:
+    - CSkeletonInstance::PostDataUpdate
+  - name: CGameSceneNode_PostDataUpdate
+    alias:
+    - CGameSceneNode::PostDataUpdate
+  - name: CGameSceneNode_UpdateEntityForHierarchyChange
+    alias:
+    - CGameSceneNode::UpdateEntityForHierarchyChange
+  - name: CPointTeleportAPI_TeleportEntityInternal
+    alias:
+    - CPointTeleportAPI::TeleportEntityInternal
+  - name: CBaseEntity_Teleport
+    alias:
+    - CBaseEntity::Teleport
+  - name: CPointTeleport_Activate
+    alias:
+    - CPointTeleport::Activate
+  - name: CBaseEntity_Activate
+    alias:
+    - CBaseEntity::Activate
+    - Activate
+  - name: CBaseEntity_DrawDebugTextOverlays
+    alias:
+    - CBaseEntity::DrawDebugTextOverlays
+  - name: CRagdollProp_DrawEntityDebugOverlays
+    alias:
+    - CRagdollProp::DrawEntityDebugOverlays
+  - name: CBaseEntity_ReloadPrivateScripts
+    alias:
+    - CBaseEntity::ReloadPrivateScripts
+  - name: CCheckTransmitInfo_m_nPlayerSlot
+    alias:
+    - CCheckTransmitInfo::m_nPlayerSlot
+    - CheckTransmitPlayerSlot
+  - name: CDedicatedServerWorkshopManager_SwitchToWorkshopMapGroup
+    alias:
+    - CDedicatedServerWorkshopManager::SwitchToWorkshopMapGroup
+  - name: IGameTypes_CreateWorkshopMapGroup
+    alias:
+    - IGameTypes::CreateWorkshopMapGroup
+  - name: CSpawnGroupMgrGameSystem_GetSpawnGroups
+    alias:
+    - CSpawnGroupMgrGameSystem::GetSpawnGroups
+    - GetSpawnGroups
+  - name: CSpawnGroupMgrGameSystem_DumpSpawnGroups
+    alias:
+    - CSpawnGroupMgrGameSystem::DumpSpawnGroups
+    - DumpSpawnGroups
+  - name: CSpawnGroupMgrGameSystem_SpawnGroupSpawnEntitiesInternal
+    alias:
+    - CSpawnGroupMgrGameSystem::SpawnGroupSpawnEntitiesInternal
+    - SpawnGroupSpawnEntitiesInternal
+  - name: IGameSystem_OnPreSpawnGroupLoad
+    alias:
+    - IGameSystem::OnPreSpawnGroupLoad
+  - name: IGameSystem_OnPostSpawnGroupLoad
+    alias:
+    - IGameSystem::OnPostSpawnGroupLoad
+  - name: CSpawnGroupMgrGameSystem_SpawnGroupShutdown
+    alias:
+    - CSpawnGroupMgrGameSystem::SpawnGroupShutdown
+    - SpawnGroupShutdown
+  - name: CSpawnGroupMgrGameSystem_SpawnGroupActuallyShutdown
+    alias:
+    - CSpawnGroupMgrGameSystem::SpawnGroupActuallyShutdown
+    - SpawnGroupActuallyShutdown
+  - name: IGameSystem_OnPreSpawnGroupUnload
+    alias:
+    - IGameSystem::OnPreSpawnGroupUnload
+  - name: IGameSystem_OnPostSpawnGroupUnload
+    alias:
+    - IGameSystem::OnPostSpawnGroupUnload
+  - name: CLoadingSpawnGroup_CreateEntityToSpawn
+    alias:
+    - CLoadingSpawnGroup::CreateEntityToSpawn
+  - name: CSpawnGroupMgrGameSystem_OnSpawnGroupPrecache
+    alias:
+    - CSpawnGroupMgrGameSystem::OnSpawnGroupPrecache
+    - SpawnGroupPrecache
+  - name: CSpawnGroupMgrGameSystem_AllocateSpawnGroup
+    alias:
+    - CSpawnGroupMgrGameSystem::AllocateSpawnGroup
+  - name: CSpawnGroupMgrGameSystem_ReleaseSpawnGroup
+    alias:
+    - CSpawnGroupMgrGameSystem::ReleaseSpawnGroup
+  - name: CSpawnGroupMgrGameSystem_SpawnGroupInit
+    alias:
+    - CSpawnGroupMgrGameSystem::SpawnGroupInit
+  - name: CSpawnGroupMgrGameSystem_CreateLoadingSpawnGroup
+    alias:
+    - CSpawnGroupMgrGameSystem::CreateLoadingSpawnGroup
+  - name: CSpawnGroupMgrGameSystem_CreateLoadingSpawnGroupForSaveFile
+    alias:
+    - CSpawnGroupMgrGameSystem::CreateLoadingSpawnGroupForSaveFile
+  - name: CSpawnGroupMgrGameSystem_SpawnGroupSpawnEntities
+    alias:
+    - CSpawnGroupMgrGameSystem::SpawnGroupSpawnEntities
+  - name: CSpawnGroupMgrGameSystem_SetActiveSpawnGroup
+    alias:
+    - CSpawnGroupMgrGameSystem::SetActiveSpawnGroup
+  - name: CSpawnGroupMgrGameSystem_UnloadSpawnGroup
+    alias:
+    - CSpawnGroupMgrGameSystem::UnloadSpawnGroup
+  - name: CSpawnGroupMgrGameSystem_SaveGame_Start
+    alias:
+    - CSpawnGroupMgrGameSystem::SaveGame_Start
+  - name: IGameSystem_OnSpawnGroupPrecache
+    alias:
+    - IGameSystem::OnSpawnGroupPrecache
+  - name: IGameSystem_OnSpawnGroupUncache
+    alias:
+    - IGameSystem::OnSpawnGroupUncache
+  - name: CBaseFilter_InputTestActivator
+    alias:
+    - CBaseFilter::InputTestActivator
+  - name: CGamePlayerEquip_InputTriggerForAllPlayers
+    alias:
+    - CGamePlayerEquip::InputTriggerForAllPlayers
+  - name: CGamePlayerEquip_InputTriggerForActivatedPlayer
+    alias:
+    - CGamePlayerEquip::InputTriggerForActivatedPlayer
+  - name: CNavMesh_GetNearestNavArea
+    alias:
+    - CNavMesh::GetNearestNavArea
+  - name: CCSBotManager_AddBot
+    alias:
+    - CCSBotManager::AddBot
+  - name: BotAdd_CommandHandler
+    alias:
+    - CCSBotManager::BotAddCommand
+  - name: BotKill_CommandHandler
+    alias:
+    - CCSBotManager::BotKillCommand
+  - name: EntInfo_CommandHandler
+    alias:
+    - CC_Ent_Info
+  - name: CEntitySystem_DestroyEntityImmediate
+    alias:
+    - CEntitySystem::DestroyEntityImmediate
+  - name: CEntitySystem_OnRemoveEntityFromDatabase
+    alias:
+    - CEntitySystem::OnRemoveEntityFromDatabase
+  - name: CEntitySystem_DoDestructEntity
+    alias:
+    - CEntitySystem::DoDestructEntity
+  - name: CEntitySystem_UpdateOnRemove
+    alias:
+    - CEntitySystem::UpdateOnRemove
+  - name: ClientPrintToController
+    alias:
+    - ClientPrint
+  - name: CCSBotManager_AddBot_BotNavIgnore
+    alias:
+    - BotNavIgnore
+  - name: CEnvHudHint_API_ShowHudHint
+    alias:
+    - CEnvHudHint_API::ShowHudHint
+  - name: UTIL_GetPlayerControllerForEntity
+    alias:
+    - UTIL_GetPlayerControllerForEntity
+  - name: CEntitySystem_ctor
+    alias:
+    - CEntitySystem::CEntitySystem
+  - name: CGameEntitySystem_ctor
+    alias:
+    - CGameEntitySystem::CGameEntitySystem
+  - name: CEntitySystem_RegisterAccessor
+    alias:
+    - CEntitySystem::RegisterAccessor
+  - name: CEntitySystem_Init
+    alias:
+    - CEntitySystem::Init
+  - name: CEntitySystem_ProcessEntityRegistration
+    alias:
+    - CEntitySystem::ProcessEntityRegistration
+  - name: CEntitySystem_PostCreateEntitySystem
+    alias:
+    - CEntitySystem::PostCreateEntitySystem
+  - name: CSource2EntitySystem_StaticInit
+    alias:
+    - CSource2EntitySystem::StaticInit
+  - name: CSpawnGroupEntityFilterRegistrar_RegisterSpawnGroupEntityFilters
+    alias:
+    - CSpawnGroupEntityFilterRegistrar::RegisterSpawnGroupEntityFilters
+  - name: CGameEntitySystem_m_spawnGroupEntityFilters
+    alias:
+    - CGameEntitySystem::m_spawnGroupEntityFilters
+  - name: CGameEntitySystem_m_pEntity2Networkables
+    alias:
+    - CGameEntitySystem::m_pEntity2Networkables
+  - name: CEntity2NetworkClasses_ServerClass_InitEntity2NetworkClasses
+    alias:
+    - CEntity2NetworkClasses<ServerClass>::InitEntity2NetworkClasses
+  - name: CEntitySystem_m_Symbols
+    alias:
+    - CEntitySystem::m_Symbols
+  - name: CEntitySystem_m_pNetworkFieldChangedEventQueue
+    alias:
+    - CEntitySystem::m_pNetworkFieldChangedEventQueue
+  - name: CEntitySystem_m_pNetworkFieldScratchData
+    alias:
+    - CEntitySystem::m_pNetworkFieldScratchData
+  - name: CEntitySystem_m_pFieldChangeLimitSpew
+    alias:
+    - CEntitySystem::m_pFieldChangeLimitSpew
+  - name: CEntitySystem_m_ComponentUnserializerInfoAllocator
+    alias:
+    - CEntitySystem::m_ComponentUnserializerInfoAllocator
+  - name: CEntitySystem_m_EntityMaterialAttributes
+    alias:
+    - CEntitySystem::m_EntityMaterialAttributes
+  - name: CEntitySystem_m_flChangeCallbackSpewThreshold
+    alias:
+    - CEntitySystem::m_flChangeCallbackSpewThreshold
+  - name: CEntitySystem_ClearEntityDatabase
+    alias:
+    - CEntitySystem::ClearEntityDatabase
+  - name: INetworkMessages_SetNetworkSerializationContextData
+    alias:
+    - INetworkMessages::SetNetworkSerializationContextData
+  - name: CFlattenedSerializers_CreateFieldChangedEventQueue
+    alias:
+    - CFlattenedSerializers::CreateFieldChangedEventQueue
+  - name: INetworkMessages_RegisterSchemaTypeOverride
+    alias:
+    - INetworkMessages::RegisterSchemaTypeOverride
+  - name: PolymorphicHelper_t__SetPolymorphicPointer
+    alias:
+    - PolymorphicHelper_t::SetPolymorphicPointer
+  - name: CSceneEntity_GetScriptDesc
+    alias:
+    - CSceneEntity::GetScriptDesc
+  - name: CEntityInstance_GetScriptDesc
+    alias:
+    - CEntityInstance::GetScriptDesc
+  - name: CEntityInstance_Spawn
+    alias:
+    - CEntityInstance::Spawn
+  - name: CEntityInstance_Activate
+    alias:
+    - CEntityInstance::Activate
+  - name: CEntityInstance_Precache
+    alias:
+    - CEntityInstance::Precache
+  - name: CEntityInstance_GetDataDescMap
+    alias:
+    - CEntityInstance::GetDataDescMap
+  - name: CEntityInstance_ReloadPrivateScripts
+    alias:
+    - CEntityInstance::ReloadPrivateScripts
+  - name: CEntityInstance_ValidatePrivateScriptScope
+    alias:
+    - CEntityInstance::ValidatePrivateScriptScope
+  - name: CEntityInstance_NetworkStateChanged
+    alias:
+    - CEntityInstance::NetworkStateChanged
+  - name: CEntityInstance_FullEdictChanged
+    alias:
+    - CEntityInstance::FullEdictChanged
+  - name: CEntityInstance_NetworkUpdateState
+    alias:
+    - CEntityInstance::NetworkUpdateState
+  - name: CEntityInstance_NetworkStateChangedLog
+    alias:
+    - CEntityInstance::NetworkStateChangedLog
+  - name: CEntityInstance_DrawDebugTextOverlays
+    alias:
+    - CEntityInstance::DrawDebugTextOverlays
+  - name: CEntityInstance_DrawEntityDebugOverlays
+    alias:
+    - CEntityInstance::DrawEntityDebugOverlays
+  - name: CEntityInstance_PostDataUpdateDelta
+    alias:
+    - CEntityInstance::PostDataUpdateDelta
+  - name: CEntityInstance_PreDataUpdate
+    alias:
+    - CEntityInstance::PreDataUpdate
+  - name: CEntityInstance_PostDataUpdate
+    alias:
+    - CEntityInstance::PostDataUpdate
+  - name: CEntityInstance_PostDataUpdatePreserve
+    alias:
+    - CEntityInstance::PostDataUpdatePreserve
+  - name: CEntityInstance_Connect
+    alias:
+    - CEntityInstance::Connect
+  - name: CEntityInstance_UpdateOnRemove
+    alias:
+    - CEntityInstance::UpdateOnRemove
+  - name: CEntityInstance_Disconnect
+    alias:
+    - CEntityInstance::Disconnect
+  - name: CEntityInstance_AddedToEntityDatabase
+    alias:
+    - CEntityInstance::AddedToEntityDatabase
+  - name: CEntityInstance_OnSetDormant
+    alias:
+    - CEntityInstance::OnSetDormant
+  - name: CEntityInstance_Schema_DynamicBinding
+    alias:
+    - CEntityInstance::Schema_DynamicBinding
+  - name: CEntitySystem_OnRemoveEntity
+    alias:
+    - CEntitySystem::OnRemoveEntity
+  - name: CEntityComponentHelperT_Free
+    alias:
+    - CEntityComponentHelperT::Free
+  - name: CScriptedSequence_SynchronizeSequence
+    alias:
+    - CScriptedSequence::SynchronizeSequence
+  - name: CNetworkUtlVectorEmbedded_NetworkStateChanged_m_vecRenderAttributes
+    alias:
+    - CNetworkUtlVectorEmbedded<CRenderAttribute>::NetworkStateChanged_m_vecRenderAttributes
+  - name: CNetworkUtlVectorEmbedded_NetworkStateChanged_m_perRoundStats
+    alias:
+    - CNetworkUtlVectorEmbedded<CSPerRoundStats_t>::NetworkStateChanged_m_perRoundStats
+  - name: CUtlVectorEmbeddedNetworkVar_CSPerRoundStats_t_NetworkVar_m_perRoundStats_SetCount
+    alias:
+    - CUtlVectorEmbeddedNetworkVar<CSPerRoundStats_t, NetworkVar>::SetCount
+  - name: CNetworkUtlVectorEmbedded_TryLateResolve_m_vecRenderAttributes
+    alias:
+    - CNetworkUtlVectorEmbedded<CRenderAttribute>::TryLateResolve
+  - name: INetworkMessages_GetLoggingChannel
+    alias:
+    - INetworkMessages::GetLoggingChannel
+  - name: CPhysicsEntitySolver_PhysEnableEntityCollisions
+    alias:
+    - CPhysicsEntitySolver::PhysEnableEntityCollisions
+  - name: CLoopModeGame_StaticInit
+    alias:
+    - CLoopModeGame::StaticInit
+  - name: CLoopModeFactory_CLoopModeGame_Init
+    alias:
+    - CLoopModeFactory<CLoopModeGame>::Init
+  - name: CLoopModeFactory_CLoopModeGame_Shutdown
+    alias:
+    - CLoopModeFactory<CLoopModeGame>::Shutdown
+  - name: CLoopModeGame_OnLoopActivate
+    alias:
+    - CLoopModeGame::OnLoopActivate
+  - name: ILoopMode_OnLoopActivate
+    alias:
+    - ILoopMode::OnLoopActivate
+  - name: CLoopModeGame_AddViewsToSceneSystem
+    alias:
+    - CLoopModeGame::AddViewsToSceneSystem
+  - name: ILoopMode_AddViewsToSceneSystem
+    alias:
+    - ILoopMode::AddViewsToSceneSystem
+  - name: CLoopModeGame_LoopInitInternal
+    alias:
+    - CLoopModeGame::LoopInitInternal
+  - name: CLoopModeGame_LoopInit
+    alias:
+    - CLoopModeGame::LoopInit
+  - name: ILoopMode_LoopInit
+    alias:
+    - ILoopMode::LoopInit
+  - name: ILoopMode_LoopShutdown
+    alias:
+    - ILoopMode::LoopShutdown
+  - name: CLoopModeGame_RegisterEventMapInternal
+    alias:
+    - CLoopModeGame::RegisterEventMapInternal
+  - name: CLoopModeGame_OnServerAdvanceTick
+    alias:
+    - CLoopModeGame::OnServerAdvanceTick
+  - name: CLoopModeGame_OnServerBeginSimulate
+    alias:
+    - CLoopModeGame::OnServerBeginSimulate
+  - name: CLoopModeGame_OnServerPostSimulate
+    alias:
+    - CLoopModeGame::OnServerPostSimulate
+  - name: CLoopModeGame_OnServerPostAdvanceTick
+    alias:
+    - CLoopModeGame::OnServerPostAdvanceTick
+  - name: CLoopModeGame_OnServerBeginAsyncPostTickWork
+    alias:
+    - CLoopModeGame::OnServerBeginAsyncPostTickWork
+  - name: CLoopModeGame_OnServerEndAsyncPostTickWork
+    alias:
+    - CLoopModeGame::OnServerEndAsyncPostTickWork
+  - name: CLoopModeGame_OnFrameBoundary
+    alias:
+    - CLoopModeGame::OnFrameBoundary
+  - name: CLoopModeGame_ReceivedServerInfo
+    alias:
+    - CLoopModeGame::ReceivedServerInfo
+  - name: CLoopModeGame_SetWorldSession
+    alias:
+    - CLoopModeGame::SetWorldSession
+  - name: CLoopModeGame_SetGameSystemState
+    alias:
+    - CLoopModeGame::SetGameSystemState
+  - name: IGameSystem_DestroyAllGameSystems
+    alias:
+    - IGameSystem::DestroyAllGameSystems
+  - name: IGameSystem_ShutdownAllSystems
+    alias:
+    - IGameSystem::ShutdownAllSystems
+  - name: IGameSystem_LoopDestroyAllSystems
+    alias:
+    - IGameSystem::LoopDestroyAllSystems
+  - name: IGameSystem_LoopPreShutdownAllSystems
+    alias:
+    - IGameSystem::LoopPreShutdownAllSystems
+  - name: CLoopModeGame_Shutdown
+    alias:
+    - CLoopModeGame::Shutdown
+  - name: CLoopModeGame_LoopShutdown
+    alias:
+    - CLoopModeGame::LoopShutdown
+  - name: CLoopModeGame_ShutdownServer
+    alias:
+    - CLoopModeGame::ShutdownServer
+  - name: CLoopModeGame_OnLoopDeactivate
+    alias:
+    - CLoopModeGame::OnLoopDeactivate
+  - name: ILoopMode_OnLoopDeactivate
+    alias:
+    - ILoopMode::OnLoopDeactivate
+  - name: CPlayerCommandQueue_ctor
+    alias:
+    - CPlayerCommandQueue::CPlayerCommandQueue
+  - name: IGameResourceService_SetEntityResourceManifestHandler
+    alias:
+    - IGameResourceService::SetEntityResourceManifestHandler
+  - name: CNetworkSerializerBindingBuildFilter_GetFieldPriority
+    alias:
+    - CNetworkSerializerBindingBuildFilter::GetFieldPriority
+  - name: CEntitySystem_FindComponentTypeByName
+    alias:
+    - CEntitySystem::FindComponentTypeByName
+- name: networksystem
+  symbols:
+  - name: INetworkMessages_GetFieldChangeCallbackOrderCount
+    alias:
+    - INetworkMessages::GetFieldChangeCallbackOrderCount
+  - name: INetworkMessages_GetFieldChangeCallbackPriorities
+    alias:
+    - INetworkMessages::GetFieldChangeCallbackPriorities

--- a/gamesymbols/14169.metadata.yaml
+++ b/gamesymbols/14169.metadata.yaml
@@ -1,0 +1,2879 @@
+modules:
+- name: networksystem
+  symbols:
+  - name: CNetworkMessages_RegisterNetworkCategory
+    alias:
+    - CNetworkMessages::RegisterNetworkCategory
+  - name: CNetworkMessages_AssociateNetMessageWithChannelCategoryAbstract
+    alias:
+    - CNetworkMessages::AssociateNetMessageWithChannelCategoryAbstract
+  - name: CNetworkMessages_FindOrCreateNetMessage
+    alias:
+    - CNetworkMessages::FindOrCreateNetMessage
+  - name: CNetworkMessages_SerializeInternal
+    alias:
+    - CNetworkMessages::SerializeInternal
+  - name: CNetworkMessages_UnserializeMessageInternal
+    alias:
+    - CNetworkMessages::UnserializeMessageInternal
+  - name: CNetworkMessages_SerializeMessageInternal
+    alias:
+    - CNetworkMessages::SerializeMessageInternal
+  - name: CNetworkMessages_UnserializeFromStream
+    alias:
+    - CNetworkMessages::UnserializeFromStream
+  - name: CNetworkMessages_AllocateAndCopyConstructNetMessageAbstract
+    alias:
+    - CNetworkMessages::AllocateAndCopyConstructNetMessageAbstract
+  - name: CNetworkMessages_DeallocateNetMessageAbstract
+    alias:
+    - CNetworkMessages::DeallocateNetMessageAbstract
+  - name: CNetworkMessages_RegisterNetworkFieldSerializer
+    alias:
+    - CNetworkMessages::RegisterNetworkFieldSerializer
+  - name: CNetworkMessages_RegisterNetworkArrayFieldSerializer
+    alias:
+    - CNetworkMessages::RegisterNetworkArrayFieldSerializer
+  - name: CNetworkMessages_AssociateNetMessageGroupIdWithChannelCategory
+    alias:
+    - CNetworkMessages::AssociateNetMessageGroupIdWithChannelCategory
+  - name: CNetworkMessages_RegisterNetworkFieldChangeCallbackInternal
+    alias:
+    - CNetworkMessages::RegisterNetworkFieldChangeCallbackInternal
+  - name: CNetworkMessages_AllowAdditionalMessageRegistration
+    alias:
+    - CNetworkMessages::AllowAdditionalMessageRegistration
+  - name: CNetworkMessages_IsAdditionalMessageRegistrationAllowed
+    alias:
+    - CNetworkMessages::IsAdditionalMessageRegistrationAllowed
+  - name: CNetworkMessages_RegisterFieldChangeCallbackPriority
+    alias:
+    - CNetworkMessages::RegisterFieldChangeCallbackPriority
+  - name: CNetworkMessages_ComputeOrderForPriority
+    alias:
+    - CNetworkMessages::ComputeOrderForPriority
+  - name: CNetworkMessages_dtor
+    alias:
+    - CNetworkMessages::~CNetworkMessages
+  - name: CNetworkMessages_GetIsForServer
+    alias:
+    - CNetworkMessages::GetIsForServer
+  - name: CNetworkMessages_GetNetworkSerializationContextData
+    alias:
+    - CNetworkMessages::GetNetworkSerializationContextData
+  - name: CNetChan_ParseMessagesDemoInternal
+    alias:
+    - CNetChan::ParseMessagesDemoInternal
+  - name: CNetChan_ParseNetMessageShowFilter
+    alias:
+    - CNetChan::ParseNetMessageShowFilter
+  - name: CNetworkMessages_FindNetworkMessagePartial
+    alias:
+    - CNetworkMessages::FindNetworkMessagePartial
+  - name: CNetworkMessages_FindNetworkMessage
+    alias:
+    - CNetworkMessages::FindNetworkMessage
+  - name: CNetworkMessages_FindNetworkGroup
+    alias:
+    - CNetworkMessages::FindNetworkGroup
+  - name: CNetworkSystem_SendNetworkStats
+    alias:
+    - CNetworkSystem::SendNetworkStats
+  - name: CNetworkMessages_GetNetworkGroupCount
+    alias:
+    - CNetworkMessages::GetNetworkGroupCount
+  - name: CNetworkMessages_GetNetworkGroupName
+    alias:
+    - CNetworkMessages::GetNetworkGroupName
+  - name: CNetworkMessages_GetNetworkGroupColor
+    alias:
+    - CNetworkMessages::GetNetworkGroupColor
+  - name: CNetworkMessages_ConfirmAllMessageHandlersInstalled
+    alias:
+    - CNetworkMessages::ConfirmAllMessageHandlersInstalled
+- name: engine
+  symbols:
+  - name: CServerSideClient_IsHearingClient
+    alias:
+    - IsHearingClient
+  - name: CGameResourceService_BuildResourceManifest
+    alias:
+    - CGameResourceService::BuildResourceManifest
+    - BuildResourceManifest
+  - name: CGameResourceService_m_pEntitySystem
+    alias:
+    - GameEntitySystem
+  - name: CGameResourceService_LoadGameResourceManifestNamed
+    alias:
+    - CGameResourceService::LoadGameResourceManifestNamed
+  - name: CGameResourceService_LoadGameResourceManifestGroup
+    alias:
+    - CGameResourceService::LoadGameResourceManifestGroup
+  - name: CGameResourceService_GetResourceManifestDebugName
+    alias:
+    - CGameResourceService::GetResourceManifestDebugName
+  - name: CGameResourceService_PrecacheEntitiesAndConfirmResourcesAreLoaded
+    alias:
+    - CGameResourceService::PrecacheEntitiesAndConfirmResourcesAreLoaded
+  - name: CGameResourceService_LoadGameResourceManifest_IEntityResourceManifest
+    alias:
+    - CGameResourceService::LoadGameResourceManifest
+  - name: CGameResourceService_DescribeContents
+    alias:
+    - CGameResourceService::DescribeContents
+  - name: CGameResourceService_AppendToGameResourceManifest
+    alias:
+    - CGameResourceService::AppendToGameResourceManifest
+  - name: CGameResourceService_RegisterEventMap
+    alias:
+    - CGameResourceService::RegisterEventMap
+  - name: IEntityResourceManifestBuilder_BuildResourceManifest_ManifestNameOrGroupName
+    alias:
+    - IEntityResourceManifestBuilder::BuildResourceManifest
+  - name: CServerSideClientBase_ClientPrintf
+    alias:
+    - CServerSideClientBase::ClientPrintf
+    - ClientPrintf
+  - name: CNetworkGameServer_ClientList
+    alias:
+    - CNetworkGameServer::ClientList
+  - name: CNetworkGameServerBase_SendPeerList
+    alias:
+    - CNetworkGameServerBase::SendPeerList
+  - name: CNetworkGameServerBase_ConnectClient
+    alias:
+    - CNetworkGameServerBase::ConnectClient
+  - name: CNetworkGameServerBase_ServerSimulateInternal
+    alias:
+    - CNetworkGameServerBase::ServerSimulateInternal
+  - name: CNetworkGameServerBase_ServerSimulate
+    alias:
+    - CNetworkGameServerBase::ServerSimulate
+  - name: CNetworkGameServerBase_ServerPollNetworking
+    alias:
+    - CNetworkGameServerBase::ServerPollNetworking
+  - name: CNetworkGameServerBase_BroadcastMessage
+    alias:
+    - CNetworkGameServerBase::BroadcastMessage
+  - name: CNetworkGameServerBase_BroadcastPrintf
+    alias:
+    - CNetworkGameServerBase::BroadcastPrintf
+  - name: CNetworkGameServerBase_ReserveServerForQueuedGame
+    alias:
+    - CNetworkGameServerBase::ReserveServerForQueuedGame
+  - name: CNetworkGameServerBase_FinishChangeLevel
+    alias:
+    - CNetworkGameServerBase::FinishChangeLevel
+  - name: CNetworkGameServerBase_StartChangeLevel
+    alias:
+    - CNetworkGameServerBase::StartChangeLevel
+  - name: CNetworkGameServerBase_SetServerState
+    alias:
+    - CNetworkGameServerBase::SetServerState
+  - name: CNetworkGameServer_GetFreeClient
+    alias:
+    - CNetworkGameServer::GetFreeClient
+    - GetFreeClient
+  - name: CNetworkGameServerBase_CreateFakeClient
+    alias:
+    - CNetworkGameServerBase::CreateFakeClient
+  - name: CNetworkGameServerBase_UserInfoChanged
+    alias:
+    - CNetworkGameServerBase::UserInfoChanged
+  - name: CNetworkGameServerBase_GetPlayerNetworkIDString
+    alias:
+    - CNetworkGameServerBase::GetPlayerNetworkIDString
+  - name: CNetworkGameServerBase_StartHLTVMaster
+    alias:
+    - CNetworkGameServerBase::StartHLTVMaster
+  - name: CNetworkGameServerBase_RegisterLoadingSpawnGroups
+    alias:
+    - CNetworkGameServerBase::RegisterLoadingSpawnGroups
+  - name: CNetworkServerSpawnGroupCreatePrerequisites_Init
+    alias:
+    - CNetworkServerSpawnGroupCreatePrerequisites::Init
+  - name: CNetworkGameServerBase_LoadSpawnGroup
+    alias:
+    - CNetworkGameServerBase::LoadSpawnGroup
+  - name: CNetworkGameServerBase_SpawnGroupThink
+    alias:
+    - CNetworkGameServerBase::SpawnGroupThink
+  - name: CNetworkGameServerBase_PrintSpawnGroupStatus
+    alias:
+    - CNetworkGameServerBase::PrintSpawnGroupStatus
+  - name: CNetworkGameServerBase_AsyncUnloadSpawnGroup
+    alias:
+    - CNetworkGameServerBase::AsyncUnloadSpawnGroup
+  - name: CNetworkGameServerBase_AsyncUnloadSpawnGroupInternal
+    alias:
+    - CNetworkGameServerBase::AsyncUnloadSpawnGroupInternal
+  - name: CNetworkGameServer_PrepareForAssetLoad
+    alias:
+    - CNetworkGameServer::PrepareForAssetLoad
+  - name: CNetworkGameServerBase_IsSaveRestoreAllowed
+    alias:
+    - CNetworkGameServerBase::IsSaveRestoreAllowed
+  - name: CNetworkGameServerBase_Init
+    alias:
+    - CNetworkGameServerBase::Init
+  - name: CNetworkGameServerBase_Shutdown
+    alias:
+    - CNetworkGameServerBase::Shutdown
+  - name: CNetworkGameServerBase_ShutdownInternal
+    alias:
+    - CNetworkGameServerBase::ShutdownInternal
+  - name: CNetworkGameServer_ActivateServer
+    alias:
+    - CNetworkGameServer::ActivateServer
+  - name: CNetworkGameServer_DirectUpdate
+    alias:
+    - CNetworkGameServer::DirectUpdate
+  - name: CNetworkGameServer_Init
+    alias:
+    - CNetworkGameServer::Init
+  - name: CNetworkGameServer_Shutdown
+    alias:
+    - CNetworkGameServer::Shutdown
+  - name: CNetworkGameServer_SpawnServer
+    alias:
+    - CNetworkGameServer::SpawnServer
+  - name: CNetworkGameServerBase_GetMaxClients
+    alias:
+    - CNetworkGameServerBase::GetMaxClients
+  - name: CNetworkGameServerBase_SetMaxClients
+    alias:
+    - CNetworkGameServerBase::SetMaxClients
+  - name: CNetworkGameServerBase_CheckTimeouts
+    alias:
+    - CNetworkGameServerBase::CheckTimeouts
+  - name: CNetworkGameServerBase_OnKickById
+    alias:
+    - CNetworkGameServerBase::OnKickById
+  - name: CNetworkGameServerBase_OnKickByName
+    alias:
+    - CNetworkGameServerBase::OnKickByName
+  - name: CNetworkGameClient_SendMovePacket
+    alias:
+    - CNetworkGameClient::SendMovePacket
+    - SendMovePacket
+  - name: CNetworkGameClient_SendMove
+    alias:
+    - CNetworkGameClient::SendMove
+    - SendMove
+  - name: INetworkMessages_Serialize
+    alias:
+    - INetworkMessages::Serialize
+  - name: CDemoRecorder_ParseMessage
+    alias:
+    - CDemoRecorder::ParseMessage
+  - name: CDemoRecorder_WriteSpawnGroups
+    alias:
+    - CDemoRecorder::WriteSpawnGroups
+  - name: INetworkMessages_SerializeAbstract
+    alias:
+    - INetworkMessages::SerializeAbstract
+  - name: INetworkMessages_GetNetMessageInfo
+    alias:
+    - INetworkMessages::GetNetMessageInfo
+  - name: INetworkMessages_FindNetworkMessageById
+    alias:
+    - INetworkMessages::FindNetworkMessageById
+  - name: CNetChan_ProcessMessages
+    alias:
+    - CNetChan::ProcessMessages
+  - name: CNetChan_ParseMessagesDemo
+    alias:
+    - CNetChan::ParseMessagesDemo
+  - name: CNetworkGameClient_ProcessPacketEntitiesInternal
+    alias:
+    - CNetworkGameClient::ProcessPacketEntitiesInternal
+  - name: CNetworkGameClient_ProcessPacketEntities
+    alias:
+    - CNetworkGameClient::ProcessPacketEntities
+    - ProcessPacketEntities
+  - name: CNetworkGameClient_RecordEntityBandwidth
+    alias:
+    - CNetworkGameClient::RecordEntityBandwidth
+    - RecordEntityBandwidth
+  - name: CNetworkGameClient_PrintNetStats
+    alias:
+    - CNetworkGameClient::PrintNetStats
+  - name: CMsgSource2NetworkFlowQuality_PrintStats
+    alias:
+    - CMsgSource2NetworkFlowQuality::PrintStats
+  - name: CNetworkGameClient_DisconnectGame
+    alias:
+    - CNetworkGameClient::DisconnectGame
+  - name: INetworkMessages_FindNetworkGroup
+    alias:
+    - INetworkMessages::FindNetworkGroup
+  - name: INetworkClientService_IsActive
+    alias:
+    - INetworkClientService::IsActive
+  - name: INetworkClientService_IsConnected
+    alias:
+    - INetworkClientService::IsConnected
+  - name: CNetworkClientService_ReceivedServerInfo
+    alias:
+    - CNetworkClientService::ReceivedServerInfo
+  - name: CNetworkClientService_SplitScreenConnect
+    alias:
+    - CNetworkClientService::SplitScreenConnect
+  - name: CNetworkClientService_SendNetMessage
+    alias:
+    - CNetworkClientService::SendNetMessage
+  - name: CNetworkClientService_SendStringCmd
+    alias:
+    - CNetworkClientService::SendStringCmd
+  - name: CNetworkClientService_StartChangeLevel
+    alias:
+    - CNetworkClientService::StartChangeLevel
+  - name: CNetworkClientService_FinishChangeLevel
+    alias:
+    - CNetworkClientService::FinishChangeLevel
+  - name: CNetworkClientService_PrintConnectionStatus
+    alias:
+    - CNetworkClientService::PrintConnectionStatus
+  - name: CNetworkClientService_OnStatus
+    alias:
+    - CNetworkClientService::OnStatus
+  - name: CNetworkClientService_ServerCmd
+    alias:
+    - CNetworkClientService::ServerCmd
+  - name: CNetworkClientService_GetDisconnectReason
+    alias:
+    - CNetworkClientService::GetDisconnectReason
+  - name: CNetworkClientService_PrintSpawnGroupStatus
+    alias:
+    - CNetworkClientService::PrintSpawnGroupStatus
+  - name: CNetworkClientService_IsActive
+    alias:
+    - CNetworkClientService::IsActive
+  - name: CNetworkClientService_IsConnected
+    alias:
+    - CNetworkClientService::IsConnected
+  - name: CNetworkClientService_ClockDriftAdjustFrameTime
+    alias:
+    - CNetworkClientService::ClockDriftAdjustFrameTime
+  - name: CNetworkClientService_Init
+    alias:
+    - CNetworkClientService::Init
+  - name: CNetworkClientService_Shutdown
+    alias:
+    - CNetworkClientService::Shutdown
+  - name: CNetworkClientService_DisconnectGameNow
+    alias:
+    - CNetworkClientService::DisconnectGameNow
+  - name: CGameClientConnectPrerequisite_ctor
+    alias:
+    - CGameClientConnectPrerequisite::CGameClientConnectPrerequisite
+  - name: CNetworkClientService_AddClientPrerequisites
+    alias:
+    - CNetworkClientService::AddClientPrerequisites
+  - name: CNetworkClientService_AllocateRemoteConnectionClient
+    alias:
+    - CNetworkClientService::AllocateRemoteConnectionClient
+  - name: CNetworkServerService_Init
+    alias:
+    - CNetworkServerService::Init
+  - name: CNetworkServerService_StartupServer
+    alias:
+    - CNetworkServerService::StartupServer
+  - name: CNetworkServerService_RegisterEventMapInternal
+    alias:
+    - CNetworkServerService::RegisterEventMapInternal
+  - name: CNetworkServerService_OnServerAdvanceTick
+    alias:
+    - CNetworkServerService::OnServerAdvanceTick
+  - name: CNetworkServerService_OnServerPollNetworking
+    alias:
+    - CNetworkServerService::OnServerPollNetworking
+  - name: CNetworkServerService_OnServerProcessNetworking
+    alias:
+    - CNetworkServerService::OnServerProcessNetworking
+  - name: CNetworkServerService_OnServerBeginSimulate
+    alias:
+    - CNetworkServerService::OnServerBeginSimulate
+  - name: CNetworkServerService_OnServerEndSimulate
+    alias:
+    - CNetworkServerService::OnServerEndSimulate
+  - name: CNetworkServerService_OnServerPostSimulate
+    alias:
+    - CNetworkServerService::OnServerPostSimulate
+  - name: CNetworkServerService_OnServerPostAdvanceTick
+    alias:
+    - CNetworkServerService::OnServerPostAdvanceTick
+  - name: CNetworkServerService_OnFrameBoundary
+    alias:
+    - CNetworkServerService::OnFrameBoundary
+  - name: CNetworkServerService_OnClientPollNetworking
+    alias:
+    - CNetworkServerService::OnClientPollNetworking
+  - name: CNetworkServerService_OnSimpleLoopFrameUpdate
+    alias:
+    - CNetworkServerService::OnSimpleLoopFrameUpdate
+  - name: CNetworkServerService_OnKickByIdHLTV
+    alias:
+    - CNetworkServerService::OnKickByIdHLTV
+  - name: CNetworkServerService_DisconnectGameNow
+    alias:
+    - CNetworkServerService::DisconnectGameNow
+  - name: INetworkGameServer_GetMaxClients
+    alias:
+    - INetworkGameServer::GetMaxClients
+  - name: INetworkGameServer_PreWorldUpdate
+    alias:
+    - INetworkGameServer::PreWorldUpdate
+  - name: CNetworkGameServer_PreWorldUpdate
+    alias:
+    - CNetworkGameServer::PreWorldUpdate
+  - name: INetworkGameServer_ServerEndSimulate
+    alias:
+    - INetworkGameServer::ServerEndSimulate
+  - name: CNetworkGameServerBase_ServerEndSimulate
+    alias:
+    - CNetworkGameServerBase::ServerEndSimulate
+  - name: INetworkGameServer_ServerPostSimulate
+    alias:
+    - INetworkGameServer::ServerPostSimulate
+  - name: CNetworkGameServerBase_ServerPostSimulate
+    alias:
+    - CNetworkGameServerBase::ServerPostSimulate
+  - name: INetworkGameServer_ServerAdvanceTick
+    alias:
+    - INetworkGameServer::ServerAdvanceTick
+  - name: CNetworkGameServerBase_ServerAdvanceTick
+    alias:
+    - CNetworkGameServerBase::ServerAdvanceTick
+  - name: INetworkGameServer_ServerProcessNetworking
+    alias:
+    - INetworkGameServer::ServerProcessNetworking
+  - name: CNetworkGameServerBase_ServerProcessNetworking
+    alias:
+    - CNetworkGameServerBase::ServerProcessNetworking
+  - name: INetworkGameServer_GetTimescale
+    alias:
+    - INetworkGameServer::GetTimescale
+  - name: CNetworkGameServerBase_GetTimescale
+    alias:
+    - CNetworkGameServerBase::GetTimescale
+  - name: ISource2Server_PreWorldUpdate
+    alias:
+    - ISource2Server::PreWorldUpdate
+  - name: ISource2Server_OutOfGameFrameBoundary
+    alias:
+    - ISource2Server::OutOfGameFrameBoundary
+  - name: INetworkMessages_SetIsForServer
+    alias:
+    - INetworkMessages::SetIsForServer
+  - name: CEngineClient_DumpNetStats
+    alias:
+    - CEngineClient::DumpNetStats
+  - name: CEngineServer_DumpNetStats
+    alias:
+    - CEngineServer::DumpNetStats
+  - name: CEngineServer_ClientPrintf
+    alias:
+    - CEngineServer::ClientPrintf
+  - name: CEngineServer_GetFrameTimeAmnesty
+    alias:
+    - CEngineServer::GetFrameTimeAmnesty
+  - name: CEngineServer_ShowFrameTimeReport
+    alias:
+    - CEngineServer::ShowFrameTimeReport
+  - name: CEngineServer_SetFrameTimeAmnesty
+    alias:
+    - CEngineServer::SetFrameTimeAmnesty
+  - name: CEngineServer_GetSteamUniverse
+    alias:
+    - CEngineServer::GetSteamUniverse
+  - name: CEngineServer_ChangeLevel
+    alias:
+    - CEngineServer::ChangeLevel
+  - name: CMapListService_IsMapValid
+    alias:
+    - CMapListService::IsMapValid
+    - IMapListService::IsMapValid
+  - name: CEngineServer_IsMapValid
+    alias:
+    - CEngineServer::IsMapValid
+  - name: CEngineServer_PrecacheGeneric
+    alias:
+    - CEngineServer::PrecacheGeneric
+  - name: CEngineServer_ClientCommand
+    alias:
+    - CEngineServer::ClientCommand
+  - name: CEngineServer_GetClientConVarValue
+    alias:
+    - CEngineServer::GetClientConVarValue
+  - name: CEngineServer_SetFakeClientConVarValue
+    alias:
+    - CEngineServer::SetFakeClientConVarValue
+  - name: CEngineServer_CreateFakeClient
+    alias:
+    - CEngineServer::CreateFakeClient
+  - name: CEngineServer_GetPlayerInfo
+    alias:
+    - CEngineServer::GetPlayerInfo
+  - name: CEngineServer_ClientCommandKeyValues
+    alias:
+    - CEngineServer::ClientCommandKeyValues
+  - name: CLog_Print
+    alias:
+    - CLog::Print
+  - name: CEngineServer_LogPrint
+    alias:
+    - CEngineServer::LogPrint
+  - name: CEngineServer_KickClient
+    alias:
+    - CEngineServer::KickClient
+  - name: CEngineServer_IsDedicatedServer
+    alias:
+    - CEngineServer::IsDedicatedServer
+  - name: CEngineServer_ServerCommand
+    alias:
+    - CEngineServer::ServerCommand
+  - name: CLoopTypeClientSimple_ActivateEngineServices
+    alias:
+    - CLoopTypeClientServer::ActivateEngineServices
+  - name: CLoopTypeClientServer_LoopTypeInit
+    alias:
+    - CLoopTypeClientServer::LoopTypeInit
+  - name: CLoopTypeClientServer_AdvanceTime
+    alias:
+    - CLoopTypeClientServer::AdvanceTime
+  - name: CLoopTypeClientServer_Update
+    alias:
+    - CLoopTypeClientServer::Update
+  - name: CLoopTypeClientServer_ActivateLoop
+    alias:
+    - CLoopTypeClientServer::ActivateLoop
+  - name: CLoopTypeClientServer_AllocateLoopMode
+    alias:
+    - CLoopTypeClientServer::AllocateLoopMode
+  - name: CLoopTypeClientServer_WritePerfStats
+    alias:
+    - CLoopTypeClientServer::WritePerfStats
+  - name: CLoopTypeClientServer_DeactivateLoop
+    alias:
+    - CLoopTypeClientServer::DeactivateLoop
+  - name: CLoopTypeClientServer_OutputListeners
+    alias:
+    - CLoopTypeClientServer::OutputListeners
+  - name: CLoopTypeSimple_FrameUpdate
+    alias:
+    - CLoopTypeSimple::FrameUpdate
+  - name: CLoopTypeClientServerService_OnLoopActivate
+    alias:
+    - CLoopTypeClientServerService::OnLoopActivate
+  - name: CLoopTypeSimpleService_OnLoopActivate
+    alias:
+    - CLoopTypeSimpleService::OnLoopActivate
+  - name: CLoopTypeClientServerService_HandleInputEvent
+    alias:
+    - CLoopTypeClientServerService::HandleInputEvent
+  - name: ILoopMode_HandleInputEvent
+    alias:
+    - ILoopMode::HandleInputEvent
+  - name: ILoopType_AddEngineService
+    alias:
+    - ILoopType::AddEngineService
+  - name: CLoopTypeBase_DeallocateLoopMode
+    alias:
+    - CLoopTypeBase::DeallocateLoopMode
+  - name: CLoopTypeBase_EngineLoop
+    alias:
+    - CLoopTypeBase::EngineLoop
+  - name: CLoopTypeBase_FrameUpdate
+    alias:
+    - CLoopTypeBase::FrameUpdate
+  - name: CLoopTypeBase_ActivateLoop
+    alias:
+    - CLoopTypeBase::ActivateLoop
+  - name: CLoopTypeBase_AllocateLoopMode
+    alias:
+    - CLoopTypeBase::AllocateLoopMode
+  - name: CLoopTypeBase_DeactivateLoop
+    alias:
+    - CLoopTypeBase::DeactivateLoop
+  - name: CLoopTypeBase_LoopTypeInit
+    alias:
+    - CLoopTypeBase::LoopTypeInit
+  - name: CLoopTypeBase_LoopTypeShutdown
+    alias:
+    - CLoopTypeBase::LoopTypeShutdown
+  - name: CLoopTypeBase_GetClientServerMode
+    alias:
+    - CLoopTypeBase::GetClientServerMode
+  - name: CLoopTypeBase_GetImplType
+    alias:
+    - CLoopTypeBase::GetImplType
+  - name: CLoopTypeBase_AddDependentServices
+    alias:
+    - CLoopTypeBase::AddDependentServices
+  - name: CLoopTypeBase_GenerateServiceDependencies
+    alias:
+    - CLoopTypeBase::GenerateServiceDependencies
+  - name: CLoopTypeBase_GenerateSecondaryDependencies
+    alias:
+    - CLoopTypeBase::GenerateSecondaryDependencies
+  - name: CLoopTypeBase_LoadDependentServices
+    alias:
+    - CLoopTypeBase::LoadDependentServices
+  - name: IEngineService_GetServiceDependencies
+    alias:
+    - IEngineService::GetServiceDependencies
+  - name: IEngineService_GetName
+    alias:
+    - IEngineService::GetName
+  - name: ILoopModeFactory_GetLoopModeType
+    alias:
+    - ILoopModeFactory::GetLoopModeType
+  - name: ILoopModeFactory_Shutdown
+    alias:
+    - ILoopModeFactory::Shutdown
+  - name: CEngineServiceMgr_RegisterEngineService
+    alias:
+    - CEngineServiceMgr::RegisterEngineService
+  - name: CEngineServiceMgr_RegisterLoopMode
+    alias:
+    - CEngineServiceMgr::RegisterLoopMode
+  - name: CEngineServiceMgr_UnregisterLoopMode
+    alias:
+    - CEngineServiceMgr::UnregisterLoopMode
+  - name: CEngineServiceMgr_UnregisterEngineService
+    alias:
+    - CEngineServiceMgr::UnregisterEngineService
+  - name: CEngineServiceMgr_SwitchToLoop
+    alias:
+    - CEngineServiceMgr::SwitchToLoop
+  - name: CEngineServiceMgr_PrintStatus
+    alias:
+    - CEngineServiceMgr::PrintStatus
+  - name: CEngineServiceMgr__MainLoop
+    alias:
+    - CEngineServiceMgr::_MainLoop
+  - name: CEngineServiceMgr_DeactivateLoop
+    alias:
+    - CEngineServiceMgr::DeactivateLoop
+  - name: CEngineServiceMgr_Shutdown
+    alias:
+    - CEngineServiceMgr::Shutdown
+  - name: CEngineServiceMgr_GetActiveLoopClientServerMode
+    alias:
+    - CEngineServiceMgr::GetActiveLoopClientServerMode
+  - name: CEngineServiceMgr_GetEventDispatcher
+    alias:
+    - CEngineServiceMgr::GetEventDispatcher
+  - name: CEngineGameUI_Shutdown
+    alias:
+    - CEngineGameUI::Shutdown
+  - name: IAppSystem_Shutdown
+    alias:
+    - IAppSystem::Shutdown
+  - name: CSplitScreenService_AddSplitScreenUser
+    alias:
+    - CSplitScreenService::AddSplitScreenUser
+  - name: CSplitScreenService_LoadUserConfiguration
+    alias:
+    - CSplitScreenService::LoadUserConfiguration
+  - name: CHLTVClient_ProcessSetConVar
+    alias:
+    - CHLTVClient::ProcessSetConVar
+  - name: CServerSideClientBase_ProcessTick
+    alias:
+    - CServerSideClientBase::ProcessTick
+  - name: CServerSideClientBase_ProcessStringCmd
+    alias:
+    - CServerSideClientBase::ProcessStringCmd
+  - name: CServerSideClientBase_MarkSpawnGroupLoadCompleted
+    alias:
+    - CServerSideClientBase::MarkSpawnGroupLoadCompleted
+  - name: CServerSideClientBase_ProcessSpawnGroup_LoadCompleted
+    alias:
+    - CServerSideClientBase::ProcessSpawnGroup_LoadCompleted
+  - name: CServerSideClientBase_ProcessClientInfo
+    alias:
+    - CServerSideClientBase::ProcessClientInfo
+  - name: CServerSideClientBase_ProcessBaselineAck
+    alias:
+    - CServerSideClientBase::ProcessBaselineAck
+  - name: CServerSideClientBase_ProcessSplitPlayerConnectInternal
+    alias:
+    - CServerSideClientBase::ProcessSplitPlayerConnectInternal
+  - name: CServerSideClientBase_ProcessSplitPlayerConnect
+    alias:
+    - CServerSideClientBase::ProcessSplitPlayerConnect
+  - name: CServerSideClientBase_GetUserIDString
+    alias:
+    - CServerSideClientBase::GetUserIDString
+  - name: CServerSideClientBase_GetNetworkIDString
+    alias:
+    - CServerSideClientBase::GetNetworkIDString
+  - name: CServerSideClientBase_Connect
+    alias:
+    - CServerSideClientBase::Connect
+  - name: CServerSideClientBase_GetPlayerInfo
+    alias:
+    - CServerSideClientBase::GetPlayerInfo
+  - name: CNetworkGameServer_GetPlayerNetworkIDString
+    alias:
+    - CNetworkGameServer::GetPlayerNetworkIDString
+  - name: CNetworkGameServerBase_RemoveClientFromGame
+    alias:
+    - CNetworkGameServerBase::RemoveClientFromGame
+  - name: CEngineServer_GetPlayerNetworkIDString
+    alias:
+    - CEngineServer::GetPlayerNetworkIDString
+  - name: CNetworkGameClientBase_ServerCmd
+    alias:
+    - CNetworkGameClientBase::ServerCmd
+  - name: CNetworkGameClientBase_ProcessSetConVar
+    alias:
+    - CNetworkGameClientBase::ProcessSetConVar
+  - name: CNetworkGameClientBase_SendStringCmd
+    alias:
+    - CNetworkGameClientBase::SendStringCmd
+  - name: CNetworkGameClientBase_StartChangeLevel
+    alias:
+    - CNetworkGameClientBase::StartChangeLevel
+  - name: CNetworkGameClientBase_FinishChangeLevel
+    alias:
+    - CNetworkGameClientBase::FinishChangeLevel
+  - name: CNetworkGameClientBase_DeferActivate
+    alias:
+    - CNetworkGameClientBase::DeferActivate
+  - name: CNetworkGameClientBase_ClockDrift_AdjustFrameTime
+    alias:
+    - CNetworkGameClientBase::ClockDrift_AdjustFrameTime
+  - name: CNetworkGameClientBase_Connect
+    alias:
+    - CNetworkGameClientBase::Connect
+  - name: CNetworkGameClientBase_DisconnectGame
+    alias:
+    - CNetworkGameClientBase::DisconnectGame
+  - name: CNetSupportImpl_Connect
+    alias:
+    - CNetSupportImpl::Connect
+- name: client
+  symbols:
+  - name: CLoopModeGame_RegisterEventMapInternal
+    alias:
+    - CLoopModeGame::RegisterEventMapInternal
+  - name: CLoopModeGame_OnClientPollNetworking
+    alias:
+    - CLoopModeGame::OnClientPollNetworking
+  - name: CLoopModeGame_OnClientAdvanceTick
+    alias:
+    - CLoopModeGame::OnClientAdvanceTick
+  - name: CLoopModeGame_OnClientPostAdvanceTick
+    alias:
+    - CLoopModeGame::OnClientPostAdvanceTick
+  - name: CLoopModeGame_OnClientPreSimulate
+    alias:
+    - CLoopModeGame::OnClientPreSimulate
+  - name: CLoopModeGame_OnClientPreOutput
+    alias:
+    - CLoopModeGame::OnClientPreOutput
+  - name: CLoopModeGame_OnClientPreOutputParallelWithServer
+    alias:
+    - CLoopModeGame::OnClientPreOutputParallelWithServer
+  - name: CLoopModeGame_OnClientPostOutput
+    alias:
+    - CLoopModeGame::OnClientPostOutput
+  - name: CLoopModeGame_OnClientFrameSimulate
+    alias:
+    - CLoopModeGame::OnClientFrameSimulate
+  - name: CLoopModeGame_OnClientAdvanceNonRenderedFrame
+    alias:
+    - CLoopModeGame::OnClientAdvanceNonRenderedFrame
+  - name: CLoopModeGame_OnClientPostSimulate
+    alias:
+    - CLoopModeGame::OnClientPostSimulate
+  - name: CLoopModeGame_OnClientPauseSimulate
+    alias:
+    - CLoopModeGame::OnClientPauseSimulate
+  - name: CLoopModeGame_OnClientSimulate
+    alias:
+    - CLoopModeGame::OnClientSimulate
+  - name: CLoopModeGame_OnPostDataUpdate
+    alias:
+    - CLoopModeGame::OnPostDataUpdate
+  - name: CLoopModeGame_OnPreDataUpdate
+    alias:
+    - CLoopModeGame::OnPreDataUpdate
+  - name: CLoopModeGame_OnFrameBoundary
+    alias:
+    - CLoopModeGame::OnFrameBoundary
+  - name: CLoopModeGame_StaticInit
+    alias:
+    - CLoopModeGame::StaticInit
+  - name: CLoopModeFactory_CLoopModeGame_Init
+    alias:
+    - CLoopModeFactory<CLoopModeGame>::Init
+  - name: CLoopModeFactory_CLoopModeGame_Shutdown
+    alias:
+    - CLoopModeFactory<CLoopModeGame>::Shutdown
+  - name: CLoopModeGame_OnLoopActivate
+    alias:
+    - CLoopModeGame::OnLoopActivate
+  - name: ILoopMode_OnLoopActivate
+    alias:
+    - ILoopMode::OnLoopActivate
+  - name: CLoopModeGame_AddViewsToSceneSystem
+    alias:
+    - CLoopModeGame::AddViewsToSceneSystem
+  - name: ILoopMode_AddViewsToSceneSystem
+    alias:
+    - ILoopMode::AddViewsToSceneSystem
+  - name: CLoopModeGame_LoopInitInternal
+    alias:
+    - CLoopModeGame::LoopInitInternal
+  - name: CLoopModeGame_LoopInit
+    alias:
+    - CLoopModeGame::LoopInit
+  - name: ILoopMode_LoopInit
+    alias:
+    - ILoopMode::LoopInit
+  - name: ILoopMode_LoopShutdown
+    alias:
+    - ILoopMode::LoopShutdown
+  - name: CLoopModeGame_ReceivedServerInfo
+    alias:
+    - CLoopModeGame::ReceivedServerInfo
+  - name: CLoopModeGame_RegisterEventMap
+    alias:
+    - CLoopModeGame::RegisterEventMap
+  - name: ILoopMode_RegisterEventMap
+    alias:
+    - ILoopMode::RegisterEventMap
+  - name: CLoopModeGame_SetWorldSession
+    alias:
+    - CLoopModeGame::SetWorldSession
+  - name: CLoopModeGame_SetGameSystemState
+    alias:
+    - CLoopModeGame::SetGameSystemState
+  - name: CLoopModeGame_LoopShutdown
+    alias:
+    - CLoopModeGame::LoopShutdown
+  - name: IGameSystem_AddByName
+    alias:
+    - IGameSystem::AddByName
+  - name: IGameSystem_Add
+    alias:
+    - IGameSystem::Add
+  - name: IGameSystem_PostInit
+    alias:
+    - IGameSystem::PostInit
+  - name: IGameSystem_InitAllSystems
+    alias:
+    - IGameSystem::InitAllSystems
+  - name: IGameSystem_LoopInitAllSystems
+    alias:
+    - IGameSystem::LoopInitAllSystems
+  - name: IGameSystemFactory_PostInit
+    alias:
+    - IGameSystemFactory::PostInit
+  - name: IGameSystemFactory_GetStaticGameSystem
+    alias:
+    - IGameSystemFactory::GetStaticGameSystem
+  - name: IGameSystemFactory_ShouldAutoAdd
+    alias:
+    - IGameSystemFactory::ShouldAutoAdd
+  - name: IGameSystemFactory_CreateGameSystem
+    alias:
+    - IGameSystemFactory::CreateGameSystem
+  - name: IGameSystemFactory_IsReallocating
+    alias:
+    - IGameSystemFactory::IsReallocating
+  - name: IGameSystem_SetName
+    alias:
+    - IGameSystem::SetName
+  - name: CSpawnGroupMgrGameSystem_DoesGameSystemReallocate
+    alias:
+    - IGameSystem::DoesGameSystemReallocate
+  - name: IGameSystem_DestroyAllGameSystems
+    alias:
+    - IGameSystem::DestroyAllGameSystems
+  - name: IGameSystem_ShutdownAllSystems
+    alias:
+    - IGameSystem::ShutdownAllSystems
+  - name: IGameSystem_LoopDestroyAllSystems
+    alias:
+    - IGameSystem::LoopDestroyAllSystems
+  - name: IGameSystem_LoopPreShutdownAllSystems
+    alias:
+    - IGameSystem::LoopPreShutdownAllSystems
+  - name: IGameSystem_OnClientPollNetworking
+    alias:
+    - IGameSystem::OnClientPollNetworking
+  - name: IGameSystem_OnClientGamePostSimulate
+    alias:
+    - IGameSystem::ClientGamePostSimulate
+  - name: IGameSystem_OnClientPauseSimulate
+    alias:
+    - IGameSystem::OnClientPauseSimulate
+  - name: IGameSystem_OnClientPreUpdate
+    alias:
+    - IGameSystem::OnClientPreUpdate
+  - name: IGameSystem_OnClientPostUpdate
+    alias:
+    - IGameSystem::OnClientPostUpdate
+  - name: IGameSystem_OnClientPostDataUpdate
+    alias:
+    - IGameSystem::OnClientPostDataUpdate
+  - name: IGameSystem_OnGameFrameBoundary
+    alias:
+    - IGameSystem::OnGameFrameBoundary
+  - name: IGameSystem_OnClientAdvanceNonRenderedFrame
+    alias:
+    - IGameSystem::OnClientAdvanceNonRenderedFrame
+  - name: IGameSystem_OnClientFrameSimulate
+    alias:
+    - IGameSystem::OnClientFrameSimulate
+  - name: IGameSystem_OnClientAdvanceTick
+    alias:
+    - IGameSystem::ClientAdvanceTick
+  - name: IGameSystem_OnClientPostAdvanceTick
+    alias:
+    - IGameSystem::ClientPostAdvanceTick
+  - name: IGameSystem_OnClientPostRender
+    alias:
+    - IGameSystem::OnClientPostRender
+  - name: IGameSystem_OnClientPreRender
+    alias:
+    - IGameSystem::OnClientPreRender
+  - name: IGameSystem_OnClientPreRenderAlt
+    alias:
+    - IGameSystem::OnClientPreRenderAlt
+  - name: CSource2Client_OnDisconnect
+    alias:
+    - CSource2Client::OnDisconnect
+  - name: IGameSystem_OnClientDisconnect
+    alias:
+    - IGameSystem::OnClientDisconnect
+  - name: IGameSystem_OnClientPreEntityThink
+    alias:
+    - IGameSystem::OnClientPreEntityThink
+  - name: CSteamworksGameStats_OnReceivedSessionID
+    alias:
+    - CSteamworksGameStats::OnReceivedSessionID
+  - name: IGameSystem_GetName
+    alias:
+    - IGameSystem::GetName
+  - name: IGameSystemFactory_DestroyGameSystem
+    alias:
+    - IGameSystemFactory::DestroyGameSystem
+  - name: IGameSystemFactory_Init
+    alias:
+    - IGameSystemFactory::Init
+  - name: IGameSystemFactory_GetPriority
+    alias:
+    - IGameSystemFactory::GetPriority
+  - name: IGameSystemFactory_Shutdown
+    alias:
+    - IGameSystemFactory::Shutdown
+  - name: IGameSystemFactory_SetGlobalPtr
+    alias:
+    - IGameSystemFactory::SetGlobalPtr
+  - name: CPrediction_PostNetworkDataReceived
+    alias:
+    - CPrediction::PostNetworkDataReceived
+  - name: IEngineServiceMgr_GetActiveLoopClientServerMode
+    alias:
+    - IEngineServiceMgr::GetActiveLoopClientServerMode
+  - name: IEngineServiceMgr_GetEventDispatcher
+    alias:
+    - IEngineServiceMgr::GetEventDispatcher
+  - name: ClientModeCSNormal_Update
+    alias:
+    - ClientModeCSNormal::Update
+  - name: CEntitySystem_ctor
+    alias:
+    - CEntitySystem::CEntitySystem
+  - name: CGameEntitySystem_ctor
+    alias:
+    - CGameEntitySystem::CGameEntitySystem
+  - name: CEntitySystem_Init
+    alias:
+    - CEntitySystem::Init
+  - name: CEntitySystem_PostCreateEntitySystem
+    alias:
+    - CEntitySystem::PostCreateEntitySystem
+  - name: CSource2EntitySystem_StaticInit
+    alias:
+    - CSource2EntitySystem::StaticInit
+  - name: CGameSystemReallocatingFactory_CSource2EntitySystem_Init
+    alias:
+    - CGameSystemReallocatingFactory<CSource2EntitySystem>::Init
+  - name: CGameSystemReallocatingFactory_CSource2EntitySystem_CreateGameSystem
+    alias:
+    - CGameSystemReallocatingFactory<CSource2EntitySystem>::CreateGameSystem
+  - name: CSkeletonInstance_PostDataUpdate
+    alias:
+    - CSkeletonInstance::PostDataUpdate
+  - name: CSkeletonInstance_m_modelState
+    alias:
+    - CSkeletonInstance::m_modelState
+  - name: CSkeletonInstance_m_modelState_m_hModel
+    alias:
+    - CSkeletonInstance::m_modelState.m_hModel
+  - name: CModelState_SetupJointState
+    alias:
+    - CModelState::SetupJointState
+  - name: CModelState_m_nTotalTransformCount
+    alias:
+    - CModelState::m_nTotalTransformCount
+  - name: CModelState_m_nBoneCount
+    alias:
+    - CModelState::m_nBoneCount
+  - name: CModelState_m_nAttachmentCount
+    alias:
+    - CModelState::m_nAttachmentCount
+  - name: IVEngineClient2_GetNetworkClient
+    alias:
+    - IVEngineClient2::GetNetworkClient
+  - name: INetworkClient_GetLocalAddress
+    alias:
+    - INetworkClient::GetLocalAddress
+  - name: INetworkClientService_IsConnected
+    alias:
+    - INetworkClientService::IsConnected
+  - name: INetworkClientService_SendNetMessage
+    alias:
+    - INetworkClientService::SendNetMessage
+  - name: IGameResourceService_SetEntityResourceManifestHandler
+    alias:
+    - IGameResourceService::SetEntityResourceManifestHandler
+  - name: CNetworkSerializerBindingBuildFilter_GetFieldPriority
+    alias:
+    - CNetworkSerializerBindingBuildFilter::GetFieldPriority
+- name: server
+  symbols:
+  - name: CSource2Server_OnStreamEntitiesFromFileCompleted
+    alias:
+    - CSource2Server::OnStreamEntitiesFromFileCompleted
+  - name: CSource2Server_PreWorldUpdate
+    alias:
+    - CSource2Server::PreWorldUpdate
+  - name: CSource2Server_OutOfGameFrameBoundary
+    alias:
+    - CSource2Server::OutOfGameFrameBoundary
+  - name: CGameSystemReallocatingFactory_CSource2EntitySystem_Init
+    alias:
+    - CGameSystemReallocatingFactory<CSource2EntitySystem>::Init
+  - name: CGameSystemReallocatingFactory_CSource2EntitySystem_CreateGameSystem
+    alias:
+    - CGameSystemReallocatingFactory<CSource2EntitySystem>::CreateGameSystem
+  - name: IGameSystemFactory_Init
+    alias:
+    - IGameSystemFactory::Init
+  - name: IGameSystemFactory_Shutdown
+    alias:
+    - IGameSystemFactory::Shutdown
+  - name: IGameSystemFactory_SetGlobalPtr
+    alias:
+    - IGameSystemFactory::SetGlobalPtr
+  - name: CGameSystemReallocatingFactory_CSpawnGroupMgrGameSystem_DestroyGameSystem
+    alias:
+    - CGameSystemReallocatingFactory<CSpawnGroupMgrGameSystem>::Deallocate
+  - name: IGameSystem_SetGameSystemGlobalPtrs
+    alias:
+    - IGameSystem::SetGameSystemGlobalPtrs
+  - name: IGameSystem_vdtor
+    alias:
+    - IGameSystem::~IGameSystem
+  - name: IGameSystem_OnGameInit
+    alias:
+    - IGameSystem::GameInit
+  - name: CMultiplayRules_ctor
+    alias:
+    - CMultiplayRules::CMultiplayRules
+  - name: CGameMoney_OnMoneySpent
+    alias:
+    - CGameMoney::OnMoneySpent
+  - name: CGameMoney_m_DataMap
+    alias:
+    - CGameMoney::m_DataMap
+  - name: CGameMoney_GetDataDescMap
+    alias:
+    - CGameMoney::GetDataDescMap
+  - name: CCSPlayer_UseServices_OnUseImpl
+    alias:
+    - CCSPlayer_UseServices::OnUseImpl
+  - name: CCSPlayer_UseServices_OnUse
+    alias:
+    - CCSPlayer_UseServices::OnUse
+  - name: CCSPlayer_MovementServices_ProcessMovement
+    alias:
+    - CCSPlayer_MovementServices::ProcessMovement
+    - ProcessMovement
+  - name: CCSPlayer_MovementServices_CheckMovingGround
+    alias:
+    - CCSPlayer_MovementServices::CheckMovingGround
+    - CheckMovingGround
+  - name: CCSPlayer_MovementServices_WalkMove
+    alias:
+    - CCSPlayer_MovementServices::WalkMove
+    - WalkMove
+  - name: CCSPlayer_MovementServices_FullWalkMove
+    alias:
+    - CCSPlayer_MovementServices::FullWalkMove
+    - FullWalkMove
+  - name: CCSPlayer_MovementServices_CheckVelocity
+    alias:
+    - CCSPlayer_MovementServices::CheckVelocity
+    - CheckVelocity
+  - name: CCSPlayer_MovementServices_WaterMove
+    alias:
+    - CCSPlayer_MovementServices::WaterMove
+    - WaterMove
+  - name: CCSPlayer_MovementServices_FullWalkMove_SpeedClamp
+    alias:
+    - ServerMovementUnlock
+  - name: CCSPlayer_MovementServices_CheckJumpButton
+    alias:
+    - CCSPlayer_MovementServices::CheckJumpButton
+  - name: CCSPlayer_MovementServices_CheckJumpButton_WaterPatch
+    alias:
+    - CheckJumpButtonWater
+    - FixWaterFloorJump
+  - name: CPlayer_MovementServices_PlayWaterStepSound
+    alias:
+    - CPlayer_MovementServices::PlayWaterStepSound
+  - name: CPlayer_MovementServices_ForceButtons
+    alias:
+    - CPlayer_MovementServices::ForceButtons
+  - name: CPlayer_MovementServices_ForceButtonState
+    alias:
+    - CPlayer_MovementServices::ForceButtonState
+  - name: CPlayer_MovementServices_s_pRunCommandPawn
+    alias:
+    - CPlayer_MovementServices::s_pRunCommandPawn
+  - name: CEntityInstance_m_pEntity
+    alias:
+    - CEntityInstance::m_pEntity
+  - name: CEntityInstance_m_hPrivateScope
+    alias:
+    - CEntityInstance::m_hPrivateScope
+  - name: CEntityInstance_m_CScriptComponent
+    alias:
+    - CEntityInstance::m_CScriptComponent
+  - name: CEntityInstance_m_pKeyValues
+    alias:
+    - CEntityInstance::m_pKeyValues
+  - name: CEntityInstance_m_iszPrivateVScripts
+    alias:
+    - CEntityInstance::m_iszPrivateVScripts
+  - name: CBaseEntity_OnRestore
+    alias:
+    - CBaseEntity::OnRestore
+  - name: CEntityInstance_OnRestore
+    alias:
+    - CEntityInstance::OnRestore
+  - name: CBaseEntity_ctor
+    alias:
+    - CBaseEntity::CBaseEntity
+  - name: CBaseEntity_dtor
+    alias:
+    - CBaseEntity::~CBaseEntity
+  - name: CBaseEntity_vdtor
+    alias:
+    - CBaseEntity::~CBaseEntity (virtual)
+  - name: CEntityInstance_vdtor
+    alias:
+    - CEntityInstance::~CEntityInstance (virtual)
+  - name: CEntitySaveRestoreBlockHandler_PreSave
+    alias:
+    - CEntitySaveRestoreBlockHandler::PreSave
+  - name: CEntitySaveRestoreBlockHandler_SaveInternal
+    alias:
+    - CEntitySaveRestoreBlockHandler::SaveInternal
+  - name: CEntitySaveRestoreBlockHandler_Save
+    alias:
+    - CEntitySaveRestoreBlockHandler::Save
+  - name: CEntitySaveRestoreBlockHandler_Restore
+    alias:
+    - CEntitySaveRestoreBlockHandler::Restore
+  - name: CEntitySaveRestoreBlockHandler_DoRestoreEntity
+    alias:
+    - CEntitySaveRestoreBlockHandler::DoRestoreEntity
+  - name: CEntitySaveRestoreBlockHandler_RestoreEntity
+    alias:
+    - CEntitySaveRestoreBlockHandler::RestoreEntity
+  - name: CreateEntityTransitionList
+    alias:
+    - CreateEntityTransitionList
+  - name: CEntitySaveRestoreBlockHandler_WriteSaveHeaders
+    alias:
+    - CEntitySaveRestoreBlockHandler::WriteSaveHeaders
+  - name: CEntitySaveRestoreBlockHandler_ReadRestoreHeaders
+    alias:
+    - CEntitySaveRestoreBlockHandler::ReadRestoreHeaders
+  - name: CEntity2SaveRestore_StreamEntitiesFromFile
+    alias:
+    - CEntity2SaveRestore::StreamEntitiesFromFile
+  - name: CSaveRestoreBlockSet_PreRestore
+    alias:
+    - CSaveRestoreBlockSet::PreRestore
+  - name: CSaveRestoreBlockSet_PostRestore
+    alias:
+    - CSaveRestoreBlockSet::PostRestore
+  - name: CEntitySaveRestoreBlockHandler_PreRestore
+    alias:
+    - CEntitySaveRestoreBlockHandler::PreRestore
+  - name: CEntitySaveRestoreBlockHandler_PostRestore
+    alias:
+    - CEntitySaveRestoreBlockHandler::PostRestore
+  - name: CEntitySystem_ForceSetInPVSCallsIntoQueue
+    alias:
+    - CEntitySystem::ForceSetInPVSCallsIntoQueue
+  - name: CEntitySystem_ExecuteQueuedSetInPVS
+    alias:
+    - CEntitySystem::ExecuteQueuedSetInPVS
+  - name: CEntitySystem_m_nSuppressDormancyChangeCount
+    alias:
+    - CEntitySystem::m_nSuppressDormancyChangeCount
+  - name: CEntitySystem_m_nExecuteQueuedCreationDepth
+    alias:
+    - CEntitySystem::m_nExecuteQueuedCreationDepth
+  - name: CEntitySystem_m_queuedDormancyChanges
+    alias:
+    - CEntitySystem::m_queuedDormancyChanges
+  - name: CEntitySystem_SetInPVS
+    alias:
+    - CEntitySystem::SetInPVS
+  - name: CEntitySystem_OnSetDormant
+    alias:
+    - CEntitySystem::OnSetDormant
+  - name: CEntitySystem_BuildResourceManifestForEntity
+    alias:
+    - CEntitySystem::BuildResourceManifestForEntity
+  - name: CEntityInstance_ObjectCaps
+    alias:
+    - CEntityInstance::ObjectCaps
+  - name: CEntityInstance_Save
+    alias:
+    - CEntityInstance::Save
+  - name: CEntityInstance_Restore
+    alias:
+    - CEntityInstance::Restore
+  - name: CEntitySaveRestoreBlockHandler_SaveInitEntities
+    alias:
+    - CEntitySaveRestoreBlockHandler::SaveInitEntities
+  - name: CEntityInstance_OnSave
+    alias:
+    - CEntityInstance::OnSave
+  - name: CEntityInstance_RequiredEdictIndex
+    alias:
+    - CEntityInstance::RequiredEdictIndex
+  - name: PolymorphicHelper_t__SetPolymorphicPointer
+    alias:
+    - PolymorphicHelper_t::SetPolymorphicPointer
+  - name: CEntityInstance_AddChangeAccessorPathPolymorphic
+    alias:
+    - CEntityInstance::AddChangeAccessorPathPolymorphic
+  - name: CEntityInstance_AssignChangeAccessorPathIdsPolymorphic
+    alias:
+    - CEntityInstance::AssignChangeAccessorPathIdsPolymorphic
+  - name: CEntityInstance_AddChangeAccessorPath
+    alias:
+    - CEntityInstance::AddChangeAccessorPath
+  - name: CEntityInstance_AssignChangeAccessorPathIds
+    alias:
+    - CEntityInstance::AssignChangeAccessorPathIds
+  - name: CEntityInstance_GetChangeAccessorPathInfo_2
+    alias:
+    - CEntityInstance::GetChangeAccessorPathInfo_2
+  - name: CBaseEntity_GetChangeAccessorPathInfo_2
+    alias:
+    - CBaseEntity::GetChangeAccessorPathInfo_2
+  - name: CBaseEntity_GetChangeAccessorPathInfo_1
+    alias:
+    - CBaseEntity::GetChangeAccessorPathInfo_1
+  - name: CMomentaryRotButton_Use
+    alias:
+    - CMomentaryRotButton::Use
+  - name: CBaseEntity_TakeDamageOld
+    alias:
+    - CBaseEntity::TakeDamageOld
+  - name: CBaseEntity_OnTakeDamage
+    alias:
+    - CBasePlayerPawn::OnTakeDamage
+  - name: CBasePlayerPawn_OnTakeDamage_Alive
+    alias:
+    - CBasePlayerPawn::OnTakeDamage_Alive
+  - name: CBasePlayerPawn_OnTakeDamage_Dying
+    alias:
+    - CBasePlayerPawn::OnTakeDamage_Dying
+  - name: CBasePlayerPawn_OnTakeDamage_Dead
+    alias:
+    - CBasePlayerPawn::OnTakeDamage_Dead
+  - name: CBasePlayerPawn_OnTakeDamage
+    alias:
+    - CBasePlayerPawn::OnTakeDamage
+  - name: CCSPlayerPawn_OnTakeDamage_Alive
+    alias:
+    - CCSPlayerPawn::OnTakeDamage_Alive
+  - name: CCSPlayerPawn_OnTakeDamage_Dying
+    alias:
+    - CCSPlayerPawn::OnTakeDamage_Dying
+  - name: CCSPlayerPawn_OnTakeDamage_Dead
+    alias:
+    - CCSPlayerPawn::OnTakeDamage_Dead
+  - name: CFlashbangProjectile_Spawn
+    alias:
+    - CFlashbangProjectile::Spawn
+  - name: CSmokeGrenadeProjectile_Create
+    alias:
+    - CSmokeGrenadeProjectile::Create
+  - name: CEntitySystem_QueueDestroyEntity
+    alias:
+    - CEntitySystem::QueueDestroyEntity
+  - name: CEntitySystem_ExecuteQueuedDeletion
+    alias:
+    - CEntitySystem::ExecuteQueuedDeletion
+  - name: CEntitySystem_m_nExecuteQueuedDeletionDepth
+    alias:
+    - CEntitySystem::m_nExecuteQueuedDeletionDepth
+  - name: CBaseModelEntity_SetModel
+    alias:
+    - CBaseModelEntity::SetModel
+  - name: CBaseModelEntity_SetRenderAttribute
+    alias:
+    - CBaseModelEntity::SetRenderAttribute
+  - name: CBaseEntity_GetScriptDescInternal
+    alias:
+    - CBaseEntity::GetScriptDescInternal
+  - name: CBaseModelEntity_GetScriptDescInternal
+    alias:
+    - CBaseModelEntity::GetScriptDescInternal
+  - name: CBaseModelEntity_GetModelScale
+    alias:
+    - CBaseModelEntity::GetModelScale
+  - name: CBaseModelEntity_Script_SetModelScale
+    alias:
+    - CBaseModelEntity::Script_SetModelScale
+  - name: CBaseModelEntity_ScriptLookupAttachment
+    alias:
+    - CBaseModelEntity::ScriptLookupAttachment
+  - name: CBaseModelEntity_ScriptGetAttachmentOrigin
+    alias:
+    - CBaseModelEntity::ScriptGetAttachmentOrigin
+  - name: CBaseModelEntity_ScriptGetAttachmentAngles
+    alias:
+    - CBaseModelEntity::ScriptGetAttachmentAngles
+  - name: CBaseModelEntity_ScriptGetAttachmentForward
+    alias:
+    - CBaseModelEntity::ScriptGetAttachmentForward
+  - name: CBaseModelEntity_ScriptSetSize
+    alias:
+    - CBaseModelEntity::ScriptSetSize
+  - name: CBaseModelEntity_ScriptSetModel
+    alias:
+    - CBaseModelEntity::ScriptSetModel
+  - name: CBaseModelEntity_ScriptGetRenderAlpha
+    alias:
+    - CBaseModelEntity::ScriptGetRenderAlpha
+  - name: CBaseModelEntity_ScriptSetRenderAlpha
+    alias:
+    - CBaseModelEntity::ScriptSetRenderAlpha
+  - name: CBaseModelEntity_ScriptSetRenderMode
+    alias:
+    - CBaseModelEntity::ScriptSetRenderMode
+  - name: CBaseModelEntity_ScriptSetRenderColor
+    alias:
+    - CBaseModelEntity::ScriptSetRenderColor
+  - name: CBaseModelEntity_ScriptGetRenderColor
+    alias:
+    - CBaseModelEntity::ScriptGetRenderColor
+  - name: CBaseModelEntity_ScriptSetMaterialGroup
+    alias:
+    - CBaseModelEntity::ScriptSetMaterialGroup
+  - name: CBaseModelEntity_ScriptSetMaterialGroupHash
+    alias:
+    - CBaseModelEntity::ScriptSetMaterialGroupHash
+  - name: CBaseModelEntity_ScriptGetMaterialGroupHash
+    alias:
+    - CBaseModelEntity::ScriptGetMaterialGroupHash
+  - name: CBaseModelEntity_ScriptSetSingleMeshGroup
+    alias:
+    - CBaseModelEntity::ScriptSetSingleMeshGroup
+  - name: CBaseModelEntity_ScriptSetMeshGroupMask
+    alias:
+    - CBaseModelEntity::ScriptSetMeshGroupMask
+  - name: CBaseModelEntity_ScriptGetMeshGroupMask
+    alias:
+    - CBaseModelEntity::ScriptGetMeshGroupMask
+  - name: CBaseModelEntity_ScriptSetBodygroupByName
+    alias:
+    - CBaseModelEntity::ScriptSetBodygroupByName
+  - name: CBaseModelEntity_Script_SetBodygroup
+    alias:
+    - CBaseModelEntity::Script_SetBodygroup
+  - name: CBaseModelEntity_Script_SetSkin
+    alias:
+    - CBaseModelEntity::Script_SetSkin
+  - name: CEntityInstance_NetworkUpdateState_thunk
+    alias:
+    - CEntityInstance::NetworkUpdateState_thunk
+  - name: CBaseEntity_SetGravityScale
+    alias:
+    - CBaseEntity::SetGravityScale
+  - name: CTriggerGravity_GravityTouch
+    alias:
+    - CTriggerGravity::GravityTouch
+  - name: CTriggerGravity_GetTouchFunction
+    alias:
+    - CTriggerGravity::GetTouchFunction
+  - name: CBasePlayerController_HandleCommand_JoinTeam
+    alias:
+    - CBasePlayerController::HandleCommand_JoinTeam
+  - name: CBasePlayerController_SetPlayerName
+    alias:
+    - CBasePlayerController::SetPlayerName
+  - name: CBasePlayerController_ProcessUsercmds
+    alias:
+    - ProcessUsercmds
+  - name: CBasePlayerController_SetPawn
+    alias:
+    - CBasePlayerController::SetPawn
+  - name: CBasePlayerController_GetPawn
+    alias:
+    - CBasePlayerController::GetPawn
+  - name: CBasePlayerController_Connect
+    alias:
+    - CBasePlayerController::Connect
+  - name: CSource2GameClients_ClientDisconnect
+    alias:
+    - CSource2GameClients::ClientDisconnect
+  - name: CSource2GameClients_ClientPutInServer
+    alias:
+    - CSource2GameClients::ClientPutInServer
+  - name: CSource2GameClients_ClientConnect
+    alias:
+    - CSource2GameClients::ClientConnect
+  - name: CSource2GameClients_ClientActive
+    alias:
+    - CSource2GameClients::ClientActive
+  - name: CSource2GameClients_ClientFullyConnect
+    alias:
+    - CSource2GameClients::ClientFullyConnect
+  - name: CSource2GameClients_ClientCommand
+    alias:
+    - CSource2GameClients::ClientCommand
+  - name: CSource2GameClients_ProcessUsercmds
+    alias:
+    - CSource2GameClients::ProcessUsercmds
+  - name: CSource2GameClients_GetBugReportInfo
+    alias:
+    - CSource2GameClients::GetBugReportInfo
+  - name: CSource2GameClients_ClientDiagnostic
+    alias:
+    - CSource2GameClients::ClientDiagnostic
+  - name: CSource2GameClients_SendHLTVStatusMessage
+    alias:
+    - CSource2GameClients::SendHLTVStatusMessage
+  - name: CSource2GameClients_OnClientConnected
+    alias:
+    - CSource2GameClients::OnClientConnected
+  - name: CGameRules_FindPickerEntity
+    alias:
+    - CGameRules::FindPickerEntity
+  - name: CCSGameRules_FindPickerEntity
+    alias:
+    - CCSGameRules::FindPickerEntity
+  - name: CCSGameRules_TerminateRound
+    alias:
+    - CCSGameRules::TerminateRound
+    - CGameRules::TerminateRound
+    - CGameRules_TerminateRound
+  - name: CCSGameRules_GoToIntermission
+    alias:
+    - CCSGameRules::GoToIntermission
+  - name: CEntityInstance_AcceptInput
+    alias:
+    - CEntityInstance::AcceptInput
+    - AcceptInput
+  - name: CEntityIdentity_AcceptInput
+    alias:
+    - CEntityIdentity::AcceptInput
+  - name: CEntityIdentity_AcceptInputInternal
+    alias:
+    - CEntityIdentity::AcceptInputInternal
+  - name: CEntityInstance_ScriptAcceptInput
+    alias:
+    - CEntityInstance::ScriptAcceptInput
+  - name: CEntityIdentity_SetEntityName
+    alias:
+    - CEntityIdentity::SetEntityName
+  - name: CEntitySystem_RemoveEntityFromNameMap
+    alias:
+    - CEntitySystem::RemoveEntityFromNameMap
+  - name: CEntitySystem_AddEntityToNameMap
+    alias:
+    - CEntitySystem::AddEntityToNameMap
+  - name: ScriptBinding_Entity_SetEntityName
+    alias:
+    - Entity::SetEntityName
+  - name: CBtActionCoordinatedBuy_Update
+    alias:
+    - CBtActionCoordinatedBuy::Update
+  - name: CCSPlayer_ItemServices_CanAcquire
+    alias:
+    - CCSPlayer_ItemServices::CanAcquire
+  - name: CCSPlayer_ItemServices_GiveDefaultItems
+    alias:
+    - CCSPlayer_ItemServices::GiveDefaultItems
+  - name: CCSPlayer_ItemServices_GiveNamedItem
+    alias:
+    - CCSPlayer_ItemServices::GiveNamedItem
+  - name: CCSPlayer_ItemServices_GiveNamedItemBool
+    alias:
+    - CCSPlayer_ItemServices::GiveNamedItemBool
+  - name: CCSPlayer_WeaponServices_CanUse
+    alias:
+    - CCSPlayer_WeaponServices::CanUse
+  - name: CCSPlayer_WeaponServices_PickupItem
+    alias:
+    - CCSPlayer_WeaponServices::PickupItem
+  - name: CCSPlayer_WeaponServices_EquipWeapon
+    alias:
+    - CCSPlayer_WeaponServices::EquipWeapon
+  - name: CCSPlayer_WeaponServices_Weapon_GetSlot
+    alias:
+    - CCSPlayer_WeaponServices_Weapon_GetSlot
+  - name: CCSPlayerController_ChangeTeam
+    alias:
+    - CCSPlayerController::ChangeTeam
+  - name: CCSPlayerController_GetThinkFunction
+    alias:
+    - CCSPlayerController::GetThinkFunction
+  - name: CCSPlayerController_PlayerForceTeamThink
+    alias:
+    - PlayerForceTeamThink
+    - CCSPlayerController::PlayerForceTeamThink
+  - name: CCSPlayerController_ResetForceTeamThink
+    alias:
+    - ResetForceTeamThink
+    - CCSPlayerController::ResetForceTeamThink
+  - name: CCSPlayerController_ResourceDataThink
+    alias:
+    - ResourceDataThink
+    - CCSPlayerController::ResourceDataThink
+  - name: CCSPlayerController_InventoryUpdateThink
+    alias:
+    - InventoryUpdateThink
+    - CCSPlayerController::InventoryUpdateThink
+  - name: g_CCSPlayerController_PlayerForceTeamThink
+    alias:
+    - g_CCSPlayerController::PlayerForceTeamThink
+  - name: g_CCSPlayerController_ResetForceTeamThink
+    alias:
+    - g_CCSPlayerController::ResetForceTeamThink
+  - name: g_CCSPlayerController_ResourceDataThink
+    alias:
+    - g_CCSPlayerController::ResourceDataThink
+  - name: g_CCSPlayerController_InventoryUpdateThink
+    alias:
+    - g_CCSPlayerController::InventoryUpdateThink
+  - name: CCSGameRules__sm_mapGcBanInformation
+    alias:
+    - CCSGameRules::sm_mapGcBanInformation
+  - name: CCSGameRules_BeginRound
+    alias:
+    - CCSGameRules::BeginRound
+  - name: CCSGameRules_PlayerSpawn
+    alias:
+    - CCSGameRules::PlayerSpawn
+  - name: CBasePlayerController_Respawn
+    alias:
+    - CBasePlayerController::Respawn
+  - name: CCSPlayerController_Respawn
+    alias:
+    - CCSPlayerController::Respawn
+  - name: CCSPlayerController_Connect
+    alias:
+    - CCSPlayerController::Connect
+  - name: CCSPlayerController_SwitchTeam
+    alias:
+    - CCSPlayerController::SwitchTeam
+  - name: CCSPlayerPawnBase_OnSetDormant
+    alias:
+    - CCSPlayerPawnBase::OnSetDormant
+  - name: CCSPlayerPawnBase_CheckForIdle
+    alias:
+    - CCSPlayerPawnBase::CheckForIdle
+  - name: CCSPlayerPawnBase_CheckForIdleInternal
+    alias:
+    - CCSPlayerPawnBase::CheckForIdleInternal
+  - name: CCSPlayerPawn_PostThink
+    alias:
+    - CCSPlayerPawnBase::PostThink
+    - CCSPlayerPawn::PostThink
+    - CCSPlayerPawnBase_PostThink
+    - CCSPlayerPawn_PostThink
+    - PostThink
+  - name: CCSPlayerPawn_OnSwitchWeapons
+    alias:
+    - CCSPlayerPawn::OnSwitchWeapons
+  - name: CCSPlayerPawn_ProcessSuicideAsKillReward
+    alias:
+    - CCSPlayerPawn::ProcessSuicideAsKillReward
+  - name: CGameRules_ClientSettingsChanged
+    alias:
+    - CGameRules::ClientSettingsChanged
+  - name: CGameRulesGameSystem_OnGameInit
+    alias:
+    - CGameRulesGameSystem::GameInit
+  - name: CGameRulesGameSystem_OnGameShutdown
+    alias:
+    - CGameRulesGameSystem::GameShutdown
+  - name: IGameSystem_OnGameShutdown
+    alias:
+    - IGameSystem::GameShutdown
+  - name: IGameSystem_OnGamePostInit
+    alias:
+    - IGameSystem::GamePostInit
+  - name: IGameSystem_OnGamePreShutdown
+    alias:
+    - IGameSystem::GamePreShutdown
+  - name: CMultiplayRules_ClientDisconnected
+    alias:
+    - CMultiplayRules::ClientDisconnected
+  - name: CSource2Server_Init
+    alias:
+    - CSource2Server::Init
+  - name: CSource2Server_ApplyGameSettings
+    alias:
+    - CSource2Server::ApplyGameSettings
+  - name: CSource2Server_WriteSignonMessages
+    alias:
+    - CSource2Server::WriteSignonMessages
+  - name: CSource2Server_GameCreateNetworkStringTables
+    alias:
+    - CSource2Server::GameCreateNetworkStringTables
+  - name: CSource2Server_GetMatchmakingGameData
+    alias:
+    - CSource2Server::GetMatchmakingGameData
+  - name: CSource2Server_GameServerSteamAPIActivated
+    alias:
+    - CSource2Server::GameServerSteamAPIActivated
+  - name: CSource2Server_GameServerSteamAPIDeactivated
+    alias:
+    - CSource2Server::GameServerSteamAPIDeactivated
+  - name: CSource2Server_OnHostNameChanged
+    alias:
+    - CSource2Server::OnHostNameChanged
+  - name: CSource2Server_GetLevelsFromSaveFile
+    alias:
+    - CSource2Server::GetLevelsFromSaveFile
+  - name: CSource2Server_ServerConVarChanged
+    alias:
+    - CSource2Server::ServerConVarChanged
+  - name: CSource2Server_Save
+    alias:
+    - CSource2Server::Save
+  - name: CSource2Server_Connect
+    alias:
+    - CSource2Server::Connect
+  - name: CSource2Server_PreShutdown
+    alias:
+    - CSource2Server::PreShutdown
+  - name: IAppSystem_Connect
+    alias:
+    - IAppSystem::Connect
+  - name: IAppSystem_PreShutdown
+    alias:
+    - IAppSystem::PreShutdown
+  - name: IVEngineServer2_ServerCommand
+    alias:
+    - IVEngineServer2::ServerCommand
+  - name: IVEngineServer2_IsDedicatedServer
+    alias:
+    - IVEngineServer2::IsDedicatedServer
+  - name: CSource2Server_Shutdown
+    alias:
+    - CSource2Server::Shutdown
+  - name: CGameEventManager_Shutdown
+    alias:
+    - CGameEventManager::Shutdown
+  - name: CLoopModeRegistry_UnregisterLoopModes
+    alias:
+    - CLoopModeRegistry::UnregisterLoopModes
+  - name: CEngineServiceRegistry_UnregisterEngineServices
+    alias:
+    - CEngineServiceRegistry::UnregisterEngineServices
+  - name: IEngineServiceMgr_UnregisterLoopMode
+    alias:
+    - IEngineServiceMgr::UnregisterLoopMode
+  - name: IEngineServiceMgr_UnregisterEngineService
+    alias:
+    - IEngineServiceMgr::UnregisterEngineService
+  - name: CSource2Server_GameFrame
+    alias:
+    - CSource2Server::GameFrame
+  - name: CGameEventManager_Init
+    alias:
+    - CGameEventManager::Init
+  - name: CTakeDamageInfo_HitGroupInfo
+    alias:
+    - CTakeDamageInfo::HitGroupInfo
+    - CTakeDamageInfo::HitGroup
+    - CTakeDamageInfo_HitGroup
+  - name: CEntitySystem_RegisterEntityClass
+    alias:
+    - CEntitySystem::RegisterEntityClass
+  - name: CEntitySystem_CreateEntityByName
+    alias:
+    - CEntitySystem::CreateEntityByName
+  - name: CEntitySystem_CreateEntity
+    alias:
+    - CEntitySystem::CreateEntity
+  - name: CEntitySystem_AddEntityToEntityDataBase
+    alias:
+    - CEntitySystem::AddEntityToEntityDataBase
+  - name: CEntitySystem_OnAddEntity
+    alias:
+    - CEntitySystem::OnAddEntity
+  - name: CEntitySystem_OnEntityParentChanged
+    alias:
+    - CEntitySystem::OnEntityParentChanged
+  - name: CEntitySystem_PrecacheEntity
+    alias:
+    - CEntitySystem::PrecacheEntity
+  - name: CEntitySystem_InvokePrecacheCallback
+    alias:
+    - CEntitySystem::InvokePrecacheCallback
+  - name: CEntitySystem_DestroyEntity
+    alias:
+    - CEntitySystem::DestroyEntity
+  - name: CConcreteEntityList_AllocEntity
+    alias:
+    - CConcreteEntityList::AllocEntity
+  - name: CEntitySystem_ConstructEntity
+    alias:
+    - CEntitySystem::ConstructEntity
+  - name: CEntitySystem_DoConstructEntity
+    alias:
+    - CEntitySystem::DoConstructEntity
+  - name: CEntitySystem_GetSpawnGroupWorldId
+    alias:
+    - CEntitySystem::GetSpawnGroupWorldId
+  - name: CEntitySystem_FindClassByDesignName
+    alias:
+    - CEntitySystem::FindClassByDesignName
+  - name: CEntitySystem_m_EntityList
+    alias:
+    - CEntitySystem::m_EntityList
+  - name: CEntitySystem_m_entityNames
+    alias:
+    - CEntitySystem::m_entityNames
+  - name: CEntitySystem_m_entityComponentHelpers
+    alias:
+    - CEntitySystem::m_entityComponentHelpers
+  - name: CEntitySystem_m_DataDescKeyUnserializers
+    alias:
+    - CEntitySystem::m_DataDescKeyUnserializers
+  - name: CEntitySystem_m_EntityPostSpawnCallback
+    alias:
+    - CEntitySystem::m_EntityPostSpawnCallback
+  - name: CEntityIdentity_FreeAttributes
+    alias:
+    - CEntityIdentity::FreeAttributes
+  - name: CConcreteEntityList_FreeEntity
+    alias:
+    - CConcreteEntityList::FreeEntity
+  - name: UTIL_CreateEntityByName
+    alias:
+    - CreateEntityByName
+  - name: CBaseEntity_DispatchSpawn
+    alias:
+    - CBaseEntity::DispatchSpawn
+    - DispatchSpawn
+  - name: CEntitySystem_QueueSpawnEntity
+    alias:
+    - CEntitySystem::QueueSpawnEntity
+  - name: CEntitySystem_HelperExecuteQueuedSpawn
+    alias:
+    - CEntitySystem::HelperExecuteQueuedSpawn
+  - name: CEntitySystem_SortEntities
+    alias:
+    - CEntitySystem::SortEntities
+  - name: CGameEntitySystem_SortEntities
+    alias:
+    - CGameEntitySystem::SortEntities
+  - name: CEntitySystem_InstallCreationWrapperCallbacks
+    alias:
+    - CEntitySystem::InstallCreationWrapperCallbacks
+  - name: CEntitySystem_ExecuteQueuedCreation
+    alias:
+    - CEntitySystem::ExecuteQueuedCreation
+  - name: CEntitySystem_ExecuteQueuedActivates
+    alias:
+    - CEntitySystem::ExecuteQueuedActivates
+  - name: CEntitySystem_ExecuteQueuedPostDataUpdateAndActivates
+    alias:
+    - CEntitySystem::ExecuteQueuedPostDataUpdateAndActivates
+  - name: CEntitySystem_Activate
+    alias:
+    - CEntitySystem::Activate
+  - name: CEntitySystem_PostDataUpdate
+    alias:
+    - CEntitySystem::PostDataUpdate
+  - name: CBaseEntity_NetworkStateChangedLog
+    alias:
+    - CBaseEntity::NetworkStateChangedLog
+  - name: CBaseEntity_NetworkStateChanged
+    alias:
+    - CBaseEntity::NetworkStateChanged
+  - name: CBaseEntity_FullEdictChanged
+    alias:
+    - CBaseEntity::FullEdictChanged
+  - name: CBaseEntity_m_NetworkTransmitComponent
+    alias:
+    - CBaseEntity::m_NetworkTransmitComponent
+  - name: CNetworkTransmitComponent_StateChanged
+    alias:
+    - CNetworkTransmitComponent::StateChanged
+  - name: CNetworkTransmitComponent_m_nStateFlags
+    alias:
+    - CNetworkTransmitComponent::m_nStateFlags
+  - name: CInferno_InfernoThink
+    alias:
+    - CInferno::InfernoThink
+  - name: CPhysExplosion_Activate
+    alias:
+    - CPhysExplosion::Activate
+  - name: CPhysExplosion_Explode
+    alias:
+    - CPhysExplosion::Explode
+  - name: UTIL_SayTextFilter2
+    alias:
+    - UTIL_SayText2Filter
+  - name: CCSWeaponBase_ItemPostFrame_ProcessReloadAction
+    alias:
+    - CCSWeaponBase::ItemPostFrame::ProcessReloadAction
+  - name: CCSPlayer_WeaponServices_HandleDropWeapon
+    alias:
+    - CCSPlayer_WeaponServices::HandleDropWeapon
+  - name: CCSPlayer_UseServices_BumpWeapon
+    alias:
+    - CCSPlayer_UseServices::BumpWeapon
+  - name: CCSPlayerPawn_HandleDropWeapon
+    alias:
+    - CCSPlayerPawn::HandleDropWeapon
+  - name: CCSPlayerPawn_ClientCommand
+    alias:
+    - CCSPlayerPawn::ClientCommand
+  - name: CCSPlayerPawn_SprayPaint
+    alias:
+    - CCSPlayerPawn::SprayPaint
+  - name: CEntitySpawner_CPlayerSprayDecal_Spawn
+    alias:
+    - CEntitySpawner<CPlayerSprayDecal>::Spawn
+  - name: CEntityKeyValuesAllocator_GetTempBuffer
+    alias:
+    - CEntityKeyValuesAllocator::GetTempBuffer
+  - name: CEntityKeyValues_LoadFromContext
+    alias:
+    - CEntityKeyValues::LoadFromContext
+  - name: CEntityKeyValues_Initialized
+    alias:
+    - CEntityKeyValues::Initialized
+  - name: CEntitySystem_m_nEntityKeyValuesAllocatorRefCount
+    alias:
+    - CEntitySystem::m_nEntityKeyValuesAllocatorRefCount
+  - name: CEntitySystem_AddRefKeyValues
+    alias:
+    - CEntitySystem::AddRefKeyValues
+  - name: CEntitySystem_ReleaseKeyValues
+    alias:
+    - CEntitySystem::ReleaseKeyValues
+  - name: CCSPlayerController_HandleCommandDrop
+    alias:
+    - CCSPlayerController::HandleCommandDrop
+  - name: IGameSystem_InitAllSystems
+    alias:
+    - IGameSystem::InitAllSystems
+  - name: IGameSystem_LoopInitAllSystems
+    alias:
+    - IGameSystem::LoopInitAllSystems
+  - name: IGameSystem_LoopPostInitAllSystems
+    alias:
+    - IGameSystem::LoopPostInitAllSystems
+  - name: IGameSystem_PostInit
+    alias:
+    - IGameSystem::PostInit
+  - name: IGameSystemFactory_PostInit
+    alias:
+    - IGameSystemFactory::PostInit
+  - name: IGameSystemFactory_GetStaticGameSystem
+    alias:
+    - IGameSystemFactory::GetStaticGameSystem
+  - name: IGameSystem_InitAllSystems_pFirst
+    alias:
+    - IGameSystem::InitAllSystems::pFirst
+    - IGameSystem::InitAllSystems->pFirst
+  - name: IGameSystem_LoopPostInitAllSystems_pEventDispatcher
+    alias:
+    - IGameSystem::LoopPostInitAllSystems::pEventDispatcher
+    - IGameSystem::LoopPostInitAllSystems->pEventDispatcher
+  - name: IGameSystem_LoopDestroyAllSystems_s_GameSystems
+    alias:
+    - IGameSystem::LoopDestroyAllSystems::s_GameSystems
+    - IGameSystem::LoopDestroyAllSystems->s_GameSystems
+  - name: CSource2GameEntities_CheckTransmit
+    alias:
+    - CSource2GameEntities::CheckTransmit
+    - ISource2GameEntities::CheckTransmit
+    - ISource2GameEntities_CheckTransmit
+    - CheckTransmit
+  - name: CBaseEntity_EmitSoundFilter
+    alias:
+    - CBaseEntity::EmitSoundFilter
+  - name: CBaseEntity_ScriptInputKill
+    alias:
+    - CBaseEntity::ScriptInputKill
+  - name: CBaseEntity_ScriptGetForward
+    alias:
+    - CBaseEntity::ScriptGetForward
+  - name: CBaseEntity_ScriptGetRight
+    alias:
+    - CBaseEntity::ScriptGetRight
+  - name: CBaseEntity_ScriptGetLeft
+    alias:
+    - CBaseEntity::ScriptGetLeft
+  - name: CBaseEntity_ScriptGetUp
+    alias:
+    - CBaseEntity::ScriptGetUp
+  - name: CBaseEntity_ScriptGetModelName
+    alias:
+    - CBaseEntity::ScriptGetModelName
+  - name: CBaseEntity_ScriptGetMoveParent
+    alias:
+    - CBaseEntity::ScriptGetMoveParent
+  - name: CBaseEntity_ScriptGetRootMoveParent
+    alias:
+    - CBaseEntity::ScriptGetRootMoveParent
+  - name: CBaseEntity_ScriptFirstMoveChild
+    alias:
+    - CBaseEntity::ScriptFirstMoveChild
+  - name: CBaseEntity_ScriptNextMovePeer
+    alias:
+    - CBaseEntity::ScriptNextMovePeer
+  - name: CBaseEntity_ScriptGetOwnerEntity
+    alias:
+    - CBaseEntity::ScriptGetOwnerEntity
+  - name: CBaseEntity_Script_GetChildren
+    alias:
+    - CBaseEntity::Script_GetChildren
+  - name: CBaseEntity_ScriptSetParent
+    alias:
+    - CBaseEntity::ScriptSetParent
+  - name: CBaseEntity_ScriptEyePosition
+    alias:
+    - CBaseEntity::ScriptEyePosition
+  - name: CBaseEntity_ScriptSetAngles
+    alias:
+    - CBaseEntity::ScriptSetAngles
+  - name: CBaseEntity_ScriptSetAbsAngles
+    alias:
+    - CBaseEntity::ScriptSetAbsAngles
+  - name: CBaseEntity_ScriptGetAngles
+    alias:
+    - CBaseEntity::ScriptGetAngles
+  - name: CBaseEntity_ScriptEyeAngles
+    alias:
+    - CBaseEntity::ScriptEyeAngles
+  - name: CBaseEntity_ScriptSetOrigin
+    alias:
+    - CBaseEntity::ScriptSetOrigin
+  - name: CBaseEntity_ScriptSetLocalAngles
+    alias:
+    - CBaseEntity::ScriptSetLocalAngles
+  - name: CBaseEntity_ScriptGetLocalAngles
+    alias:
+    - CBaseEntity::ScriptGetLocalAngles
+  - name: CBaseEntity_ScriptSetLocalOrigin
+    alias:
+    - CBaseEntity::ScriptSetLocalOrigin
+  - name: CBaseEntity_ScriptGetLocalOrigin
+    alias:
+    - CBaseEntity::ScriptGetLocalOrigin
+  - name: CBaseEntity_ScriptTransformPointEntityToWorld
+    alias:
+    - CBaseEntity::ScriptTransformPointEntityToWorld
+  - name: CBaseEntity_ScriptTransformPointWorldToEntity
+    alias:
+    - CBaseEntity::ScriptTransformPointWorldToEntity
+  - name: CBaseEntity_ScriptSetForward
+    alias:
+    - CBaseEntity::ScriptSetForward
+  - name: CBaseEntity_ScriptGetBoundingMins
+    alias:
+    - CBaseEntity::ScriptGetBoundingMins
+  - name: CBaseEntity_ScriptGetBoundingMaxs
+    alias:
+    - CBaseEntity::ScriptGetBoundingMaxs
+  - name: CBaseEntity_ScriptGetBounds
+    alias:
+    - CBaseEntity::ScriptGetBounds
+  - name: CBaseEntity_ScriptGetLocalAngularVelocity_OBSOLETE
+    alias:
+    - CBaseEntity::ScriptGetLocalAngularVelocity_OBSOLETE
+  - name: CBaseEntity_ScriptSetLocalAngularVelocity_OBSOLETE
+    alias:
+    - CBaseEntity::ScriptSetLocalAngularVelocity_OBSOLETE
+  - name: CBaseEntity_ScriptAddEffects
+    alias:
+    - CBaseEntity::ScriptAddEffects
+  - name: CBaseEntity_ScriptRemoveEffects
+    alias:
+    - CBaseEntity::ScriptRemoveEffects
+  - name: CBaseEntity_ScriptSetAttributeFloatValue
+    alias:
+    - CBaseEntity::ScriptSetAttributeFloatValue
+  - name: CBaseEntity_ScriptGetAttributeFloatValue
+    alias:
+    - CBaseEntity::ScriptGetAttributeFloatValue
+  - name: CBaseEntity_ScriptSetAttributeIntValue
+    alias:
+    - CBaseEntity::ScriptSetAttributeIntValue
+  - name: CBaseEntity_ScriptGetAttributeIntValue
+    alias:
+    - CBaseEntity::ScriptGetAttributeIntValue
+  - name: CBaseEntity_ScriptHasAttribute
+    alias:
+    - CBaseEntity::ScriptHasAttribute
+  - name: CBaseEntity_ScriptDeleteAttribute
+    alias:
+    - CBaseEntity::ScriptDeleteAttribute
+  - name: CBaseEntity_GetScriptOwnerEntity
+    alias:
+    - CBaseEntity::GetScriptOwnerEntity
+  - name: CBaseEntity_SetScriptOwnerEntity
+    alias:
+    - CBaseEntity::SetScriptOwnerEntity
+  - name: CBaseEntity_ScriptSetEntityName
+    alias:
+    - CBaseEntity::ScriptSetEntityName
+  - name: CBaseEntity_ScriptGetMass
+    alias:
+    - CBaseEntity::ScriptGetMass
+  - name: CBaseEntity_ScriptSetMass
+    alias:
+    - CBaseEntity::ScriptSetMass
+  - name: CBaseEntity_ScriptGetSpawnGroupHandle
+    alias:
+    - CBaseEntity::ScriptGetSpawnGroupHandle
+  - name: CBaseEntity_GetAbsAngles
+    alias:
+    - CBaseEntity::GetAbsAngles
+  - name: CBaseEntity_Script_GetTeamNumber
+    alias:
+    - CBaseEntity::Script_GetTeamNumber
+  - name: CBaseEntity_Script_FollowEntity
+    alias:
+    - CBaseEntity::Script_FollowEntity
+  - name: CBaseEntity_Script_FollowEntityMerge
+    alias:
+    - CBaseEntity::Script_FollowEntityMerge
+  - name: CBaseEntity_Script_Trigger
+    alias:
+    - CBaseEntity::Script_Trigger
+  - name: CBaseEntity_Script_SetContextThink
+    alias:
+    - CBaseEntity::Script_SetContextThink
+  - name: CBaseEntity_AddContextForScript
+    alias:
+    - CBaseEntity::AddContextForScript
+  - name: CBaseEntity_AddContextForScriptNumeric
+    alias:
+    - CBaseEntity::AddContextForScriptNumeric
+  - name: CBaseEntity_GetContextForScript
+    alias:
+    - CBaseEntity::GetContextForScript
+  - name: CBaseEntity_ScriptGatherCriteria
+    alias:
+    - CBaseEntity::ScriptGatherCriteria
+  - name: CBaseEntity_Script_TakeDamage
+    alias:
+    - CBaseEntity::Script_TakeDamage
+  - name: CBaseEntity_SetGravityScale
+    alias:
+    - CBaseEntity::SetGravityScale
+  - name: CBaseEntity_SetAbsVelocity
+    alias:
+    - CBaseEntity::SetAbsVelocity
+  - name: CBaseEntity_GetAbsVelocity
+    alias:
+    - CBaseEntity::GetAbsVelocity
+  - name: CBaseEntity_Script_ApplyLocalAngularVelocityImpulse
+    alias:
+    - CBaseEntity::Script_ApplyLocalAngularVelocityImpulse
+  - name: CBaseEntity_GetLocalAngularVelocity_OBSOLETE
+    alias:
+    - CBaseEntity::GetLocalAngularVelocity_OBSOLETE
+  - name: CBaseEntity_ScriptEmitSoundParams
+    alias:
+    - CBaseEntity::ScriptEmitSoundParams
+    - CBaseEntity::EmitSoundParams
+    - CBaseEntity_EmitSoundParams
+  - name: CBaseEntity_ScriptStopSound
+    alias:
+    - CBaseEntity::ScriptStopSound
+  - name: CBaseEntity_ScriptSoundDuration
+    alias:
+    - CBaseEntity::ScriptSoundDuration
+  - name: CBaseEntity_ScriptGetAbsOrigin
+    alias:
+    - CBaseEntity::ScriptGetAbsOrigin
+  - name: CBaseEntity_Precache
+    alias:
+    - CBaseEntity::Precache
+    - Precache
+  - name: CEnvEntityIgniter_Precache
+    alias:
+    - CEnvEntityIgniter::Precache
+  - name: CEnvShake_Spawn
+    alias:
+    - CEnvShake::Spawn
+  - name: CBaseEntity_SetMoveType
+    alias:
+    - CBaseEntity::SetMoveType
+  - name: CBasePlayerPawn_CommitSuicide
+    alias:
+    - CBasePlayerPawn::CommitSuicide
+    - CommitSuicide
+  - name: CBaseCombatCharacter_OnKilled
+    alias:
+    - CBaseCombatCharacter::OnKilled
+  - name: CCSPlayerPawn_Event_KilledOther
+    alias:
+    - CCSPlayerPawn::Event_KilledOther
+  - name: CCSPlayerPawn_Event_Killed
+    alias:
+    - CCSPlayerPawn::Event_Killed
+  - name: CBasePlayerPawn_Event_Killed
+    alias:
+    - CBasePlayerPawn::Event_Killed
+  - name: ScriptBinding_CSPlayerPawn_DestroyWeapon
+    alias:
+    - CSPlayerPawn::DestroyWeapon
+  - name: CBasePlayerPawn_RemovePlayerItem
+    alias:
+    - CBasePlayerPawn::RemovePlayerItem
+  - name: CBasePlayerPawn_DropActivePlayerWeapon
+    alias:
+    - CBasePlayerPawn::DropActivePlayerWeapon
+  - name: CBasePlayerPawn_GetEyePosition
+    alias:
+    - CBasePlayerPawn::GetEyePosition
+  - name: CBaseEntity_GetEyePosition
+    alias:
+    - CBaseEntity::GetEyePosition
+  - name: CCSBotManager_BotPlaceCommand
+    alias:
+    - CCSBotManager::BotPlace
+  - name: CBasePlayerPawn_EyeVectors
+    alias:
+    - CBasePlayerPawn::EyeVectors
+  - name: CBasePlayerPawn_GetEyeAngles
+    alias:
+    - CBasePlayerPawn::GetEyeAngles
+  - name: CBaseEntity_GetEyeAngles
+    alias:
+    - CBaseEntity::GetEyeAngles
+  - name: CCSBot_Upkeep
+    alias:
+    - CCSBot::Upkeep
+  - name: CCSBot_SetState
+    alias:
+    - CCSBot::SetState
+  - name: CCSBot_UpdatePathMovement
+    alias:
+    - CCSBot::UpdatePathMovement
+  - name: CCSBot_PrintIfWatched
+    alias:
+    - CCSBot::PrintIfWatched
+  - name: HideState_OnUpdate
+    alias:
+    - HideState::OnUpdate
+  - name: CCSBot_Attack
+    alias:
+    - CCSBot::Attack
+  - name: CCSBot_MoveTo
+    alias:
+    - CCSBot::MoveTo
+  - name: CCSBot_InhibitLookAround
+    alias:
+    - CCSBot::InhibitLookAround
+  - name: CCSBot_SetDisposition
+    alias:
+    - CCSBot::SetDisposition
+  - name: CCSBot_Idle
+    alias:
+    - CCSBot::Idle
+  - name: CCSBot_ComputePath
+    alias:
+    - CCSBot::ComputePath
+  - name: CBaseEntity_IsAlive
+    alias:
+    - CBaseEntity::IsAlive
+  - name: CBaseEntity_SetOwner
+    alias:
+    - CBaseEntity::SetOwner
+  - name: CBaseEntity_CollisionRulesChanged
+    alias:
+    - CBaseEntity::CollisionRulesChanged
+    - CollisionRulesChanged
+  - name: CBaseEntity_Use
+    alias:
+    - CBaseEntity::Use
+  - name: CGameSceneNode_PostSpawnKeyValues
+    alias:
+    - CGameSceneNode::PostSpawnKeyValues
+  - name: CBaseEntity_Spawn
+    alias:
+    - CBaseEntity::Spawn
+    - Spawn
+  - name: CBaseEntity_SpawnRadius
+    alias:
+    - CBaseEntity::SpawnRadius
+  - name: CCSPlayer_ItemServices_DropActivePlayerWeapon
+    alias:
+    - CCSPlayer_ItemServices::DropActivePlayerWeapon
+  - name: CCSPlayer_WeaponServices_DropWeapon
+    alias:
+    - CCSPlayer_WeaponServices::DropWeapon
+  - name: CCSPlayer_ItemServices_RemoveWeapons
+    alias:
+    - CCSPlayer_ItemServices::RemoveWeapons
+  - name: CCSPlayer_WeaponServices_SelectItem
+    alias:
+    - CCSPlayer_WeaponServices::SelectItem
+  - name: CEntFireOutputAutoCompletionFunctor_FireOutput
+    alias:
+    - CEntFireOutputAutoCompletionFunctor::FireOutput
+  - name: CEntityInstance_FindOutputsByName
+    alias:
+    - CEntityInstance::FindOutputsByName
+  - name: CEntityInstance_ScriptEntityIO
+    alias:
+    - CEntityInstance::ScriptEntityIO
+  - name: CEntityIOOutput_FireOutputInternal
+    alias:
+    - CEntityIOOutput::FireOutputInternal
+  - name: CEntitySystem_AddEntityIOEvent
+    alias:
+    - CEntitySystem::AddEntityIOEvent
+  - name: CEntitySystem_AddEntityIOEvent2
+    alias:
+    - CEntitySystem::AddEntityIOEvent2
+  - name: CEntitySystem_AddEntityIOEventBuildStruct
+    alias:
+    - CEntitySystem::AddEntityIOEventBuildStruct
+  - name: CEntitySystem_AddEntityIOEventToQueue
+    alias:
+    - CEntitySystem::AddEntityIOEventToQueue
+  - name: CEntitySystem_m_EventQueue
+    alias:
+    - CEntitySystem::m_EventQueue
+  - name: CGameEntitySystem_FindEntityByClassName
+    alias:
+    - CGameEntitySystem::FindEntityByClassName
+  - name: CGameEntitySystem_FindEntityByName
+    alias:
+    - CGameEntitySystem::FindEntityByName
+  - name: CGameEntitySystem_OnAddEntity
+    alias:
+    - CGameEntitySystem::OnAddEntity
+  - name: CGameEntitySystem_BuildResourceManifest_ManifestNameOrGroupName
+    alias:
+    - CGameEntitySystem::BuildResourceManifest_ManifestNameOrGroupName
+  - name: CGameEntitySystem_BuildResourceManifest_KeyValuesVectors
+    alias:
+    - CGameEntitySystem::BuildResourceManifest_KeyValuesVectors
+  - name: CGameEntitySystem_FindEntityProcedural
+    alias:
+    - CGameEntitySystem::FindEntityProcedural
+  - name: CGameEntitySystem_Spawn
+    alias:
+    - CGameEntitySystem::Spawn
+  - name: CEntitySystem_Spawn
+    alias:
+    - CEntitySystem::Spawn
+  - name: CBodyGameSystem_SpawnDependencyIsland
+    alias:
+    - CBodyGameSystem::SpawnDependencyIsland
+  - name: CGameEntitySystem_CheckGlobalState
+    alias:
+    - CGameEntitySystem::CheckGlobalState
+  - name: IGameSystem_OnBuildGameSessionManifest
+    alias:
+    - IGameSystem::BuildGameSessionManifest
+  - name: IGameSystem_OnServerPreEntityThink
+    alias:
+    - IGameSystem::OnServerPreEntityThink
+  - name: IGameSystem_OnServerPostEntityThink
+    alias:
+    - IGameSystem::OnServerPostEntityThink
+  - name: IGameSystem_OnServerPreClientUpdate
+    alias:
+    - IGameSystem::ServerPreClientUpdate
+  - name: IGameSystem_OnServerAdvanceTick
+    alias:
+    - IGameSystem::ServerAdvanceTick
+  - name: IGameSystem_OnServerGamePostSimulate
+    alias:
+    - IGameSystem::ServerGamePostSimulate
+  - name: IGameSystem_OnServerPostAdvanceTick
+    alias:
+    - IGameSystem::ServerPostAdvanceTick
+  - name: IGameSystem_OnServerPreBeginAsyncPostTickWork
+    alias:
+    - IGameSystem::OnServerPreBeginAsyncPostTickWork
+  - name: IGameSystem_OnServerBeginAsyncPostTickWork
+    alias:
+    - IGameSystem::OnServerBeginAsyncPostTickWork
+  - name: IGameSystem_OnServerPreEndAsyncPostTickWork
+    alias:
+    - IGameSystem::OnServerPreEndAsyncPostTickWork
+  - name: IGameSystem_OnServerPostEndAsyncPostTickWork
+    alias:
+    - IGameSystem::OnServerPostEndAsyncPostTickWork
+  - name: IGameSystem_OnSaveGame
+    alias:
+    - IGameSystem::OnSaveGame
+  - name: IGameSystem_OnRestoreGame
+    alias:
+    - IGameSystem::OnRestoreGame
+  - name: IGameSystem_OnOutOfGameFrameBoundary
+    alias:
+    - IGameSystem::OnOutOfGameFrameBoundary
+  - name: CSource2GameClients_StartHLTVServer
+    alias:
+    - CSource2GameClients::StartHLTVServer
+  - name: LegacyGameEventListener
+    alias:
+    - GetLegacyGameEventListener
+  - name: CPhysicsGameSystem_ProcessContactEvents
+    alias:
+    - CPhysicsGameSystem::ProcessContactEvents
+  - name: CBaseEntity_PhysicsDispatchStartTouch
+    alias:
+    - CBaseEntity::PhysicsDispatchStartTouch
+  - name: CBaseEntity_PhysicsNotifyOtherOfEndTouch
+    alias:
+    - CBaseEntity::PhysicsNotifyOtherOfEndTouch
+  - name: CBaseEntity_PhysicsDispatchTouch
+    alias:
+    - CBaseEntity::PhysicsDispatchTouch
+  - name: CBaseEntity_StartTouch
+    alias:
+    - CBaseEntity::StartTouch
+    - StartTouch
+  - name: CBaseEntity_Touch
+    alias:
+    - CBaseEntity::Touch
+    - Touch
+  - name: CBaseEntity_EndTouch
+    alias:
+    - CBaseEntity::EndTouch
+    - EndTouch
+  - name: IVPhys2World_GetTouchingList
+    alias:
+    - IVPhys2World::GetTouchingList
+    - CVPhys2World::GetTouchingList
+  - name: CTriggerPush_Touch
+    alias:
+    - CTriggerPush::Touch
+    - TriggerPush_Touch
+  - name: CPhysBox_Use
+    alias:
+    - CPhysBox::Use
+  - name: CBaseEntity_SetGroundEntity
+    alias:
+    - SetGroundEntity
+  - name: CBaseEntity_GetHammerUniqueId
+    alias:
+    - CBaseEntity::GetHammerUniqueId
+    - GetHammerUniqueId
+  - name: CBaseEntity_IsPlayerPawn
+    alias:
+    - CBaseEntity::IsPlayerPawn
+    - IsEntityPawn
+    - IsPlayerPawn
+  - name: CBaseEntity_IsPlayerController
+    alias:
+    - CBaseEntity::IsPlayerController
+    - IsEntityController
+    - IsPlayerController
+  - name: CBaseTrigger_StartTouch
+    alias:
+    - CBaseTrigger::StartTouch
+  - name: CBaseTrigger_EndTouch
+    alias:
+    - CBaseTrigger::EndTouch
+  - name: CBaseTrigger_PassesTriggerFilters
+    alias:
+    - CBaseTrigger::PassesTriggerFilters
+    - PassesTriggerFilters
+  - name: CBaseAnimGraph_GetAnimationController
+    alias:
+    - CBaseAnimGraph::GetAnimationController
+  - name: CBaseAnimGraph_m_skeletonInstance
+    alias:
+    - CBaseAnimGraph::m_skeletonInstance
+  - name: CGameSceneNode_PreInstanceSpawn
+    alias:
+    - CGameSceneNode::PreInstanceSpawn
+  - name: CGameSceneNode_GetSkeletonInstance
+    alias:
+    - CGameSceneNode::GetSkeletonInstance
+  - name: CSkeletonInstance_m_animationController
+    alias:
+    - CSkeletonInstance::m_animationController
+  - name: CSkeletonInstance_PostDataUpdate
+    alias:
+    - CSkeletonInstance::PostDataUpdate
+  - name: CGameSceneNode_PostDataUpdate
+    alias:
+    - CGameSceneNode::PostDataUpdate
+  - name: CGameSceneNode_UpdateEntityForHierarchyChange
+    alias:
+    - CGameSceneNode::UpdateEntityForHierarchyChange
+  - name: CPointTeleportAPI_TeleportEntityInternal
+    alias:
+    - CPointTeleportAPI::TeleportEntityInternal
+  - name: CBaseEntity_Teleport
+    alias:
+    - CBaseEntity::Teleport
+  - name: CPointTeleport_Activate
+    alias:
+    - CPointTeleport::Activate
+  - name: CBaseEntity_Activate
+    alias:
+    - CBaseEntity::Activate
+    - Activate
+  - name: CBaseEntity_DrawDebugTextOverlays
+    alias:
+    - CBaseEntity::DrawDebugTextOverlays
+  - name: CRagdollProp_DrawEntityDebugOverlays
+    alias:
+    - CRagdollProp::DrawEntityDebugOverlays
+  - name: CBaseEntity_ReloadPrivateScripts
+    alias:
+    - CBaseEntity::ReloadPrivateScripts
+  - name: CCheckTransmitInfo_m_nPlayerSlot
+    alias:
+    - CCheckTransmitInfo::m_nPlayerSlot
+    - CheckTransmitPlayerSlot
+  - name: CDedicatedServerWorkshopManager_SwitchToWorkshopMapGroup
+    alias:
+    - CDedicatedServerWorkshopManager::SwitchToWorkshopMapGroup
+  - name: IGameTypes_CreateWorkshopMapGroup
+    alias:
+    - IGameTypes::CreateWorkshopMapGroup
+  - name: CSpawnGroupMgrGameSystem_GetSpawnGroups
+    alias:
+    - CSpawnGroupMgrGameSystem::GetSpawnGroups
+    - GetSpawnGroups
+  - name: CSpawnGroupMgrGameSystem_DumpSpawnGroups
+    alias:
+    - CSpawnGroupMgrGameSystem::DumpSpawnGroups
+    - DumpSpawnGroups
+  - name: CSpawnGroupMgrGameSystem_SpawnGroupSpawnEntitiesInternal
+    alias:
+    - CSpawnGroupMgrGameSystem::SpawnGroupSpawnEntitiesInternal
+    - SpawnGroupSpawnEntitiesInternal
+  - name: IGameSystem_OnPreSpawnGroupLoad
+    alias:
+    - IGameSystem::OnPreSpawnGroupLoad
+  - name: IGameSystem_OnPostSpawnGroupLoad
+    alias:
+    - IGameSystem::OnPostSpawnGroupLoad
+  - name: CSpawnGroupMgrGameSystem_SpawnGroupShutdown
+    alias:
+    - CSpawnGroupMgrGameSystem::SpawnGroupShutdown
+    - SpawnGroupShutdown
+  - name: CSpawnGroupMgrGameSystem_SpawnGroupActuallyShutdown
+    alias:
+    - CSpawnGroupMgrGameSystem::SpawnGroupActuallyShutdown
+    - SpawnGroupActuallyShutdown
+  - name: IGameSystem_OnPreSpawnGroupUnload
+    alias:
+    - IGameSystem::OnPreSpawnGroupUnload
+  - name: IGameSystem_OnPostSpawnGroupUnload
+    alias:
+    - IGameSystem::OnPostSpawnGroupUnload
+  - name: CLoadingSpawnGroup_CreateEntityToSpawn
+    alias:
+    - CLoadingSpawnGroup::CreateEntityToSpawn
+  - name: CSpawnGroupMgrGameSystem_OnSpawnGroupPrecache
+    alias:
+    - CSpawnGroupMgrGameSystem::OnSpawnGroupPrecache
+    - SpawnGroupPrecache
+  - name: CSpawnGroupMgrGameSystem_AllocateSpawnGroup
+    alias:
+    - CSpawnGroupMgrGameSystem::AllocateSpawnGroup
+  - name: CSpawnGroupMgrGameSystem_ReleaseSpawnGroup
+    alias:
+    - CSpawnGroupMgrGameSystem::ReleaseSpawnGroup
+  - name: CSpawnGroupMgrGameSystem_SpawnGroupInit
+    alias:
+    - CSpawnGroupMgrGameSystem::SpawnGroupInit
+  - name: CSpawnGroupMgrGameSystem_CreateLoadingSpawnGroup
+    alias:
+    - CSpawnGroupMgrGameSystem::CreateLoadingSpawnGroup
+  - name: CSpawnGroupMgrGameSystem_CreateLoadingSpawnGroupForSaveFile
+    alias:
+    - CSpawnGroupMgrGameSystem::CreateLoadingSpawnGroupForSaveFile
+  - name: CSpawnGroupMgrGameSystem_SpawnGroupSpawnEntities
+    alias:
+    - CSpawnGroupMgrGameSystem::SpawnGroupSpawnEntities
+  - name: CSpawnGroupMgrGameSystem_SetActiveSpawnGroup
+    alias:
+    - CSpawnGroupMgrGameSystem::SetActiveSpawnGroup
+  - name: CSpawnGroupMgrGameSystem_UnloadSpawnGroup
+    alias:
+    - CSpawnGroupMgrGameSystem::UnloadSpawnGroup
+  - name: CSpawnGroupMgrGameSystem_SaveGame_Start
+    alias:
+    - CSpawnGroupMgrGameSystem::SaveGame_Start
+  - name: IGameSystem_OnSpawnGroupPrecache
+    alias:
+    - IGameSystem::OnSpawnGroupPrecache
+  - name: IGameSystem_OnSpawnGroupUncache
+    alias:
+    - IGameSystem::OnSpawnGroupUncache
+  - name: CBaseFilter_InputTestActivator
+    alias:
+    - CBaseFilter::InputTestActivator
+  - name: CGamePlayerEquip_InputTriggerForAllPlayers
+    alias:
+    - CGamePlayerEquip::InputTriggerForAllPlayers
+  - name: CGamePlayerEquip_InputTriggerForActivatedPlayer
+    alias:
+    - CGamePlayerEquip::InputTriggerForActivatedPlayer
+  - name: CNavMesh_GetNearestNavArea
+    alias:
+    - CNavMesh::GetNearestNavArea
+  - name: CCSBotManager_AddBot
+    alias:
+    - CCSBotManager::AddBot
+  - name: BotAdd_CommandHandler
+    alias:
+    - CCSBotManager::BotAddCommand
+  - name: BotKill_CommandHandler
+    alias:
+    - CCSBotManager::BotKillCommand
+  - name: EntInfo_CommandHandler
+    alias:
+    - CC_Ent_Info
+  - name: CEntitySystem_DestroyEntityImmediate
+    alias:
+    - CEntitySystem::DestroyEntityImmediate
+  - name: CEntitySystem_OnRemoveEntityFromDatabase
+    alias:
+    - CEntitySystem::OnRemoveEntityFromDatabase
+  - name: CEntitySystem_DoDestructEntity
+    alias:
+    - CEntitySystem::DoDestructEntity
+  - name: CEntitySystem_UpdateOnRemove
+    alias:
+    - CEntitySystem::UpdateOnRemove
+  - name: ClientPrintToController
+    alias:
+    - ClientPrint
+  - name: CCSBotManager_AddBot_BotNavIgnore
+    alias:
+    - BotNavIgnore
+  - name: CEnvHudHint_API_ShowHudHint
+    alias:
+    - CEnvHudHint_API::ShowHudHint
+  - name: UTIL_GetPlayerControllerForEntity
+    alias:
+    - UTIL_GetPlayerControllerForEntity
+  - name: CEntitySystem_ctor
+    alias:
+    - CEntitySystem::CEntitySystem
+  - name: CGameEntitySystem_ctor
+    alias:
+    - CGameEntitySystem::CGameEntitySystem
+  - name: CEntitySystem_RegisterAccessor
+    alias:
+    - CEntitySystem::RegisterAccessor
+  - name: CEntitySystem_Init
+    alias:
+    - CEntitySystem::Init
+  - name: CEntitySystem_ProcessEntityRegistration
+    alias:
+    - CEntitySystem::ProcessEntityRegistration
+  - name: CEntitySystem_PostCreateEntitySystem
+    alias:
+    - CEntitySystem::PostCreateEntitySystem
+  - name: CSource2EntitySystem_StaticInit
+    alias:
+    - CSource2EntitySystem::StaticInit
+  - name: CSpawnGroupEntityFilterRegistrar_RegisterSpawnGroupEntityFilters
+    alias:
+    - CSpawnGroupEntityFilterRegistrar::RegisterSpawnGroupEntityFilters
+  - name: CGameEntitySystem_m_spawnGroupEntityFilters
+    alias:
+    - CGameEntitySystem::m_spawnGroupEntityFilters
+  - name: CGameEntitySystem_m_pEntity2Networkables
+    alias:
+    - CGameEntitySystem::m_pEntity2Networkables
+  - name: CEntity2NetworkClasses_ServerClass_InitEntity2NetworkClasses
+    alias:
+    - CEntity2NetworkClasses<ServerClass>::InitEntity2NetworkClasses
+  - name: CEntitySystem_m_Symbols
+    alias:
+    - CEntitySystem::m_Symbols
+  - name: CEntitySystem_m_pNetworkFieldChangedEventQueue
+    alias:
+    - CEntitySystem::m_pNetworkFieldChangedEventQueue
+  - name: CEntitySystem_m_pNetworkFieldScratchData
+    alias:
+    - CEntitySystem::m_pNetworkFieldScratchData
+  - name: CEntitySystem_m_pFieldChangeLimitSpew
+    alias:
+    - CEntitySystem::m_pFieldChangeLimitSpew
+  - name: CEntitySystem_m_ComponentUnserializerInfoAllocator
+    alias:
+    - CEntitySystem::m_ComponentUnserializerInfoAllocator
+  - name: CEntitySystem_m_EntityMaterialAttributes
+    alias:
+    - CEntitySystem::m_EntityMaterialAttributes
+  - name: CEntitySystem_m_flChangeCallbackSpewThreshold
+    alias:
+    - CEntitySystem::m_flChangeCallbackSpewThreshold
+  - name: CEntitySystem_ClearEntityDatabase
+    alias:
+    - CEntitySystem::ClearEntityDatabase
+  - name: INetworkMessages_SetNetworkSerializationContextData
+    alias:
+    - INetworkMessages::SetNetworkSerializationContextData
+  - name: CFlattenedSerializers_CreateFieldChangedEventQueue
+    alias:
+    - CFlattenedSerializers::CreateFieldChangedEventQueue
+  - name: INetworkMessages_RegisterSchemaTypeOverride
+    alias:
+    - INetworkMessages::RegisterSchemaTypeOverride
+  - name: PolymorphicHelper_t__SetPolymorphicPointer
+    alias:
+    - PolymorphicHelper_t::SetPolymorphicPointer
+  - name: CSceneEntity_GetScriptDesc
+    alias:
+    - CSceneEntity::GetScriptDesc
+  - name: CEntityInstance_GetScriptDesc
+    alias:
+    - CEntityInstance::GetScriptDesc
+  - name: CEntityInstance_Spawn
+    alias:
+    - CEntityInstance::Spawn
+  - name: CEntityInstance_Activate
+    alias:
+    - CEntityInstance::Activate
+  - name: CEntityInstance_Precache
+    alias:
+    - CEntityInstance::Precache
+  - name: CEntityInstance_GetDataDescMap
+    alias:
+    - CEntityInstance::GetDataDescMap
+  - name: CEntityInstance_ReloadPrivateScripts
+    alias:
+    - CEntityInstance::ReloadPrivateScripts
+  - name: CEntityInstance_ValidatePrivateScriptScope
+    alias:
+    - CEntityInstance::ValidatePrivateScriptScope
+  - name: CEntityInstance_NetworkStateChanged
+    alias:
+    - CEntityInstance::NetworkStateChanged
+  - name: CEntityInstance_FullEdictChanged
+    alias:
+    - CEntityInstance::FullEdictChanged
+  - name: CEntityInstance_NetworkUpdateState
+    alias:
+    - CEntityInstance::NetworkUpdateState
+  - name: CEntityInstance_NetworkStateChangedLog
+    alias:
+    - CEntityInstance::NetworkStateChangedLog
+  - name: CEntityInstance_DrawDebugTextOverlays
+    alias:
+    - CEntityInstance::DrawDebugTextOverlays
+  - name: CEntityInstance_DrawEntityDebugOverlays
+    alias:
+    - CEntityInstance::DrawEntityDebugOverlays
+  - name: CEntityInstance_PostDataUpdateDelta
+    alias:
+    - CEntityInstance::PostDataUpdateDelta
+  - name: CEntityInstance_PreDataUpdate
+    alias:
+    - CEntityInstance::PreDataUpdate
+  - name: CEntityInstance_PostDataUpdate
+    alias:
+    - CEntityInstance::PostDataUpdate
+  - name: CEntityInstance_PostDataUpdatePreserve
+    alias:
+    - CEntityInstance::PostDataUpdatePreserve
+  - name: CEntityInstance_Connect
+    alias:
+    - CEntityInstance::Connect
+  - name: CEntityInstance_UpdateOnRemove
+    alias:
+    - CEntityInstance::UpdateOnRemove
+  - name: CEntityInstance_Disconnect
+    alias:
+    - CEntityInstance::Disconnect
+  - name: CEntityInstance_AddedToEntityDatabase
+    alias:
+    - CEntityInstance::AddedToEntityDatabase
+  - name: CEntityInstance_OnSetDormant
+    alias:
+    - CEntityInstance::OnSetDormant
+  - name: CEntityInstance_Schema_DynamicBinding
+    alias:
+    - CEntityInstance::Schema_DynamicBinding
+  - name: CEntitySystem_OnRemoveEntity
+    alias:
+    - CEntitySystem::OnRemoveEntity
+  - name: CEntityComponentHelperT_Free
+    alias:
+    - CEntityComponentHelperT::Free
+  - name: CScriptedSequence_SynchronizeSequence
+    alias:
+    - CScriptedSequence::SynchronizeSequence
+  - name: CNetworkUtlVectorEmbedded_NetworkStateChanged_m_vecRenderAttributes
+    alias:
+    - CNetworkUtlVectorEmbedded<CRenderAttribute>::NetworkStateChanged_m_vecRenderAttributes
+  - name: CNetworkUtlVectorEmbedded_NetworkStateChanged_m_perRoundStats
+    alias:
+    - CNetworkUtlVectorEmbedded<CSPerRoundStats_t>::NetworkStateChanged_m_perRoundStats
+  - name: CUtlVectorEmbeddedNetworkVar_CSPerRoundStats_t_NetworkVar_m_perRoundStats_SetCount
+    alias:
+    - CUtlVectorEmbeddedNetworkVar<CSPerRoundStats_t, NetworkVar>::SetCount
+  - name: CNetworkUtlVectorEmbedded_TryLateResolve_m_vecRenderAttributes
+    alias:
+    - CNetworkUtlVectorEmbedded<CRenderAttribute>::TryLateResolve
+  - name: INetworkMessages_GetLoggingChannel
+    alias:
+    - INetworkMessages::GetLoggingChannel
+  - name: CPhysicsEntitySolver_PhysEnableEntityCollisions
+    alias:
+    - CPhysicsEntitySolver::PhysEnableEntityCollisions
+  - name: CLoopModeGame_StaticInit
+    alias:
+    - CLoopModeGame::StaticInit
+  - name: CLoopModeFactory_CLoopModeGame_Init
+    alias:
+    - CLoopModeFactory<CLoopModeGame>::Init
+  - name: CLoopModeFactory_CLoopModeGame_Shutdown
+    alias:
+    - CLoopModeFactory<CLoopModeGame>::Shutdown
+  - name: CLoopModeGame_OnLoopActivate
+    alias:
+    - CLoopModeGame::OnLoopActivate
+  - name: ILoopMode_OnLoopActivate
+    alias:
+    - ILoopMode::OnLoopActivate
+  - name: CLoopModeGame_AddViewsToSceneSystem
+    alias:
+    - CLoopModeGame::AddViewsToSceneSystem
+  - name: ILoopMode_AddViewsToSceneSystem
+    alias:
+    - ILoopMode::AddViewsToSceneSystem
+  - name: CLoopModeGame_LoopInitInternal
+    alias:
+    - CLoopModeGame::LoopInitInternal
+  - name: CLoopModeGame_LoopInit
+    alias:
+    - CLoopModeGame::LoopInit
+  - name: ILoopMode_LoopInit
+    alias:
+    - ILoopMode::LoopInit
+  - name: ILoopMode_LoopShutdown
+    alias:
+    - ILoopMode::LoopShutdown
+  - name: CLoopModeGame_RegisterEventMapInternal
+    alias:
+    - CLoopModeGame::RegisterEventMapInternal
+  - name: CLoopModeGame_OnServerAdvanceTick
+    alias:
+    - CLoopModeGame::OnServerAdvanceTick
+  - name: CLoopModeGame_OnServerBeginSimulate
+    alias:
+    - CLoopModeGame::OnServerBeginSimulate
+  - name: CLoopModeGame_OnServerPostSimulate
+    alias:
+    - CLoopModeGame::OnServerPostSimulate
+  - name: CLoopModeGame_OnServerPostAdvanceTick
+    alias:
+    - CLoopModeGame::OnServerPostAdvanceTick
+  - name: CLoopModeGame_OnServerBeginAsyncPostTickWork
+    alias:
+    - CLoopModeGame::OnServerBeginAsyncPostTickWork
+  - name: CLoopModeGame_OnServerEndAsyncPostTickWork
+    alias:
+    - CLoopModeGame::OnServerEndAsyncPostTickWork
+  - name: CLoopModeGame_OnFrameBoundary
+    alias:
+    - CLoopModeGame::OnFrameBoundary
+  - name: CLoopModeGame_ReceivedServerInfo
+    alias:
+    - CLoopModeGame::ReceivedServerInfo
+  - name: CLoopModeGame_SetWorldSession
+    alias:
+    - CLoopModeGame::SetWorldSession
+  - name: CLoopModeGame_SetGameSystemState
+    alias:
+    - CLoopModeGame::SetGameSystemState
+  - name: IGameSystem_DestroyAllGameSystems
+    alias:
+    - IGameSystem::DestroyAllGameSystems
+  - name: IGameSystem_ShutdownAllSystems
+    alias:
+    - IGameSystem::ShutdownAllSystems
+  - name: IGameSystem_LoopDestroyAllSystems
+    alias:
+    - IGameSystem::LoopDestroyAllSystems
+  - name: IGameSystem_LoopPreShutdownAllSystems
+    alias:
+    - IGameSystem::LoopPreShutdownAllSystems
+  - name: CLoopModeGame_Shutdown
+    alias:
+    - CLoopModeGame::Shutdown
+  - name: CLoopModeGame_LoopShutdown
+    alias:
+    - CLoopModeGame::LoopShutdown
+  - name: CLoopModeGame_ShutdownServer
+    alias:
+    - CLoopModeGame::ShutdownServer
+  - name: CLoopModeGame_OnLoopDeactivate
+    alias:
+    - CLoopModeGame::OnLoopDeactivate
+  - name: ILoopMode_OnLoopDeactivate
+    alias:
+    - ILoopMode::OnLoopDeactivate
+  - name: CPlayerCommandQueue_ctor
+    alias:
+    - CPlayerCommandQueue::CPlayerCommandQueue
+  - name: IGameResourceService_SetEntityResourceManifestHandler
+    alias:
+    - IGameResourceService::SetEntityResourceManifestHandler
+  - name: CNetworkSerializerBindingBuildFilter_GetFieldPriority
+    alias:
+    - CNetworkSerializerBindingBuildFilter::GetFieldPriority
+  - name: CEntitySystem_FindComponentTypeByName
+    alias:
+    - CEntitySystem::FindComponentTypeByName
+- name: networksystem
+  symbols:
+  - name: INetworkMessages_GetFieldChangeCallbackOrderCount
+    alias:
+    - INetworkMessages::GetFieldChangeCallbackOrderCount
+  - name: INetworkMessages_GetFieldChangeCallbackPriorities
+    alias:
+    - INetworkMessages::GetFieldChangeCallbackPriorities

--- a/gamesymbols/14170.metadata.yaml
+++ b/gamesymbols/14170.metadata.yaml
@@ -1,0 +1,2879 @@
+modules:
+- name: networksystem
+  symbols:
+  - name: CNetworkMessages_RegisterNetworkCategory
+    alias:
+    - CNetworkMessages::RegisterNetworkCategory
+  - name: CNetworkMessages_AssociateNetMessageWithChannelCategoryAbstract
+    alias:
+    - CNetworkMessages::AssociateNetMessageWithChannelCategoryAbstract
+  - name: CNetworkMessages_FindOrCreateNetMessage
+    alias:
+    - CNetworkMessages::FindOrCreateNetMessage
+  - name: CNetworkMessages_SerializeInternal
+    alias:
+    - CNetworkMessages::SerializeInternal
+  - name: CNetworkMessages_UnserializeMessageInternal
+    alias:
+    - CNetworkMessages::UnserializeMessageInternal
+  - name: CNetworkMessages_SerializeMessageInternal
+    alias:
+    - CNetworkMessages::SerializeMessageInternal
+  - name: CNetworkMessages_UnserializeFromStream
+    alias:
+    - CNetworkMessages::UnserializeFromStream
+  - name: CNetworkMessages_AllocateAndCopyConstructNetMessageAbstract
+    alias:
+    - CNetworkMessages::AllocateAndCopyConstructNetMessageAbstract
+  - name: CNetworkMessages_DeallocateNetMessageAbstract
+    alias:
+    - CNetworkMessages::DeallocateNetMessageAbstract
+  - name: CNetworkMessages_RegisterNetworkFieldSerializer
+    alias:
+    - CNetworkMessages::RegisterNetworkFieldSerializer
+  - name: CNetworkMessages_RegisterNetworkArrayFieldSerializer
+    alias:
+    - CNetworkMessages::RegisterNetworkArrayFieldSerializer
+  - name: CNetworkMessages_AssociateNetMessageGroupIdWithChannelCategory
+    alias:
+    - CNetworkMessages::AssociateNetMessageGroupIdWithChannelCategory
+  - name: CNetworkMessages_RegisterNetworkFieldChangeCallbackInternal
+    alias:
+    - CNetworkMessages::RegisterNetworkFieldChangeCallbackInternal
+  - name: CNetworkMessages_AllowAdditionalMessageRegistration
+    alias:
+    - CNetworkMessages::AllowAdditionalMessageRegistration
+  - name: CNetworkMessages_IsAdditionalMessageRegistrationAllowed
+    alias:
+    - CNetworkMessages::IsAdditionalMessageRegistrationAllowed
+  - name: CNetworkMessages_RegisterFieldChangeCallbackPriority
+    alias:
+    - CNetworkMessages::RegisterFieldChangeCallbackPriority
+  - name: CNetworkMessages_ComputeOrderForPriority
+    alias:
+    - CNetworkMessages::ComputeOrderForPriority
+  - name: CNetworkMessages_dtor
+    alias:
+    - CNetworkMessages::~CNetworkMessages
+  - name: CNetworkMessages_GetIsForServer
+    alias:
+    - CNetworkMessages::GetIsForServer
+  - name: CNetworkMessages_GetNetworkSerializationContextData
+    alias:
+    - CNetworkMessages::GetNetworkSerializationContextData
+  - name: CNetChan_ParseMessagesDemoInternal
+    alias:
+    - CNetChan::ParseMessagesDemoInternal
+  - name: CNetChan_ParseNetMessageShowFilter
+    alias:
+    - CNetChan::ParseNetMessageShowFilter
+  - name: CNetworkMessages_FindNetworkMessagePartial
+    alias:
+    - CNetworkMessages::FindNetworkMessagePartial
+  - name: CNetworkMessages_FindNetworkMessage
+    alias:
+    - CNetworkMessages::FindNetworkMessage
+  - name: CNetworkMessages_FindNetworkGroup
+    alias:
+    - CNetworkMessages::FindNetworkGroup
+  - name: CNetworkSystem_SendNetworkStats
+    alias:
+    - CNetworkSystem::SendNetworkStats
+  - name: CNetworkMessages_GetNetworkGroupCount
+    alias:
+    - CNetworkMessages::GetNetworkGroupCount
+  - name: CNetworkMessages_GetNetworkGroupName
+    alias:
+    - CNetworkMessages::GetNetworkGroupName
+  - name: CNetworkMessages_GetNetworkGroupColor
+    alias:
+    - CNetworkMessages::GetNetworkGroupColor
+  - name: CNetworkMessages_ConfirmAllMessageHandlersInstalled
+    alias:
+    - CNetworkMessages::ConfirmAllMessageHandlersInstalled
+- name: engine
+  symbols:
+  - name: CServerSideClient_IsHearingClient
+    alias:
+    - IsHearingClient
+  - name: CGameResourceService_BuildResourceManifest
+    alias:
+    - CGameResourceService::BuildResourceManifest
+    - BuildResourceManifest
+  - name: CGameResourceService_m_pEntitySystem
+    alias:
+    - GameEntitySystem
+  - name: CGameResourceService_LoadGameResourceManifestNamed
+    alias:
+    - CGameResourceService::LoadGameResourceManifestNamed
+  - name: CGameResourceService_LoadGameResourceManifestGroup
+    alias:
+    - CGameResourceService::LoadGameResourceManifestGroup
+  - name: CGameResourceService_GetResourceManifestDebugName
+    alias:
+    - CGameResourceService::GetResourceManifestDebugName
+  - name: CGameResourceService_PrecacheEntitiesAndConfirmResourcesAreLoaded
+    alias:
+    - CGameResourceService::PrecacheEntitiesAndConfirmResourcesAreLoaded
+  - name: CGameResourceService_LoadGameResourceManifest_IEntityResourceManifest
+    alias:
+    - CGameResourceService::LoadGameResourceManifest
+  - name: CGameResourceService_DescribeContents
+    alias:
+    - CGameResourceService::DescribeContents
+  - name: CGameResourceService_AppendToGameResourceManifest
+    alias:
+    - CGameResourceService::AppendToGameResourceManifest
+  - name: CGameResourceService_RegisterEventMap
+    alias:
+    - CGameResourceService::RegisterEventMap
+  - name: IEntityResourceManifestBuilder_BuildResourceManifest_ManifestNameOrGroupName
+    alias:
+    - IEntityResourceManifestBuilder::BuildResourceManifest
+  - name: CServerSideClientBase_ClientPrintf
+    alias:
+    - CServerSideClientBase::ClientPrintf
+    - ClientPrintf
+  - name: CNetworkGameServer_ClientList
+    alias:
+    - CNetworkGameServer::ClientList
+  - name: CNetworkGameServerBase_SendPeerList
+    alias:
+    - CNetworkGameServerBase::SendPeerList
+  - name: CNetworkGameServerBase_ConnectClient
+    alias:
+    - CNetworkGameServerBase::ConnectClient
+  - name: CNetworkGameServerBase_ServerSimulateInternal
+    alias:
+    - CNetworkGameServerBase::ServerSimulateInternal
+  - name: CNetworkGameServerBase_ServerSimulate
+    alias:
+    - CNetworkGameServerBase::ServerSimulate
+  - name: CNetworkGameServerBase_ServerPollNetworking
+    alias:
+    - CNetworkGameServerBase::ServerPollNetworking
+  - name: CNetworkGameServerBase_BroadcastMessage
+    alias:
+    - CNetworkGameServerBase::BroadcastMessage
+  - name: CNetworkGameServerBase_BroadcastPrintf
+    alias:
+    - CNetworkGameServerBase::BroadcastPrintf
+  - name: CNetworkGameServerBase_ReserveServerForQueuedGame
+    alias:
+    - CNetworkGameServerBase::ReserveServerForQueuedGame
+  - name: CNetworkGameServerBase_FinishChangeLevel
+    alias:
+    - CNetworkGameServerBase::FinishChangeLevel
+  - name: CNetworkGameServerBase_StartChangeLevel
+    alias:
+    - CNetworkGameServerBase::StartChangeLevel
+  - name: CNetworkGameServerBase_SetServerState
+    alias:
+    - CNetworkGameServerBase::SetServerState
+  - name: CNetworkGameServer_GetFreeClient
+    alias:
+    - CNetworkGameServer::GetFreeClient
+    - GetFreeClient
+  - name: CNetworkGameServerBase_CreateFakeClient
+    alias:
+    - CNetworkGameServerBase::CreateFakeClient
+  - name: CNetworkGameServerBase_UserInfoChanged
+    alias:
+    - CNetworkGameServerBase::UserInfoChanged
+  - name: CNetworkGameServerBase_GetPlayerNetworkIDString
+    alias:
+    - CNetworkGameServerBase::GetPlayerNetworkIDString
+  - name: CNetworkGameServerBase_StartHLTVMaster
+    alias:
+    - CNetworkGameServerBase::StartHLTVMaster
+  - name: CNetworkGameServerBase_RegisterLoadingSpawnGroups
+    alias:
+    - CNetworkGameServerBase::RegisterLoadingSpawnGroups
+  - name: CNetworkServerSpawnGroupCreatePrerequisites_Init
+    alias:
+    - CNetworkServerSpawnGroupCreatePrerequisites::Init
+  - name: CNetworkGameServerBase_LoadSpawnGroup
+    alias:
+    - CNetworkGameServerBase::LoadSpawnGroup
+  - name: CNetworkGameServerBase_SpawnGroupThink
+    alias:
+    - CNetworkGameServerBase::SpawnGroupThink
+  - name: CNetworkGameServerBase_PrintSpawnGroupStatus
+    alias:
+    - CNetworkGameServerBase::PrintSpawnGroupStatus
+  - name: CNetworkGameServerBase_AsyncUnloadSpawnGroup
+    alias:
+    - CNetworkGameServerBase::AsyncUnloadSpawnGroup
+  - name: CNetworkGameServerBase_AsyncUnloadSpawnGroupInternal
+    alias:
+    - CNetworkGameServerBase::AsyncUnloadSpawnGroupInternal
+  - name: CNetworkGameServer_PrepareForAssetLoad
+    alias:
+    - CNetworkGameServer::PrepareForAssetLoad
+  - name: CNetworkGameServerBase_IsSaveRestoreAllowed
+    alias:
+    - CNetworkGameServerBase::IsSaveRestoreAllowed
+  - name: CNetworkGameServerBase_Init
+    alias:
+    - CNetworkGameServerBase::Init
+  - name: CNetworkGameServerBase_Shutdown
+    alias:
+    - CNetworkGameServerBase::Shutdown
+  - name: CNetworkGameServerBase_ShutdownInternal
+    alias:
+    - CNetworkGameServerBase::ShutdownInternal
+  - name: CNetworkGameServer_ActivateServer
+    alias:
+    - CNetworkGameServer::ActivateServer
+  - name: CNetworkGameServer_DirectUpdate
+    alias:
+    - CNetworkGameServer::DirectUpdate
+  - name: CNetworkGameServer_Init
+    alias:
+    - CNetworkGameServer::Init
+  - name: CNetworkGameServer_Shutdown
+    alias:
+    - CNetworkGameServer::Shutdown
+  - name: CNetworkGameServer_SpawnServer
+    alias:
+    - CNetworkGameServer::SpawnServer
+  - name: CNetworkGameServerBase_GetMaxClients
+    alias:
+    - CNetworkGameServerBase::GetMaxClients
+  - name: CNetworkGameServerBase_SetMaxClients
+    alias:
+    - CNetworkGameServerBase::SetMaxClients
+  - name: CNetworkGameServerBase_CheckTimeouts
+    alias:
+    - CNetworkGameServerBase::CheckTimeouts
+  - name: CNetworkGameServerBase_OnKickById
+    alias:
+    - CNetworkGameServerBase::OnKickById
+  - name: CNetworkGameServerBase_OnKickByName
+    alias:
+    - CNetworkGameServerBase::OnKickByName
+  - name: CNetworkGameClient_SendMovePacket
+    alias:
+    - CNetworkGameClient::SendMovePacket
+    - SendMovePacket
+  - name: CNetworkGameClient_SendMove
+    alias:
+    - CNetworkGameClient::SendMove
+    - SendMove
+  - name: INetworkMessages_Serialize
+    alias:
+    - INetworkMessages::Serialize
+  - name: CDemoRecorder_ParseMessage
+    alias:
+    - CDemoRecorder::ParseMessage
+  - name: CDemoRecorder_WriteSpawnGroups
+    alias:
+    - CDemoRecorder::WriteSpawnGroups
+  - name: INetworkMessages_SerializeAbstract
+    alias:
+    - INetworkMessages::SerializeAbstract
+  - name: INetworkMessages_GetNetMessageInfo
+    alias:
+    - INetworkMessages::GetNetMessageInfo
+  - name: INetworkMessages_FindNetworkMessageById
+    alias:
+    - INetworkMessages::FindNetworkMessageById
+  - name: CNetChan_ProcessMessages
+    alias:
+    - CNetChan::ProcessMessages
+  - name: CNetChan_ParseMessagesDemo
+    alias:
+    - CNetChan::ParseMessagesDemo
+  - name: CNetworkGameClient_ProcessPacketEntitiesInternal
+    alias:
+    - CNetworkGameClient::ProcessPacketEntitiesInternal
+  - name: CNetworkGameClient_ProcessPacketEntities
+    alias:
+    - CNetworkGameClient::ProcessPacketEntities
+    - ProcessPacketEntities
+  - name: CNetworkGameClient_RecordEntityBandwidth
+    alias:
+    - CNetworkGameClient::RecordEntityBandwidth
+    - RecordEntityBandwidth
+  - name: CNetworkGameClient_PrintNetStats
+    alias:
+    - CNetworkGameClient::PrintNetStats
+  - name: CMsgSource2NetworkFlowQuality_PrintStats
+    alias:
+    - CMsgSource2NetworkFlowQuality::PrintStats
+  - name: CNetworkGameClient_DisconnectGame
+    alias:
+    - CNetworkGameClient::DisconnectGame
+  - name: INetworkMessages_FindNetworkGroup
+    alias:
+    - INetworkMessages::FindNetworkGroup
+  - name: INetworkClientService_IsActive
+    alias:
+    - INetworkClientService::IsActive
+  - name: INetworkClientService_IsConnected
+    alias:
+    - INetworkClientService::IsConnected
+  - name: CNetworkClientService_ReceivedServerInfo
+    alias:
+    - CNetworkClientService::ReceivedServerInfo
+  - name: CNetworkClientService_SplitScreenConnect
+    alias:
+    - CNetworkClientService::SplitScreenConnect
+  - name: CNetworkClientService_SendNetMessage
+    alias:
+    - CNetworkClientService::SendNetMessage
+  - name: CNetworkClientService_SendStringCmd
+    alias:
+    - CNetworkClientService::SendStringCmd
+  - name: CNetworkClientService_StartChangeLevel
+    alias:
+    - CNetworkClientService::StartChangeLevel
+  - name: CNetworkClientService_FinishChangeLevel
+    alias:
+    - CNetworkClientService::FinishChangeLevel
+  - name: CNetworkClientService_PrintConnectionStatus
+    alias:
+    - CNetworkClientService::PrintConnectionStatus
+  - name: CNetworkClientService_OnStatus
+    alias:
+    - CNetworkClientService::OnStatus
+  - name: CNetworkClientService_ServerCmd
+    alias:
+    - CNetworkClientService::ServerCmd
+  - name: CNetworkClientService_GetDisconnectReason
+    alias:
+    - CNetworkClientService::GetDisconnectReason
+  - name: CNetworkClientService_PrintSpawnGroupStatus
+    alias:
+    - CNetworkClientService::PrintSpawnGroupStatus
+  - name: CNetworkClientService_IsActive
+    alias:
+    - CNetworkClientService::IsActive
+  - name: CNetworkClientService_IsConnected
+    alias:
+    - CNetworkClientService::IsConnected
+  - name: CNetworkClientService_ClockDriftAdjustFrameTime
+    alias:
+    - CNetworkClientService::ClockDriftAdjustFrameTime
+  - name: CNetworkClientService_Init
+    alias:
+    - CNetworkClientService::Init
+  - name: CNetworkClientService_Shutdown
+    alias:
+    - CNetworkClientService::Shutdown
+  - name: CNetworkClientService_DisconnectGameNow
+    alias:
+    - CNetworkClientService::DisconnectGameNow
+  - name: CGameClientConnectPrerequisite_ctor
+    alias:
+    - CGameClientConnectPrerequisite::CGameClientConnectPrerequisite
+  - name: CNetworkClientService_AddClientPrerequisites
+    alias:
+    - CNetworkClientService::AddClientPrerequisites
+  - name: CNetworkClientService_AllocateRemoteConnectionClient
+    alias:
+    - CNetworkClientService::AllocateRemoteConnectionClient
+  - name: CNetworkServerService_Init
+    alias:
+    - CNetworkServerService::Init
+  - name: CNetworkServerService_StartupServer
+    alias:
+    - CNetworkServerService::StartupServer
+  - name: CNetworkServerService_RegisterEventMapInternal
+    alias:
+    - CNetworkServerService::RegisterEventMapInternal
+  - name: CNetworkServerService_OnServerAdvanceTick
+    alias:
+    - CNetworkServerService::OnServerAdvanceTick
+  - name: CNetworkServerService_OnServerPollNetworking
+    alias:
+    - CNetworkServerService::OnServerPollNetworking
+  - name: CNetworkServerService_OnServerProcessNetworking
+    alias:
+    - CNetworkServerService::OnServerProcessNetworking
+  - name: CNetworkServerService_OnServerBeginSimulate
+    alias:
+    - CNetworkServerService::OnServerBeginSimulate
+  - name: CNetworkServerService_OnServerEndSimulate
+    alias:
+    - CNetworkServerService::OnServerEndSimulate
+  - name: CNetworkServerService_OnServerPostSimulate
+    alias:
+    - CNetworkServerService::OnServerPostSimulate
+  - name: CNetworkServerService_OnServerPostAdvanceTick
+    alias:
+    - CNetworkServerService::OnServerPostAdvanceTick
+  - name: CNetworkServerService_OnFrameBoundary
+    alias:
+    - CNetworkServerService::OnFrameBoundary
+  - name: CNetworkServerService_OnClientPollNetworking
+    alias:
+    - CNetworkServerService::OnClientPollNetworking
+  - name: CNetworkServerService_OnSimpleLoopFrameUpdate
+    alias:
+    - CNetworkServerService::OnSimpleLoopFrameUpdate
+  - name: CNetworkServerService_OnKickByIdHLTV
+    alias:
+    - CNetworkServerService::OnKickByIdHLTV
+  - name: CNetworkServerService_DisconnectGameNow
+    alias:
+    - CNetworkServerService::DisconnectGameNow
+  - name: INetworkGameServer_GetMaxClients
+    alias:
+    - INetworkGameServer::GetMaxClients
+  - name: INetworkGameServer_PreWorldUpdate
+    alias:
+    - INetworkGameServer::PreWorldUpdate
+  - name: CNetworkGameServer_PreWorldUpdate
+    alias:
+    - CNetworkGameServer::PreWorldUpdate
+  - name: INetworkGameServer_ServerEndSimulate
+    alias:
+    - INetworkGameServer::ServerEndSimulate
+  - name: CNetworkGameServerBase_ServerEndSimulate
+    alias:
+    - CNetworkGameServerBase::ServerEndSimulate
+  - name: INetworkGameServer_ServerPostSimulate
+    alias:
+    - INetworkGameServer::ServerPostSimulate
+  - name: CNetworkGameServerBase_ServerPostSimulate
+    alias:
+    - CNetworkGameServerBase::ServerPostSimulate
+  - name: INetworkGameServer_ServerAdvanceTick
+    alias:
+    - INetworkGameServer::ServerAdvanceTick
+  - name: CNetworkGameServerBase_ServerAdvanceTick
+    alias:
+    - CNetworkGameServerBase::ServerAdvanceTick
+  - name: INetworkGameServer_ServerProcessNetworking
+    alias:
+    - INetworkGameServer::ServerProcessNetworking
+  - name: CNetworkGameServerBase_ServerProcessNetworking
+    alias:
+    - CNetworkGameServerBase::ServerProcessNetworking
+  - name: INetworkGameServer_GetTimescale
+    alias:
+    - INetworkGameServer::GetTimescale
+  - name: CNetworkGameServerBase_GetTimescale
+    alias:
+    - CNetworkGameServerBase::GetTimescale
+  - name: ISource2Server_PreWorldUpdate
+    alias:
+    - ISource2Server::PreWorldUpdate
+  - name: ISource2Server_OutOfGameFrameBoundary
+    alias:
+    - ISource2Server::OutOfGameFrameBoundary
+  - name: INetworkMessages_SetIsForServer
+    alias:
+    - INetworkMessages::SetIsForServer
+  - name: CEngineClient_DumpNetStats
+    alias:
+    - CEngineClient::DumpNetStats
+  - name: CEngineServer_DumpNetStats
+    alias:
+    - CEngineServer::DumpNetStats
+  - name: CEngineServer_ClientPrintf
+    alias:
+    - CEngineServer::ClientPrintf
+  - name: CEngineServer_GetFrameTimeAmnesty
+    alias:
+    - CEngineServer::GetFrameTimeAmnesty
+  - name: CEngineServer_ShowFrameTimeReport
+    alias:
+    - CEngineServer::ShowFrameTimeReport
+  - name: CEngineServer_SetFrameTimeAmnesty
+    alias:
+    - CEngineServer::SetFrameTimeAmnesty
+  - name: CEngineServer_GetSteamUniverse
+    alias:
+    - CEngineServer::GetSteamUniverse
+  - name: CEngineServer_ChangeLevel
+    alias:
+    - CEngineServer::ChangeLevel
+  - name: CMapListService_IsMapValid
+    alias:
+    - CMapListService::IsMapValid
+    - IMapListService::IsMapValid
+  - name: CEngineServer_IsMapValid
+    alias:
+    - CEngineServer::IsMapValid
+  - name: CEngineServer_PrecacheGeneric
+    alias:
+    - CEngineServer::PrecacheGeneric
+  - name: CEngineServer_ClientCommand
+    alias:
+    - CEngineServer::ClientCommand
+  - name: CEngineServer_GetClientConVarValue
+    alias:
+    - CEngineServer::GetClientConVarValue
+  - name: CEngineServer_SetFakeClientConVarValue
+    alias:
+    - CEngineServer::SetFakeClientConVarValue
+  - name: CEngineServer_CreateFakeClient
+    alias:
+    - CEngineServer::CreateFakeClient
+  - name: CEngineServer_GetPlayerInfo
+    alias:
+    - CEngineServer::GetPlayerInfo
+  - name: CEngineServer_ClientCommandKeyValues
+    alias:
+    - CEngineServer::ClientCommandKeyValues
+  - name: CLog_Print
+    alias:
+    - CLog::Print
+  - name: CEngineServer_LogPrint
+    alias:
+    - CEngineServer::LogPrint
+  - name: CEngineServer_KickClient
+    alias:
+    - CEngineServer::KickClient
+  - name: CEngineServer_IsDedicatedServer
+    alias:
+    - CEngineServer::IsDedicatedServer
+  - name: CEngineServer_ServerCommand
+    alias:
+    - CEngineServer::ServerCommand
+  - name: CLoopTypeClientSimple_ActivateEngineServices
+    alias:
+    - CLoopTypeClientServer::ActivateEngineServices
+  - name: CLoopTypeClientServer_LoopTypeInit
+    alias:
+    - CLoopTypeClientServer::LoopTypeInit
+  - name: CLoopTypeClientServer_AdvanceTime
+    alias:
+    - CLoopTypeClientServer::AdvanceTime
+  - name: CLoopTypeClientServer_Update
+    alias:
+    - CLoopTypeClientServer::Update
+  - name: CLoopTypeClientServer_ActivateLoop
+    alias:
+    - CLoopTypeClientServer::ActivateLoop
+  - name: CLoopTypeClientServer_AllocateLoopMode
+    alias:
+    - CLoopTypeClientServer::AllocateLoopMode
+  - name: CLoopTypeClientServer_WritePerfStats
+    alias:
+    - CLoopTypeClientServer::WritePerfStats
+  - name: CLoopTypeClientServer_DeactivateLoop
+    alias:
+    - CLoopTypeClientServer::DeactivateLoop
+  - name: CLoopTypeClientServer_OutputListeners
+    alias:
+    - CLoopTypeClientServer::OutputListeners
+  - name: CLoopTypeSimple_FrameUpdate
+    alias:
+    - CLoopTypeSimple::FrameUpdate
+  - name: CLoopTypeClientServerService_OnLoopActivate
+    alias:
+    - CLoopTypeClientServerService::OnLoopActivate
+  - name: CLoopTypeSimpleService_OnLoopActivate
+    alias:
+    - CLoopTypeSimpleService::OnLoopActivate
+  - name: CLoopTypeClientServerService_HandleInputEvent
+    alias:
+    - CLoopTypeClientServerService::HandleInputEvent
+  - name: ILoopMode_HandleInputEvent
+    alias:
+    - ILoopMode::HandleInputEvent
+  - name: ILoopType_AddEngineService
+    alias:
+    - ILoopType::AddEngineService
+  - name: CLoopTypeBase_DeallocateLoopMode
+    alias:
+    - CLoopTypeBase::DeallocateLoopMode
+  - name: CLoopTypeBase_EngineLoop
+    alias:
+    - CLoopTypeBase::EngineLoop
+  - name: CLoopTypeBase_FrameUpdate
+    alias:
+    - CLoopTypeBase::FrameUpdate
+  - name: CLoopTypeBase_ActivateLoop
+    alias:
+    - CLoopTypeBase::ActivateLoop
+  - name: CLoopTypeBase_AllocateLoopMode
+    alias:
+    - CLoopTypeBase::AllocateLoopMode
+  - name: CLoopTypeBase_DeactivateLoop
+    alias:
+    - CLoopTypeBase::DeactivateLoop
+  - name: CLoopTypeBase_LoopTypeInit
+    alias:
+    - CLoopTypeBase::LoopTypeInit
+  - name: CLoopTypeBase_LoopTypeShutdown
+    alias:
+    - CLoopTypeBase::LoopTypeShutdown
+  - name: CLoopTypeBase_GetClientServerMode
+    alias:
+    - CLoopTypeBase::GetClientServerMode
+  - name: CLoopTypeBase_GetImplType
+    alias:
+    - CLoopTypeBase::GetImplType
+  - name: CLoopTypeBase_AddDependentServices
+    alias:
+    - CLoopTypeBase::AddDependentServices
+  - name: CLoopTypeBase_GenerateServiceDependencies
+    alias:
+    - CLoopTypeBase::GenerateServiceDependencies
+  - name: CLoopTypeBase_GenerateSecondaryDependencies
+    alias:
+    - CLoopTypeBase::GenerateSecondaryDependencies
+  - name: CLoopTypeBase_LoadDependentServices
+    alias:
+    - CLoopTypeBase::LoadDependentServices
+  - name: IEngineService_GetServiceDependencies
+    alias:
+    - IEngineService::GetServiceDependencies
+  - name: IEngineService_GetName
+    alias:
+    - IEngineService::GetName
+  - name: ILoopModeFactory_GetLoopModeType
+    alias:
+    - ILoopModeFactory::GetLoopModeType
+  - name: ILoopModeFactory_Shutdown
+    alias:
+    - ILoopModeFactory::Shutdown
+  - name: CEngineServiceMgr_RegisterEngineService
+    alias:
+    - CEngineServiceMgr::RegisterEngineService
+  - name: CEngineServiceMgr_RegisterLoopMode
+    alias:
+    - CEngineServiceMgr::RegisterLoopMode
+  - name: CEngineServiceMgr_UnregisterLoopMode
+    alias:
+    - CEngineServiceMgr::UnregisterLoopMode
+  - name: CEngineServiceMgr_UnregisterEngineService
+    alias:
+    - CEngineServiceMgr::UnregisterEngineService
+  - name: CEngineServiceMgr_SwitchToLoop
+    alias:
+    - CEngineServiceMgr::SwitchToLoop
+  - name: CEngineServiceMgr_PrintStatus
+    alias:
+    - CEngineServiceMgr::PrintStatus
+  - name: CEngineServiceMgr__MainLoop
+    alias:
+    - CEngineServiceMgr::_MainLoop
+  - name: CEngineServiceMgr_DeactivateLoop
+    alias:
+    - CEngineServiceMgr::DeactivateLoop
+  - name: CEngineServiceMgr_Shutdown
+    alias:
+    - CEngineServiceMgr::Shutdown
+  - name: CEngineServiceMgr_GetActiveLoopClientServerMode
+    alias:
+    - CEngineServiceMgr::GetActiveLoopClientServerMode
+  - name: CEngineServiceMgr_GetEventDispatcher
+    alias:
+    - CEngineServiceMgr::GetEventDispatcher
+  - name: CEngineGameUI_Shutdown
+    alias:
+    - CEngineGameUI::Shutdown
+  - name: IAppSystem_Shutdown
+    alias:
+    - IAppSystem::Shutdown
+  - name: CSplitScreenService_AddSplitScreenUser
+    alias:
+    - CSplitScreenService::AddSplitScreenUser
+  - name: CSplitScreenService_LoadUserConfiguration
+    alias:
+    - CSplitScreenService::LoadUserConfiguration
+  - name: CHLTVClient_ProcessSetConVar
+    alias:
+    - CHLTVClient::ProcessSetConVar
+  - name: CServerSideClientBase_ProcessTick
+    alias:
+    - CServerSideClientBase::ProcessTick
+  - name: CServerSideClientBase_ProcessStringCmd
+    alias:
+    - CServerSideClientBase::ProcessStringCmd
+  - name: CServerSideClientBase_MarkSpawnGroupLoadCompleted
+    alias:
+    - CServerSideClientBase::MarkSpawnGroupLoadCompleted
+  - name: CServerSideClientBase_ProcessSpawnGroup_LoadCompleted
+    alias:
+    - CServerSideClientBase::ProcessSpawnGroup_LoadCompleted
+  - name: CServerSideClientBase_ProcessClientInfo
+    alias:
+    - CServerSideClientBase::ProcessClientInfo
+  - name: CServerSideClientBase_ProcessBaselineAck
+    alias:
+    - CServerSideClientBase::ProcessBaselineAck
+  - name: CServerSideClientBase_ProcessSplitPlayerConnectInternal
+    alias:
+    - CServerSideClientBase::ProcessSplitPlayerConnectInternal
+  - name: CServerSideClientBase_ProcessSplitPlayerConnect
+    alias:
+    - CServerSideClientBase::ProcessSplitPlayerConnect
+  - name: CServerSideClientBase_GetUserIDString
+    alias:
+    - CServerSideClientBase::GetUserIDString
+  - name: CServerSideClientBase_GetNetworkIDString
+    alias:
+    - CServerSideClientBase::GetNetworkIDString
+  - name: CServerSideClientBase_Connect
+    alias:
+    - CServerSideClientBase::Connect
+  - name: CServerSideClientBase_GetPlayerInfo
+    alias:
+    - CServerSideClientBase::GetPlayerInfo
+  - name: CNetworkGameServer_GetPlayerNetworkIDString
+    alias:
+    - CNetworkGameServer::GetPlayerNetworkIDString
+  - name: CNetworkGameServerBase_RemoveClientFromGame
+    alias:
+    - CNetworkGameServerBase::RemoveClientFromGame
+  - name: CEngineServer_GetPlayerNetworkIDString
+    alias:
+    - CEngineServer::GetPlayerNetworkIDString
+  - name: CNetworkGameClientBase_ServerCmd
+    alias:
+    - CNetworkGameClientBase::ServerCmd
+  - name: CNetworkGameClientBase_ProcessSetConVar
+    alias:
+    - CNetworkGameClientBase::ProcessSetConVar
+  - name: CNetworkGameClientBase_SendStringCmd
+    alias:
+    - CNetworkGameClientBase::SendStringCmd
+  - name: CNetworkGameClientBase_StartChangeLevel
+    alias:
+    - CNetworkGameClientBase::StartChangeLevel
+  - name: CNetworkGameClientBase_FinishChangeLevel
+    alias:
+    - CNetworkGameClientBase::FinishChangeLevel
+  - name: CNetworkGameClientBase_DeferActivate
+    alias:
+    - CNetworkGameClientBase::DeferActivate
+  - name: CNetworkGameClientBase_ClockDrift_AdjustFrameTime
+    alias:
+    - CNetworkGameClientBase::ClockDrift_AdjustFrameTime
+  - name: CNetworkGameClientBase_Connect
+    alias:
+    - CNetworkGameClientBase::Connect
+  - name: CNetworkGameClientBase_DisconnectGame
+    alias:
+    - CNetworkGameClientBase::DisconnectGame
+  - name: CNetSupportImpl_Connect
+    alias:
+    - CNetSupportImpl::Connect
+- name: client
+  symbols:
+  - name: CLoopModeGame_RegisterEventMapInternal
+    alias:
+    - CLoopModeGame::RegisterEventMapInternal
+  - name: CLoopModeGame_OnClientPollNetworking
+    alias:
+    - CLoopModeGame::OnClientPollNetworking
+  - name: CLoopModeGame_OnClientAdvanceTick
+    alias:
+    - CLoopModeGame::OnClientAdvanceTick
+  - name: CLoopModeGame_OnClientPostAdvanceTick
+    alias:
+    - CLoopModeGame::OnClientPostAdvanceTick
+  - name: CLoopModeGame_OnClientPreSimulate
+    alias:
+    - CLoopModeGame::OnClientPreSimulate
+  - name: CLoopModeGame_OnClientPreOutput
+    alias:
+    - CLoopModeGame::OnClientPreOutput
+  - name: CLoopModeGame_OnClientPreOutputParallelWithServer
+    alias:
+    - CLoopModeGame::OnClientPreOutputParallelWithServer
+  - name: CLoopModeGame_OnClientPostOutput
+    alias:
+    - CLoopModeGame::OnClientPostOutput
+  - name: CLoopModeGame_OnClientFrameSimulate
+    alias:
+    - CLoopModeGame::OnClientFrameSimulate
+  - name: CLoopModeGame_OnClientAdvanceNonRenderedFrame
+    alias:
+    - CLoopModeGame::OnClientAdvanceNonRenderedFrame
+  - name: CLoopModeGame_OnClientPostSimulate
+    alias:
+    - CLoopModeGame::OnClientPostSimulate
+  - name: CLoopModeGame_OnClientPauseSimulate
+    alias:
+    - CLoopModeGame::OnClientPauseSimulate
+  - name: CLoopModeGame_OnClientSimulate
+    alias:
+    - CLoopModeGame::OnClientSimulate
+  - name: CLoopModeGame_OnPostDataUpdate
+    alias:
+    - CLoopModeGame::OnPostDataUpdate
+  - name: CLoopModeGame_OnPreDataUpdate
+    alias:
+    - CLoopModeGame::OnPreDataUpdate
+  - name: CLoopModeGame_OnFrameBoundary
+    alias:
+    - CLoopModeGame::OnFrameBoundary
+  - name: CLoopModeGame_StaticInit
+    alias:
+    - CLoopModeGame::StaticInit
+  - name: CLoopModeFactory_CLoopModeGame_Init
+    alias:
+    - CLoopModeFactory<CLoopModeGame>::Init
+  - name: CLoopModeFactory_CLoopModeGame_Shutdown
+    alias:
+    - CLoopModeFactory<CLoopModeGame>::Shutdown
+  - name: CLoopModeGame_OnLoopActivate
+    alias:
+    - CLoopModeGame::OnLoopActivate
+  - name: ILoopMode_OnLoopActivate
+    alias:
+    - ILoopMode::OnLoopActivate
+  - name: CLoopModeGame_AddViewsToSceneSystem
+    alias:
+    - CLoopModeGame::AddViewsToSceneSystem
+  - name: ILoopMode_AddViewsToSceneSystem
+    alias:
+    - ILoopMode::AddViewsToSceneSystem
+  - name: CLoopModeGame_LoopInitInternal
+    alias:
+    - CLoopModeGame::LoopInitInternal
+  - name: CLoopModeGame_LoopInit
+    alias:
+    - CLoopModeGame::LoopInit
+  - name: ILoopMode_LoopInit
+    alias:
+    - ILoopMode::LoopInit
+  - name: ILoopMode_LoopShutdown
+    alias:
+    - ILoopMode::LoopShutdown
+  - name: CLoopModeGame_ReceivedServerInfo
+    alias:
+    - CLoopModeGame::ReceivedServerInfo
+  - name: CLoopModeGame_RegisterEventMap
+    alias:
+    - CLoopModeGame::RegisterEventMap
+  - name: ILoopMode_RegisterEventMap
+    alias:
+    - ILoopMode::RegisterEventMap
+  - name: CLoopModeGame_SetWorldSession
+    alias:
+    - CLoopModeGame::SetWorldSession
+  - name: CLoopModeGame_SetGameSystemState
+    alias:
+    - CLoopModeGame::SetGameSystemState
+  - name: CLoopModeGame_LoopShutdown
+    alias:
+    - CLoopModeGame::LoopShutdown
+  - name: IGameSystem_AddByName
+    alias:
+    - IGameSystem::AddByName
+  - name: IGameSystem_Add
+    alias:
+    - IGameSystem::Add
+  - name: IGameSystem_PostInit
+    alias:
+    - IGameSystem::PostInit
+  - name: IGameSystem_InitAllSystems
+    alias:
+    - IGameSystem::InitAllSystems
+  - name: IGameSystem_LoopInitAllSystems
+    alias:
+    - IGameSystem::LoopInitAllSystems
+  - name: IGameSystemFactory_PostInit
+    alias:
+    - IGameSystemFactory::PostInit
+  - name: IGameSystemFactory_GetStaticGameSystem
+    alias:
+    - IGameSystemFactory::GetStaticGameSystem
+  - name: IGameSystemFactory_ShouldAutoAdd
+    alias:
+    - IGameSystemFactory::ShouldAutoAdd
+  - name: IGameSystemFactory_CreateGameSystem
+    alias:
+    - IGameSystemFactory::CreateGameSystem
+  - name: IGameSystemFactory_IsReallocating
+    alias:
+    - IGameSystemFactory::IsReallocating
+  - name: IGameSystem_SetName
+    alias:
+    - IGameSystem::SetName
+  - name: CSpawnGroupMgrGameSystem_DoesGameSystemReallocate
+    alias:
+    - IGameSystem::DoesGameSystemReallocate
+  - name: IGameSystem_DestroyAllGameSystems
+    alias:
+    - IGameSystem::DestroyAllGameSystems
+  - name: IGameSystem_ShutdownAllSystems
+    alias:
+    - IGameSystem::ShutdownAllSystems
+  - name: IGameSystem_LoopDestroyAllSystems
+    alias:
+    - IGameSystem::LoopDestroyAllSystems
+  - name: IGameSystem_LoopPreShutdownAllSystems
+    alias:
+    - IGameSystem::LoopPreShutdownAllSystems
+  - name: IGameSystem_OnClientPollNetworking
+    alias:
+    - IGameSystem::OnClientPollNetworking
+  - name: IGameSystem_OnClientGamePostSimulate
+    alias:
+    - IGameSystem::ClientGamePostSimulate
+  - name: IGameSystem_OnClientPauseSimulate
+    alias:
+    - IGameSystem::OnClientPauseSimulate
+  - name: IGameSystem_OnClientPreUpdate
+    alias:
+    - IGameSystem::OnClientPreUpdate
+  - name: IGameSystem_OnClientPostUpdate
+    alias:
+    - IGameSystem::OnClientPostUpdate
+  - name: IGameSystem_OnClientPostDataUpdate
+    alias:
+    - IGameSystem::OnClientPostDataUpdate
+  - name: IGameSystem_OnGameFrameBoundary
+    alias:
+    - IGameSystem::OnGameFrameBoundary
+  - name: IGameSystem_OnClientAdvanceNonRenderedFrame
+    alias:
+    - IGameSystem::OnClientAdvanceNonRenderedFrame
+  - name: IGameSystem_OnClientFrameSimulate
+    alias:
+    - IGameSystem::OnClientFrameSimulate
+  - name: IGameSystem_OnClientAdvanceTick
+    alias:
+    - IGameSystem::ClientAdvanceTick
+  - name: IGameSystem_OnClientPostAdvanceTick
+    alias:
+    - IGameSystem::ClientPostAdvanceTick
+  - name: IGameSystem_OnClientPostRender
+    alias:
+    - IGameSystem::OnClientPostRender
+  - name: IGameSystem_OnClientPreRender
+    alias:
+    - IGameSystem::OnClientPreRender
+  - name: IGameSystem_OnClientPreRenderAlt
+    alias:
+    - IGameSystem::OnClientPreRenderAlt
+  - name: CSource2Client_OnDisconnect
+    alias:
+    - CSource2Client::OnDisconnect
+  - name: IGameSystem_OnClientDisconnect
+    alias:
+    - IGameSystem::OnClientDisconnect
+  - name: IGameSystem_OnClientPreEntityThink
+    alias:
+    - IGameSystem::OnClientPreEntityThink
+  - name: CSteamworksGameStats_OnReceivedSessionID
+    alias:
+    - CSteamworksGameStats::OnReceivedSessionID
+  - name: IGameSystem_GetName
+    alias:
+    - IGameSystem::GetName
+  - name: IGameSystemFactory_DestroyGameSystem
+    alias:
+    - IGameSystemFactory::DestroyGameSystem
+  - name: IGameSystemFactory_Init
+    alias:
+    - IGameSystemFactory::Init
+  - name: IGameSystemFactory_GetPriority
+    alias:
+    - IGameSystemFactory::GetPriority
+  - name: IGameSystemFactory_Shutdown
+    alias:
+    - IGameSystemFactory::Shutdown
+  - name: IGameSystemFactory_SetGlobalPtr
+    alias:
+    - IGameSystemFactory::SetGlobalPtr
+  - name: CPrediction_PostNetworkDataReceived
+    alias:
+    - CPrediction::PostNetworkDataReceived
+  - name: IEngineServiceMgr_GetActiveLoopClientServerMode
+    alias:
+    - IEngineServiceMgr::GetActiveLoopClientServerMode
+  - name: IEngineServiceMgr_GetEventDispatcher
+    alias:
+    - IEngineServiceMgr::GetEventDispatcher
+  - name: ClientModeCSNormal_Update
+    alias:
+    - ClientModeCSNormal::Update
+  - name: CEntitySystem_ctor
+    alias:
+    - CEntitySystem::CEntitySystem
+  - name: CGameEntitySystem_ctor
+    alias:
+    - CGameEntitySystem::CGameEntitySystem
+  - name: CEntitySystem_Init
+    alias:
+    - CEntitySystem::Init
+  - name: CEntitySystem_PostCreateEntitySystem
+    alias:
+    - CEntitySystem::PostCreateEntitySystem
+  - name: CSource2EntitySystem_StaticInit
+    alias:
+    - CSource2EntitySystem::StaticInit
+  - name: CGameSystemReallocatingFactory_CSource2EntitySystem_Init
+    alias:
+    - CGameSystemReallocatingFactory<CSource2EntitySystem>::Init
+  - name: CGameSystemReallocatingFactory_CSource2EntitySystem_CreateGameSystem
+    alias:
+    - CGameSystemReallocatingFactory<CSource2EntitySystem>::CreateGameSystem
+  - name: CSkeletonInstance_PostDataUpdate
+    alias:
+    - CSkeletonInstance::PostDataUpdate
+  - name: CSkeletonInstance_m_modelState
+    alias:
+    - CSkeletonInstance::m_modelState
+  - name: CSkeletonInstance_m_modelState_m_hModel
+    alias:
+    - CSkeletonInstance::m_modelState.m_hModel
+  - name: CModelState_SetupJointState
+    alias:
+    - CModelState::SetupJointState
+  - name: CModelState_m_nTotalTransformCount
+    alias:
+    - CModelState::m_nTotalTransformCount
+  - name: CModelState_m_nBoneCount
+    alias:
+    - CModelState::m_nBoneCount
+  - name: CModelState_m_nAttachmentCount
+    alias:
+    - CModelState::m_nAttachmentCount
+  - name: IVEngineClient2_GetNetworkClient
+    alias:
+    - IVEngineClient2::GetNetworkClient
+  - name: INetworkClient_GetLocalAddress
+    alias:
+    - INetworkClient::GetLocalAddress
+  - name: INetworkClientService_IsConnected
+    alias:
+    - INetworkClientService::IsConnected
+  - name: INetworkClientService_SendNetMessage
+    alias:
+    - INetworkClientService::SendNetMessage
+  - name: IGameResourceService_SetEntityResourceManifestHandler
+    alias:
+    - IGameResourceService::SetEntityResourceManifestHandler
+  - name: CNetworkSerializerBindingBuildFilter_GetFieldPriority
+    alias:
+    - CNetworkSerializerBindingBuildFilter::GetFieldPriority
+- name: server
+  symbols:
+  - name: CSource2Server_OnStreamEntitiesFromFileCompleted
+    alias:
+    - CSource2Server::OnStreamEntitiesFromFileCompleted
+  - name: CSource2Server_PreWorldUpdate
+    alias:
+    - CSource2Server::PreWorldUpdate
+  - name: CSource2Server_OutOfGameFrameBoundary
+    alias:
+    - CSource2Server::OutOfGameFrameBoundary
+  - name: CGameSystemReallocatingFactory_CSource2EntitySystem_Init
+    alias:
+    - CGameSystemReallocatingFactory<CSource2EntitySystem>::Init
+  - name: CGameSystemReallocatingFactory_CSource2EntitySystem_CreateGameSystem
+    alias:
+    - CGameSystemReallocatingFactory<CSource2EntitySystem>::CreateGameSystem
+  - name: IGameSystemFactory_Init
+    alias:
+    - IGameSystemFactory::Init
+  - name: IGameSystemFactory_Shutdown
+    alias:
+    - IGameSystemFactory::Shutdown
+  - name: IGameSystemFactory_SetGlobalPtr
+    alias:
+    - IGameSystemFactory::SetGlobalPtr
+  - name: CGameSystemReallocatingFactory_CSpawnGroupMgrGameSystem_DestroyGameSystem
+    alias:
+    - CGameSystemReallocatingFactory<CSpawnGroupMgrGameSystem>::Deallocate
+  - name: IGameSystem_SetGameSystemGlobalPtrs
+    alias:
+    - IGameSystem::SetGameSystemGlobalPtrs
+  - name: IGameSystem_vdtor
+    alias:
+    - IGameSystem::~IGameSystem
+  - name: IGameSystem_OnGameInit
+    alias:
+    - IGameSystem::GameInit
+  - name: CMultiplayRules_ctor
+    alias:
+    - CMultiplayRules::CMultiplayRules
+  - name: CGameMoney_OnMoneySpent
+    alias:
+    - CGameMoney::OnMoneySpent
+  - name: CGameMoney_m_DataMap
+    alias:
+    - CGameMoney::m_DataMap
+  - name: CGameMoney_GetDataDescMap
+    alias:
+    - CGameMoney::GetDataDescMap
+  - name: CCSPlayer_UseServices_OnUseImpl
+    alias:
+    - CCSPlayer_UseServices::OnUseImpl
+  - name: CCSPlayer_UseServices_OnUse
+    alias:
+    - CCSPlayer_UseServices::OnUse
+  - name: CCSPlayer_MovementServices_ProcessMovement
+    alias:
+    - CCSPlayer_MovementServices::ProcessMovement
+    - ProcessMovement
+  - name: CCSPlayer_MovementServices_CheckMovingGround
+    alias:
+    - CCSPlayer_MovementServices::CheckMovingGround
+    - CheckMovingGround
+  - name: CCSPlayer_MovementServices_WalkMove
+    alias:
+    - CCSPlayer_MovementServices::WalkMove
+    - WalkMove
+  - name: CCSPlayer_MovementServices_FullWalkMove
+    alias:
+    - CCSPlayer_MovementServices::FullWalkMove
+    - FullWalkMove
+  - name: CCSPlayer_MovementServices_CheckVelocity
+    alias:
+    - CCSPlayer_MovementServices::CheckVelocity
+    - CheckVelocity
+  - name: CCSPlayer_MovementServices_WaterMove
+    alias:
+    - CCSPlayer_MovementServices::WaterMove
+    - WaterMove
+  - name: CCSPlayer_MovementServices_FullWalkMove_SpeedClamp
+    alias:
+    - ServerMovementUnlock
+  - name: CCSPlayer_MovementServices_CheckJumpButton
+    alias:
+    - CCSPlayer_MovementServices::CheckJumpButton
+  - name: CCSPlayer_MovementServices_CheckJumpButton_WaterPatch
+    alias:
+    - CheckJumpButtonWater
+    - FixWaterFloorJump
+  - name: CPlayer_MovementServices_PlayWaterStepSound
+    alias:
+    - CPlayer_MovementServices::PlayWaterStepSound
+  - name: CPlayer_MovementServices_ForceButtons
+    alias:
+    - CPlayer_MovementServices::ForceButtons
+  - name: CPlayer_MovementServices_ForceButtonState
+    alias:
+    - CPlayer_MovementServices::ForceButtonState
+  - name: CPlayer_MovementServices_s_pRunCommandPawn
+    alias:
+    - CPlayer_MovementServices::s_pRunCommandPawn
+  - name: CEntityInstance_m_pEntity
+    alias:
+    - CEntityInstance::m_pEntity
+  - name: CEntityInstance_m_hPrivateScope
+    alias:
+    - CEntityInstance::m_hPrivateScope
+  - name: CEntityInstance_m_CScriptComponent
+    alias:
+    - CEntityInstance::m_CScriptComponent
+  - name: CEntityInstance_m_pKeyValues
+    alias:
+    - CEntityInstance::m_pKeyValues
+  - name: CEntityInstance_m_iszPrivateVScripts
+    alias:
+    - CEntityInstance::m_iszPrivateVScripts
+  - name: CBaseEntity_OnRestore
+    alias:
+    - CBaseEntity::OnRestore
+  - name: CEntityInstance_OnRestore
+    alias:
+    - CEntityInstance::OnRestore
+  - name: CBaseEntity_ctor
+    alias:
+    - CBaseEntity::CBaseEntity
+  - name: CBaseEntity_dtor
+    alias:
+    - CBaseEntity::~CBaseEntity
+  - name: CBaseEntity_vdtor
+    alias:
+    - CBaseEntity::~CBaseEntity (virtual)
+  - name: CEntityInstance_vdtor
+    alias:
+    - CEntityInstance::~CEntityInstance (virtual)
+  - name: CEntitySaveRestoreBlockHandler_PreSave
+    alias:
+    - CEntitySaveRestoreBlockHandler::PreSave
+  - name: CEntitySaveRestoreBlockHandler_SaveInternal
+    alias:
+    - CEntitySaveRestoreBlockHandler::SaveInternal
+  - name: CEntitySaveRestoreBlockHandler_Save
+    alias:
+    - CEntitySaveRestoreBlockHandler::Save
+  - name: CEntitySaveRestoreBlockHandler_Restore
+    alias:
+    - CEntitySaveRestoreBlockHandler::Restore
+  - name: CEntitySaveRestoreBlockHandler_DoRestoreEntity
+    alias:
+    - CEntitySaveRestoreBlockHandler::DoRestoreEntity
+  - name: CEntitySaveRestoreBlockHandler_RestoreEntity
+    alias:
+    - CEntitySaveRestoreBlockHandler::RestoreEntity
+  - name: CreateEntityTransitionList
+    alias:
+    - CreateEntityTransitionList
+  - name: CEntitySaveRestoreBlockHandler_WriteSaveHeaders
+    alias:
+    - CEntitySaveRestoreBlockHandler::WriteSaveHeaders
+  - name: CEntitySaveRestoreBlockHandler_ReadRestoreHeaders
+    alias:
+    - CEntitySaveRestoreBlockHandler::ReadRestoreHeaders
+  - name: CEntity2SaveRestore_StreamEntitiesFromFile
+    alias:
+    - CEntity2SaveRestore::StreamEntitiesFromFile
+  - name: CSaveRestoreBlockSet_PreRestore
+    alias:
+    - CSaveRestoreBlockSet::PreRestore
+  - name: CSaveRestoreBlockSet_PostRestore
+    alias:
+    - CSaveRestoreBlockSet::PostRestore
+  - name: CEntitySaveRestoreBlockHandler_PreRestore
+    alias:
+    - CEntitySaveRestoreBlockHandler::PreRestore
+  - name: CEntitySaveRestoreBlockHandler_PostRestore
+    alias:
+    - CEntitySaveRestoreBlockHandler::PostRestore
+  - name: CEntitySystem_ForceSetInPVSCallsIntoQueue
+    alias:
+    - CEntitySystem::ForceSetInPVSCallsIntoQueue
+  - name: CEntitySystem_ExecuteQueuedSetInPVS
+    alias:
+    - CEntitySystem::ExecuteQueuedSetInPVS
+  - name: CEntitySystem_m_nSuppressDormancyChangeCount
+    alias:
+    - CEntitySystem::m_nSuppressDormancyChangeCount
+  - name: CEntitySystem_m_nExecuteQueuedCreationDepth
+    alias:
+    - CEntitySystem::m_nExecuteQueuedCreationDepth
+  - name: CEntitySystem_m_queuedDormancyChanges
+    alias:
+    - CEntitySystem::m_queuedDormancyChanges
+  - name: CEntitySystem_SetInPVS
+    alias:
+    - CEntitySystem::SetInPVS
+  - name: CEntitySystem_OnSetDormant
+    alias:
+    - CEntitySystem::OnSetDormant
+  - name: CEntitySystem_BuildResourceManifestForEntity
+    alias:
+    - CEntitySystem::BuildResourceManifestForEntity
+  - name: CEntityInstance_ObjectCaps
+    alias:
+    - CEntityInstance::ObjectCaps
+  - name: CEntityInstance_Save
+    alias:
+    - CEntityInstance::Save
+  - name: CEntityInstance_Restore
+    alias:
+    - CEntityInstance::Restore
+  - name: CEntitySaveRestoreBlockHandler_SaveInitEntities
+    alias:
+    - CEntitySaveRestoreBlockHandler::SaveInitEntities
+  - name: CEntityInstance_OnSave
+    alias:
+    - CEntityInstance::OnSave
+  - name: CEntityInstance_RequiredEdictIndex
+    alias:
+    - CEntityInstance::RequiredEdictIndex
+  - name: PolymorphicHelper_t__SetPolymorphicPointer
+    alias:
+    - PolymorphicHelper_t::SetPolymorphicPointer
+  - name: CEntityInstance_AddChangeAccessorPathPolymorphic
+    alias:
+    - CEntityInstance::AddChangeAccessorPathPolymorphic
+  - name: CEntityInstance_AssignChangeAccessorPathIdsPolymorphic
+    alias:
+    - CEntityInstance::AssignChangeAccessorPathIdsPolymorphic
+  - name: CEntityInstance_AddChangeAccessorPath
+    alias:
+    - CEntityInstance::AddChangeAccessorPath
+  - name: CEntityInstance_AssignChangeAccessorPathIds
+    alias:
+    - CEntityInstance::AssignChangeAccessorPathIds
+  - name: CEntityInstance_GetChangeAccessorPathInfo_2
+    alias:
+    - CEntityInstance::GetChangeAccessorPathInfo_2
+  - name: CBaseEntity_GetChangeAccessorPathInfo_2
+    alias:
+    - CBaseEntity::GetChangeAccessorPathInfo_2
+  - name: CBaseEntity_GetChangeAccessorPathInfo_1
+    alias:
+    - CBaseEntity::GetChangeAccessorPathInfo_1
+  - name: CMomentaryRotButton_Use
+    alias:
+    - CMomentaryRotButton::Use
+  - name: CBaseEntity_TakeDamageOld
+    alias:
+    - CBaseEntity::TakeDamageOld
+  - name: CBaseEntity_OnTakeDamage
+    alias:
+    - CBasePlayerPawn::OnTakeDamage
+  - name: CBasePlayerPawn_OnTakeDamage_Alive
+    alias:
+    - CBasePlayerPawn::OnTakeDamage_Alive
+  - name: CBasePlayerPawn_OnTakeDamage_Dying
+    alias:
+    - CBasePlayerPawn::OnTakeDamage_Dying
+  - name: CBasePlayerPawn_OnTakeDamage_Dead
+    alias:
+    - CBasePlayerPawn::OnTakeDamage_Dead
+  - name: CBasePlayerPawn_OnTakeDamage
+    alias:
+    - CBasePlayerPawn::OnTakeDamage
+  - name: CCSPlayerPawn_OnTakeDamage_Alive
+    alias:
+    - CCSPlayerPawn::OnTakeDamage_Alive
+  - name: CCSPlayerPawn_OnTakeDamage_Dying
+    alias:
+    - CCSPlayerPawn::OnTakeDamage_Dying
+  - name: CCSPlayerPawn_OnTakeDamage_Dead
+    alias:
+    - CCSPlayerPawn::OnTakeDamage_Dead
+  - name: CFlashbangProjectile_Spawn
+    alias:
+    - CFlashbangProjectile::Spawn
+  - name: CSmokeGrenadeProjectile_Create
+    alias:
+    - CSmokeGrenadeProjectile::Create
+  - name: CEntitySystem_QueueDestroyEntity
+    alias:
+    - CEntitySystem::QueueDestroyEntity
+  - name: CEntitySystem_ExecuteQueuedDeletion
+    alias:
+    - CEntitySystem::ExecuteQueuedDeletion
+  - name: CEntitySystem_m_nExecuteQueuedDeletionDepth
+    alias:
+    - CEntitySystem::m_nExecuteQueuedDeletionDepth
+  - name: CBaseModelEntity_SetModel
+    alias:
+    - CBaseModelEntity::SetModel
+  - name: CBaseModelEntity_SetRenderAttribute
+    alias:
+    - CBaseModelEntity::SetRenderAttribute
+  - name: CBaseEntity_GetScriptDescInternal
+    alias:
+    - CBaseEntity::GetScriptDescInternal
+  - name: CBaseModelEntity_GetScriptDescInternal
+    alias:
+    - CBaseModelEntity::GetScriptDescInternal
+  - name: CBaseModelEntity_GetModelScale
+    alias:
+    - CBaseModelEntity::GetModelScale
+  - name: CBaseModelEntity_Script_SetModelScale
+    alias:
+    - CBaseModelEntity::Script_SetModelScale
+  - name: CBaseModelEntity_ScriptLookupAttachment
+    alias:
+    - CBaseModelEntity::ScriptLookupAttachment
+  - name: CBaseModelEntity_ScriptGetAttachmentOrigin
+    alias:
+    - CBaseModelEntity::ScriptGetAttachmentOrigin
+  - name: CBaseModelEntity_ScriptGetAttachmentAngles
+    alias:
+    - CBaseModelEntity::ScriptGetAttachmentAngles
+  - name: CBaseModelEntity_ScriptGetAttachmentForward
+    alias:
+    - CBaseModelEntity::ScriptGetAttachmentForward
+  - name: CBaseModelEntity_ScriptSetSize
+    alias:
+    - CBaseModelEntity::ScriptSetSize
+  - name: CBaseModelEntity_ScriptSetModel
+    alias:
+    - CBaseModelEntity::ScriptSetModel
+  - name: CBaseModelEntity_ScriptGetRenderAlpha
+    alias:
+    - CBaseModelEntity::ScriptGetRenderAlpha
+  - name: CBaseModelEntity_ScriptSetRenderAlpha
+    alias:
+    - CBaseModelEntity::ScriptSetRenderAlpha
+  - name: CBaseModelEntity_ScriptSetRenderMode
+    alias:
+    - CBaseModelEntity::ScriptSetRenderMode
+  - name: CBaseModelEntity_ScriptSetRenderColor
+    alias:
+    - CBaseModelEntity::ScriptSetRenderColor
+  - name: CBaseModelEntity_ScriptGetRenderColor
+    alias:
+    - CBaseModelEntity::ScriptGetRenderColor
+  - name: CBaseModelEntity_ScriptSetMaterialGroup
+    alias:
+    - CBaseModelEntity::ScriptSetMaterialGroup
+  - name: CBaseModelEntity_ScriptSetMaterialGroupHash
+    alias:
+    - CBaseModelEntity::ScriptSetMaterialGroupHash
+  - name: CBaseModelEntity_ScriptGetMaterialGroupHash
+    alias:
+    - CBaseModelEntity::ScriptGetMaterialGroupHash
+  - name: CBaseModelEntity_ScriptSetSingleMeshGroup
+    alias:
+    - CBaseModelEntity::ScriptSetSingleMeshGroup
+  - name: CBaseModelEntity_ScriptSetMeshGroupMask
+    alias:
+    - CBaseModelEntity::ScriptSetMeshGroupMask
+  - name: CBaseModelEntity_ScriptGetMeshGroupMask
+    alias:
+    - CBaseModelEntity::ScriptGetMeshGroupMask
+  - name: CBaseModelEntity_ScriptSetBodygroupByName
+    alias:
+    - CBaseModelEntity::ScriptSetBodygroupByName
+  - name: CBaseModelEntity_Script_SetBodygroup
+    alias:
+    - CBaseModelEntity::Script_SetBodygroup
+  - name: CBaseModelEntity_Script_SetSkin
+    alias:
+    - CBaseModelEntity::Script_SetSkin
+  - name: CEntityInstance_NetworkUpdateState_thunk
+    alias:
+    - CEntityInstance::NetworkUpdateState_thunk
+  - name: CBaseEntity_SetGravityScale
+    alias:
+    - CBaseEntity::SetGravityScale
+  - name: CTriggerGravity_GravityTouch
+    alias:
+    - CTriggerGravity::GravityTouch
+  - name: CTriggerGravity_GetTouchFunction
+    alias:
+    - CTriggerGravity::GetTouchFunction
+  - name: CBasePlayerController_HandleCommand_JoinTeam
+    alias:
+    - CBasePlayerController::HandleCommand_JoinTeam
+  - name: CBasePlayerController_SetPlayerName
+    alias:
+    - CBasePlayerController::SetPlayerName
+  - name: CBasePlayerController_ProcessUsercmds
+    alias:
+    - ProcessUsercmds
+  - name: CBasePlayerController_SetPawn
+    alias:
+    - CBasePlayerController::SetPawn
+  - name: CBasePlayerController_GetPawn
+    alias:
+    - CBasePlayerController::GetPawn
+  - name: CBasePlayerController_Connect
+    alias:
+    - CBasePlayerController::Connect
+  - name: CSource2GameClients_ClientDisconnect
+    alias:
+    - CSource2GameClients::ClientDisconnect
+  - name: CSource2GameClients_ClientPutInServer
+    alias:
+    - CSource2GameClients::ClientPutInServer
+  - name: CSource2GameClients_ClientConnect
+    alias:
+    - CSource2GameClients::ClientConnect
+  - name: CSource2GameClients_ClientActive
+    alias:
+    - CSource2GameClients::ClientActive
+  - name: CSource2GameClients_ClientFullyConnect
+    alias:
+    - CSource2GameClients::ClientFullyConnect
+  - name: CSource2GameClients_ClientCommand
+    alias:
+    - CSource2GameClients::ClientCommand
+  - name: CSource2GameClients_ProcessUsercmds
+    alias:
+    - CSource2GameClients::ProcessUsercmds
+  - name: CSource2GameClients_GetBugReportInfo
+    alias:
+    - CSource2GameClients::GetBugReportInfo
+  - name: CSource2GameClients_ClientDiagnostic
+    alias:
+    - CSource2GameClients::ClientDiagnostic
+  - name: CSource2GameClients_SendHLTVStatusMessage
+    alias:
+    - CSource2GameClients::SendHLTVStatusMessage
+  - name: CSource2GameClients_OnClientConnected
+    alias:
+    - CSource2GameClients::OnClientConnected
+  - name: CGameRules_FindPickerEntity
+    alias:
+    - CGameRules::FindPickerEntity
+  - name: CCSGameRules_FindPickerEntity
+    alias:
+    - CCSGameRules::FindPickerEntity
+  - name: CCSGameRules_TerminateRound
+    alias:
+    - CCSGameRules::TerminateRound
+    - CGameRules::TerminateRound
+    - CGameRules_TerminateRound
+  - name: CCSGameRules_GoToIntermission
+    alias:
+    - CCSGameRules::GoToIntermission
+  - name: CEntityInstance_AcceptInput
+    alias:
+    - CEntityInstance::AcceptInput
+    - AcceptInput
+  - name: CEntityIdentity_AcceptInput
+    alias:
+    - CEntityIdentity::AcceptInput
+  - name: CEntityIdentity_AcceptInputInternal
+    alias:
+    - CEntityIdentity::AcceptInputInternal
+  - name: CEntityInstance_ScriptAcceptInput
+    alias:
+    - CEntityInstance::ScriptAcceptInput
+  - name: CEntityIdentity_SetEntityName
+    alias:
+    - CEntityIdentity::SetEntityName
+  - name: CEntitySystem_RemoveEntityFromNameMap
+    alias:
+    - CEntitySystem::RemoveEntityFromNameMap
+  - name: CEntitySystem_AddEntityToNameMap
+    alias:
+    - CEntitySystem::AddEntityToNameMap
+  - name: ScriptBinding_Entity_SetEntityName
+    alias:
+    - Entity::SetEntityName
+  - name: CBtActionCoordinatedBuy_Update
+    alias:
+    - CBtActionCoordinatedBuy::Update
+  - name: CCSPlayer_ItemServices_CanAcquire
+    alias:
+    - CCSPlayer_ItemServices::CanAcquire
+  - name: CCSPlayer_ItemServices_GiveDefaultItems
+    alias:
+    - CCSPlayer_ItemServices::GiveDefaultItems
+  - name: CCSPlayer_ItemServices_GiveNamedItem
+    alias:
+    - CCSPlayer_ItemServices::GiveNamedItem
+  - name: CCSPlayer_ItemServices_GiveNamedItemBool
+    alias:
+    - CCSPlayer_ItemServices::GiveNamedItemBool
+  - name: CCSPlayer_WeaponServices_CanUse
+    alias:
+    - CCSPlayer_WeaponServices::CanUse
+  - name: CCSPlayer_WeaponServices_PickupItem
+    alias:
+    - CCSPlayer_WeaponServices::PickupItem
+  - name: CCSPlayer_WeaponServices_EquipWeapon
+    alias:
+    - CCSPlayer_WeaponServices::EquipWeapon
+  - name: CCSPlayer_WeaponServices_Weapon_GetSlot
+    alias:
+    - CCSPlayer_WeaponServices_Weapon_GetSlot
+  - name: CCSPlayerController_ChangeTeam
+    alias:
+    - CCSPlayerController::ChangeTeam
+  - name: CCSPlayerController_GetThinkFunction
+    alias:
+    - CCSPlayerController::GetThinkFunction
+  - name: CCSPlayerController_PlayerForceTeamThink
+    alias:
+    - PlayerForceTeamThink
+    - CCSPlayerController::PlayerForceTeamThink
+  - name: CCSPlayerController_ResetForceTeamThink
+    alias:
+    - ResetForceTeamThink
+    - CCSPlayerController::ResetForceTeamThink
+  - name: CCSPlayerController_ResourceDataThink
+    alias:
+    - ResourceDataThink
+    - CCSPlayerController::ResourceDataThink
+  - name: CCSPlayerController_InventoryUpdateThink
+    alias:
+    - InventoryUpdateThink
+    - CCSPlayerController::InventoryUpdateThink
+  - name: g_CCSPlayerController_PlayerForceTeamThink
+    alias:
+    - g_CCSPlayerController::PlayerForceTeamThink
+  - name: g_CCSPlayerController_ResetForceTeamThink
+    alias:
+    - g_CCSPlayerController::ResetForceTeamThink
+  - name: g_CCSPlayerController_ResourceDataThink
+    alias:
+    - g_CCSPlayerController::ResourceDataThink
+  - name: g_CCSPlayerController_InventoryUpdateThink
+    alias:
+    - g_CCSPlayerController::InventoryUpdateThink
+  - name: CCSGameRules__sm_mapGcBanInformation
+    alias:
+    - CCSGameRules::sm_mapGcBanInformation
+  - name: CCSGameRules_BeginRound
+    alias:
+    - CCSGameRules::BeginRound
+  - name: CCSGameRules_PlayerSpawn
+    alias:
+    - CCSGameRules::PlayerSpawn
+  - name: CBasePlayerController_Respawn
+    alias:
+    - CBasePlayerController::Respawn
+  - name: CCSPlayerController_Respawn
+    alias:
+    - CCSPlayerController::Respawn
+  - name: CCSPlayerController_Connect
+    alias:
+    - CCSPlayerController::Connect
+  - name: CCSPlayerController_SwitchTeam
+    alias:
+    - CCSPlayerController::SwitchTeam
+  - name: CCSPlayerPawnBase_OnSetDormant
+    alias:
+    - CCSPlayerPawnBase::OnSetDormant
+  - name: CCSPlayerPawnBase_CheckForIdle
+    alias:
+    - CCSPlayerPawnBase::CheckForIdle
+  - name: CCSPlayerPawnBase_CheckForIdleInternal
+    alias:
+    - CCSPlayerPawnBase::CheckForIdleInternal
+  - name: CCSPlayerPawn_PostThink
+    alias:
+    - CCSPlayerPawnBase::PostThink
+    - CCSPlayerPawn::PostThink
+    - CCSPlayerPawnBase_PostThink
+    - CCSPlayerPawn_PostThink
+    - PostThink
+  - name: CCSPlayerPawn_OnSwitchWeapons
+    alias:
+    - CCSPlayerPawn::OnSwitchWeapons
+  - name: CCSPlayerPawn_ProcessSuicideAsKillReward
+    alias:
+    - CCSPlayerPawn::ProcessSuicideAsKillReward
+  - name: CGameRules_ClientSettingsChanged
+    alias:
+    - CGameRules::ClientSettingsChanged
+  - name: CGameRulesGameSystem_OnGameInit
+    alias:
+    - CGameRulesGameSystem::GameInit
+  - name: CGameRulesGameSystem_OnGameShutdown
+    alias:
+    - CGameRulesGameSystem::GameShutdown
+  - name: IGameSystem_OnGameShutdown
+    alias:
+    - IGameSystem::GameShutdown
+  - name: IGameSystem_OnGamePostInit
+    alias:
+    - IGameSystem::GamePostInit
+  - name: IGameSystem_OnGamePreShutdown
+    alias:
+    - IGameSystem::GamePreShutdown
+  - name: CMultiplayRules_ClientDisconnected
+    alias:
+    - CMultiplayRules::ClientDisconnected
+  - name: CSource2Server_Init
+    alias:
+    - CSource2Server::Init
+  - name: CSource2Server_ApplyGameSettings
+    alias:
+    - CSource2Server::ApplyGameSettings
+  - name: CSource2Server_WriteSignonMessages
+    alias:
+    - CSource2Server::WriteSignonMessages
+  - name: CSource2Server_GameCreateNetworkStringTables
+    alias:
+    - CSource2Server::GameCreateNetworkStringTables
+  - name: CSource2Server_GetMatchmakingGameData
+    alias:
+    - CSource2Server::GetMatchmakingGameData
+  - name: CSource2Server_GameServerSteamAPIActivated
+    alias:
+    - CSource2Server::GameServerSteamAPIActivated
+  - name: CSource2Server_GameServerSteamAPIDeactivated
+    alias:
+    - CSource2Server::GameServerSteamAPIDeactivated
+  - name: CSource2Server_OnHostNameChanged
+    alias:
+    - CSource2Server::OnHostNameChanged
+  - name: CSource2Server_GetLevelsFromSaveFile
+    alias:
+    - CSource2Server::GetLevelsFromSaveFile
+  - name: CSource2Server_ServerConVarChanged
+    alias:
+    - CSource2Server::ServerConVarChanged
+  - name: CSource2Server_Save
+    alias:
+    - CSource2Server::Save
+  - name: CSource2Server_Connect
+    alias:
+    - CSource2Server::Connect
+  - name: CSource2Server_PreShutdown
+    alias:
+    - CSource2Server::PreShutdown
+  - name: IAppSystem_Connect
+    alias:
+    - IAppSystem::Connect
+  - name: IAppSystem_PreShutdown
+    alias:
+    - IAppSystem::PreShutdown
+  - name: IVEngineServer2_ServerCommand
+    alias:
+    - IVEngineServer2::ServerCommand
+  - name: IVEngineServer2_IsDedicatedServer
+    alias:
+    - IVEngineServer2::IsDedicatedServer
+  - name: CSource2Server_Shutdown
+    alias:
+    - CSource2Server::Shutdown
+  - name: CGameEventManager_Shutdown
+    alias:
+    - CGameEventManager::Shutdown
+  - name: CLoopModeRegistry_UnregisterLoopModes
+    alias:
+    - CLoopModeRegistry::UnregisterLoopModes
+  - name: CEngineServiceRegistry_UnregisterEngineServices
+    alias:
+    - CEngineServiceRegistry::UnregisterEngineServices
+  - name: IEngineServiceMgr_UnregisterLoopMode
+    alias:
+    - IEngineServiceMgr::UnregisterLoopMode
+  - name: IEngineServiceMgr_UnregisterEngineService
+    alias:
+    - IEngineServiceMgr::UnregisterEngineService
+  - name: CSource2Server_GameFrame
+    alias:
+    - CSource2Server::GameFrame
+  - name: CGameEventManager_Init
+    alias:
+    - CGameEventManager::Init
+  - name: CTakeDamageInfo_HitGroupInfo
+    alias:
+    - CTakeDamageInfo::HitGroupInfo
+    - CTakeDamageInfo::HitGroup
+    - CTakeDamageInfo_HitGroup
+  - name: CEntitySystem_RegisterEntityClass
+    alias:
+    - CEntitySystem::RegisterEntityClass
+  - name: CEntitySystem_CreateEntityByName
+    alias:
+    - CEntitySystem::CreateEntityByName
+  - name: CEntitySystem_CreateEntity
+    alias:
+    - CEntitySystem::CreateEntity
+  - name: CEntitySystem_AddEntityToEntityDataBase
+    alias:
+    - CEntitySystem::AddEntityToEntityDataBase
+  - name: CEntitySystem_OnAddEntity
+    alias:
+    - CEntitySystem::OnAddEntity
+  - name: CEntitySystem_OnEntityParentChanged
+    alias:
+    - CEntitySystem::OnEntityParentChanged
+  - name: CEntitySystem_PrecacheEntity
+    alias:
+    - CEntitySystem::PrecacheEntity
+  - name: CEntitySystem_InvokePrecacheCallback
+    alias:
+    - CEntitySystem::InvokePrecacheCallback
+  - name: CEntitySystem_DestroyEntity
+    alias:
+    - CEntitySystem::DestroyEntity
+  - name: CConcreteEntityList_AllocEntity
+    alias:
+    - CConcreteEntityList::AllocEntity
+  - name: CEntitySystem_ConstructEntity
+    alias:
+    - CEntitySystem::ConstructEntity
+  - name: CEntitySystem_DoConstructEntity
+    alias:
+    - CEntitySystem::DoConstructEntity
+  - name: CEntitySystem_GetSpawnGroupWorldId
+    alias:
+    - CEntitySystem::GetSpawnGroupWorldId
+  - name: CEntitySystem_FindClassByDesignName
+    alias:
+    - CEntitySystem::FindClassByDesignName
+  - name: CEntitySystem_m_EntityList
+    alias:
+    - CEntitySystem::m_EntityList
+  - name: CEntitySystem_m_entityNames
+    alias:
+    - CEntitySystem::m_entityNames
+  - name: CEntitySystem_m_entityComponentHelpers
+    alias:
+    - CEntitySystem::m_entityComponentHelpers
+  - name: CEntitySystem_m_DataDescKeyUnserializers
+    alias:
+    - CEntitySystem::m_DataDescKeyUnserializers
+  - name: CEntitySystem_m_EntityPostSpawnCallback
+    alias:
+    - CEntitySystem::m_EntityPostSpawnCallback
+  - name: CEntityIdentity_FreeAttributes
+    alias:
+    - CEntityIdentity::FreeAttributes
+  - name: CConcreteEntityList_FreeEntity
+    alias:
+    - CConcreteEntityList::FreeEntity
+  - name: UTIL_CreateEntityByName
+    alias:
+    - CreateEntityByName
+  - name: CBaseEntity_DispatchSpawn
+    alias:
+    - CBaseEntity::DispatchSpawn
+    - DispatchSpawn
+  - name: CEntitySystem_QueueSpawnEntity
+    alias:
+    - CEntitySystem::QueueSpawnEntity
+  - name: CEntitySystem_HelperExecuteQueuedSpawn
+    alias:
+    - CEntitySystem::HelperExecuteQueuedSpawn
+  - name: CEntitySystem_SortEntities
+    alias:
+    - CEntitySystem::SortEntities
+  - name: CGameEntitySystem_SortEntities
+    alias:
+    - CGameEntitySystem::SortEntities
+  - name: CEntitySystem_InstallCreationWrapperCallbacks
+    alias:
+    - CEntitySystem::InstallCreationWrapperCallbacks
+  - name: CEntitySystem_ExecuteQueuedCreation
+    alias:
+    - CEntitySystem::ExecuteQueuedCreation
+  - name: CEntitySystem_ExecuteQueuedActivates
+    alias:
+    - CEntitySystem::ExecuteQueuedActivates
+  - name: CEntitySystem_ExecuteQueuedPostDataUpdateAndActivates
+    alias:
+    - CEntitySystem::ExecuteQueuedPostDataUpdateAndActivates
+  - name: CEntitySystem_Activate
+    alias:
+    - CEntitySystem::Activate
+  - name: CEntitySystem_PostDataUpdate
+    alias:
+    - CEntitySystem::PostDataUpdate
+  - name: CBaseEntity_NetworkStateChangedLog
+    alias:
+    - CBaseEntity::NetworkStateChangedLog
+  - name: CBaseEntity_NetworkStateChanged
+    alias:
+    - CBaseEntity::NetworkStateChanged
+  - name: CBaseEntity_FullEdictChanged
+    alias:
+    - CBaseEntity::FullEdictChanged
+  - name: CBaseEntity_m_NetworkTransmitComponent
+    alias:
+    - CBaseEntity::m_NetworkTransmitComponent
+  - name: CNetworkTransmitComponent_StateChanged
+    alias:
+    - CNetworkTransmitComponent::StateChanged
+  - name: CNetworkTransmitComponent_m_nStateFlags
+    alias:
+    - CNetworkTransmitComponent::m_nStateFlags
+  - name: CInferno_InfernoThink
+    alias:
+    - CInferno::InfernoThink
+  - name: CPhysExplosion_Activate
+    alias:
+    - CPhysExplosion::Activate
+  - name: CPhysExplosion_Explode
+    alias:
+    - CPhysExplosion::Explode
+  - name: UTIL_SayTextFilter2
+    alias:
+    - UTIL_SayText2Filter
+  - name: CCSWeaponBase_ItemPostFrame_ProcessReloadAction
+    alias:
+    - CCSWeaponBase::ItemPostFrame::ProcessReloadAction
+  - name: CCSPlayer_WeaponServices_HandleDropWeapon
+    alias:
+    - CCSPlayer_WeaponServices::HandleDropWeapon
+  - name: CCSPlayer_UseServices_BumpWeapon
+    alias:
+    - CCSPlayer_UseServices::BumpWeapon
+  - name: CCSPlayerPawn_HandleDropWeapon
+    alias:
+    - CCSPlayerPawn::HandleDropWeapon
+  - name: CCSPlayerPawn_ClientCommand
+    alias:
+    - CCSPlayerPawn::ClientCommand
+  - name: CCSPlayerPawn_SprayPaint
+    alias:
+    - CCSPlayerPawn::SprayPaint
+  - name: CEntitySpawner_CPlayerSprayDecal_Spawn
+    alias:
+    - CEntitySpawner<CPlayerSprayDecal>::Spawn
+  - name: CEntityKeyValuesAllocator_GetTempBuffer
+    alias:
+    - CEntityKeyValuesAllocator::GetTempBuffer
+  - name: CEntityKeyValues_LoadFromContext
+    alias:
+    - CEntityKeyValues::LoadFromContext
+  - name: CEntityKeyValues_Initialized
+    alias:
+    - CEntityKeyValues::Initialized
+  - name: CEntitySystem_m_nEntityKeyValuesAllocatorRefCount
+    alias:
+    - CEntitySystem::m_nEntityKeyValuesAllocatorRefCount
+  - name: CEntitySystem_AddRefKeyValues
+    alias:
+    - CEntitySystem::AddRefKeyValues
+  - name: CEntitySystem_ReleaseKeyValues
+    alias:
+    - CEntitySystem::ReleaseKeyValues
+  - name: CCSPlayerController_HandleCommandDrop
+    alias:
+    - CCSPlayerController::HandleCommandDrop
+  - name: IGameSystem_InitAllSystems
+    alias:
+    - IGameSystem::InitAllSystems
+  - name: IGameSystem_LoopInitAllSystems
+    alias:
+    - IGameSystem::LoopInitAllSystems
+  - name: IGameSystem_LoopPostInitAllSystems
+    alias:
+    - IGameSystem::LoopPostInitAllSystems
+  - name: IGameSystem_PostInit
+    alias:
+    - IGameSystem::PostInit
+  - name: IGameSystemFactory_PostInit
+    alias:
+    - IGameSystemFactory::PostInit
+  - name: IGameSystemFactory_GetStaticGameSystem
+    alias:
+    - IGameSystemFactory::GetStaticGameSystem
+  - name: IGameSystem_InitAllSystems_pFirst
+    alias:
+    - IGameSystem::InitAllSystems::pFirst
+    - IGameSystem::InitAllSystems->pFirst
+  - name: IGameSystem_LoopPostInitAllSystems_pEventDispatcher
+    alias:
+    - IGameSystem::LoopPostInitAllSystems::pEventDispatcher
+    - IGameSystem::LoopPostInitAllSystems->pEventDispatcher
+  - name: IGameSystem_LoopDestroyAllSystems_s_GameSystems
+    alias:
+    - IGameSystem::LoopDestroyAllSystems::s_GameSystems
+    - IGameSystem::LoopDestroyAllSystems->s_GameSystems
+  - name: CSource2GameEntities_CheckTransmit
+    alias:
+    - CSource2GameEntities::CheckTransmit
+    - ISource2GameEntities::CheckTransmit
+    - ISource2GameEntities_CheckTransmit
+    - CheckTransmit
+  - name: CBaseEntity_EmitSoundFilter
+    alias:
+    - CBaseEntity::EmitSoundFilter
+  - name: CBaseEntity_ScriptInputKill
+    alias:
+    - CBaseEntity::ScriptInputKill
+  - name: CBaseEntity_ScriptGetForward
+    alias:
+    - CBaseEntity::ScriptGetForward
+  - name: CBaseEntity_ScriptGetRight
+    alias:
+    - CBaseEntity::ScriptGetRight
+  - name: CBaseEntity_ScriptGetLeft
+    alias:
+    - CBaseEntity::ScriptGetLeft
+  - name: CBaseEntity_ScriptGetUp
+    alias:
+    - CBaseEntity::ScriptGetUp
+  - name: CBaseEntity_ScriptGetModelName
+    alias:
+    - CBaseEntity::ScriptGetModelName
+  - name: CBaseEntity_ScriptGetMoveParent
+    alias:
+    - CBaseEntity::ScriptGetMoveParent
+  - name: CBaseEntity_ScriptGetRootMoveParent
+    alias:
+    - CBaseEntity::ScriptGetRootMoveParent
+  - name: CBaseEntity_ScriptFirstMoveChild
+    alias:
+    - CBaseEntity::ScriptFirstMoveChild
+  - name: CBaseEntity_ScriptNextMovePeer
+    alias:
+    - CBaseEntity::ScriptNextMovePeer
+  - name: CBaseEntity_ScriptGetOwnerEntity
+    alias:
+    - CBaseEntity::ScriptGetOwnerEntity
+  - name: CBaseEntity_Script_GetChildren
+    alias:
+    - CBaseEntity::Script_GetChildren
+  - name: CBaseEntity_ScriptSetParent
+    alias:
+    - CBaseEntity::ScriptSetParent
+  - name: CBaseEntity_ScriptEyePosition
+    alias:
+    - CBaseEntity::ScriptEyePosition
+  - name: CBaseEntity_ScriptSetAngles
+    alias:
+    - CBaseEntity::ScriptSetAngles
+  - name: CBaseEntity_ScriptSetAbsAngles
+    alias:
+    - CBaseEntity::ScriptSetAbsAngles
+  - name: CBaseEntity_ScriptGetAngles
+    alias:
+    - CBaseEntity::ScriptGetAngles
+  - name: CBaseEntity_ScriptEyeAngles
+    alias:
+    - CBaseEntity::ScriptEyeAngles
+  - name: CBaseEntity_ScriptSetOrigin
+    alias:
+    - CBaseEntity::ScriptSetOrigin
+  - name: CBaseEntity_ScriptSetLocalAngles
+    alias:
+    - CBaseEntity::ScriptSetLocalAngles
+  - name: CBaseEntity_ScriptGetLocalAngles
+    alias:
+    - CBaseEntity::ScriptGetLocalAngles
+  - name: CBaseEntity_ScriptSetLocalOrigin
+    alias:
+    - CBaseEntity::ScriptSetLocalOrigin
+  - name: CBaseEntity_ScriptGetLocalOrigin
+    alias:
+    - CBaseEntity::ScriptGetLocalOrigin
+  - name: CBaseEntity_ScriptTransformPointEntityToWorld
+    alias:
+    - CBaseEntity::ScriptTransformPointEntityToWorld
+  - name: CBaseEntity_ScriptTransformPointWorldToEntity
+    alias:
+    - CBaseEntity::ScriptTransformPointWorldToEntity
+  - name: CBaseEntity_ScriptSetForward
+    alias:
+    - CBaseEntity::ScriptSetForward
+  - name: CBaseEntity_ScriptGetBoundingMins
+    alias:
+    - CBaseEntity::ScriptGetBoundingMins
+  - name: CBaseEntity_ScriptGetBoundingMaxs
+    alias:
+    - CBaseEntity::ScriptGetBoundingMaxs
+  - name: CBaseEntity_ScriptGetBounds
+    alias:
+    - CBaseEntity::ScriptGetBounds
+  - name: CBaseEntity_ScriptGetLocalAngularVelocity_OBSOLETE
+    alias:
+    - CBaseEntity::ScriptGetLocalAngularVelocity_OBSOLETE
+  - name: CBaseEntity_ScriptSetLocalAngularVelocity_OBSOLETE
+    alias:
+    - CBaseEntity::ScriptSetLocalAngularVelocity_OBSOLETE
+  - name: CBaseEntity_ScriptAddEffects
+    alias:
+    - CBaseEntity::ScriptAddEffects
+  - name: CBaseEntity_ScriptRemoveEffects
+    alias:
+    - CBaseEntity::ScriptRemoveEffects
+  - name: CBaseEntity_ScriptSetAttributeFloatValue
+    alias:
+    - CBaseEntity::ScriptSetAttributeFloatValue
+  - name: CBaseEntity_ScriptGetAttributeFloatValue
+    alias:
+    - CBaseEntity::ScriptGetAttributeFloatValue
+  - name: CBaseEntity_ScriptSetAttributeIntValue
+    alias:
+    - CBaseEntity::ScriptSetAttributeIntValue
+  - name: CBaseEntity_ScriptGetAttributeIntValue
+    alias:
+    - CBaseEntity::ScriptGetAttributeIntValue
+  - name: CBaseEntity_ScriptHasAttribute
+    alias:
+    - CBaseEntity::ScriptHasAttribute
+  - name: CBaseEntity_ScriptDeleteAttribute
+    alias:
+    - CBaseEntity::ScriptDeleteAttribute
+  - name: CBaseEntity_GetScriptOwnerEntity
+    alias:
+    - CBaseEntity::GetScriptOwnerEntity
+  - name: CBaseEntity_SetScriptOwnerEntity
+    alias:
+    - CBaseEntity::SetScriptOwnerEntity
+  - name: CBaseEntity_ScriptSetEntityName
+    alias:
+    - CBaseEntity::ScriptSetEntityName
+  - name: CBaseEntity_ScriptGetMass
+    alias:
+    - CBaseEntity::ScriptGetMass
+  - name: CBaseEntity_ScriptSetMass
+    alias:
+    - CBaseEntity::ScriptSetMass
+  - name: CBaseEntity_ScriptGetSpawnGroupHandle
+    alias:
+    - CBaseEntity::ScriptGetSpawnGroupHandle
+  - name: CBaseEntity_GetAbsAngles
+    alias:
+    - CBaseEntity::GetAbsAngles
+  - name: CBaseEntity_Script_GetTeamNumber
+    alias:
+    - CBaseEntity::Script_GetTeamNumber
+  - name: CBaseEntity_Script_FollowEntity
+    alias:
+    - CBaseEntity::Script_FollowEntity
+  - name: CBaseEntity_Script_FollowEntityMerge
+    alias:
+    - CBaseEntity::Script_FollowEntityMerge
+  - name: CBaseEntity_Script_Trigger
+    alias:
+    - CBaseEntity::Script_Trigger
+  - name: CBaseEntity_Script_SetContextThink
+    alias:
+    - CBaseEntity::Script_SetContextThink
+  - name: CBaseEntity_AddContextForScript
+    alias:
+    - CBaseEntity::AddContextForScript
+  - name: CBaseEntity_AddContextForScriptNumeric
+    alias:
+    - CBaseEntity::AddContextForScriptNumeric
+  - name: CBaseEntity_GetContextForScript
+    alias:
+    - CBaseEntity::GetContextForScript
+  - name: CBaseEntity_ScriptGatherCriteria
+    alias:
+    - CBaseEntity::ScriptGatherCriteria
+  - name: CBaseEntity_Script_TakeDamage
+    alias:
+    - CBaseEntity::Script_TakeDamage
+  - name: CBaseEntity_SetGravityScale
+    alias:
+    - CBaseEntity::SetGravityScale
+  - name: CBaseEntity_SetAbsVelocity
+    alias:
+    - CBaseEntity::SetAbsVelocity
+  - name: CBaseEntity_GetAbsVelocity
+    alias:
+    - CBaseEntity::GetAbsVelocity
+  - name: CBaseEntity_Script_ApplyLocalAngularVelocityImpulse
+    alias:
+    - CBaseEntity::Script_ApplyLocalAngularVelocityImpulse
+  - name: CBaseEntity_GetLocalAngularVelocity_OBSOLETE
+    alias:
+    - CBaseEntity::GetLocalAngularVelocity_OBSOLETE
+  - name: CBaseEntity_ScriptEmitSoundParams
+    alias:
+    - CBaseEntity::ScriptEmitSoundParams
+    - CBaseEntity::EmitSoundParams
+    - CBaseEntity_EmitSoundParams
+  - name: CBaseEntity_ScriptStopSound
+    alias:
+    - CBaseEntity::ScriptStopSound
+  - name: CBaseEntity_ScriptSoundDuration
+    alias:
+    - CBaseEntity::ScriptSoundDuration
+  - name: CBaseEntity_ScriptGetAbsOrigin
+    alias:
+    - CBaseEntity::ScriptGetAbsOrigin
+  - name: CBaseEntity_Precache
+    alias:
+    - CBaseEntity::Precache
+    - Precache
+  - name: CEnvEntityIgniter_Precache
+    alias:
+    - CEnvEntityIgniter::Precache
+  - name: CEnvShake_Spawn
+    alias:
+    - CEnvShake::Spawn
+  - name: CBaseEntity_SetMoveType
+    alias:
+    - CBaseEntity::SetMoveType
+  - name: CBasePlayerPawn_CommitSuicide
+    alias:
+    - CBasePlayerPawn::CommitSuicide
+    - CommitSuicide
+  - name: CBaseCombatCharacter_OnKilled
+    alias:
+    - CBaseCombatCharacter::OnKilled
+  - name: CCSPlayerPawn_Event_KilledOther
+    alias:
+    - CCSPlayerPawn::Event_KilledOther
+  - name: CCSPlayerPawn_Event_Killed
+    alias:
+    - CCSPlayerPawn::Event_Killed
+  - name: CBasePlayerPawn_Event_Killed
+    alias:
+    - CBasePlayerPawn::Event_Killed
+  - name: ScriptBinding_CSPlayerPawn_DestroyWeapon
+    alias:
+    - CSPlayerPawn::DestroyWeapon
+  - name: CBasePlayerPawn_RemovePlayerItem
+    alias:
+    - CBasePlayerPawn::RemovePlayerItem
+  - name: CBasePlayerPawn_DropActivePlayerWeapon
+    alias:
+    - CBasePlayerPawn::DropActivePlayerWeapon
+  - name: CBasePlayerPawn_GetEyePosition
+    alias:
+    - CBasePlayerPawn::GetEyePosition
+  - name: CBaseEntity_GetEyePosition
+    alias:
+    - CBaseEntity::GetEyePosition
+  - name: CCSBotManager_BotPlaceCommand
+    alias:
+    - CCSBotManager::BotPlace
+  - name: CBasePlayerPawn_EyeVectors
+    alias:
+    - CBasePlayerPawn::EyeVectors
+  - name: CBasePlayerPawn_GetEyeAngles
+    alias:
+    - CBasePlayerPawn::GetEyeAngles
+  - name: CBaseEntity_GetEyeAngles
+    alias:
+    - CBaseEntity::GetEyeAngles
+  - name: CCSBot_Upkeep
+    alias:
+    - CCSBot::Upkeep
+  - name: CCSBot_SetState
+    alias:
+    - CCSBot::SetState
+  - name: CCSBot_UpdatePathMovement
+    alias:
+    - CCSBot::UpdatePathMovement
+  - name: CCSBot_PrintIfWatched
+    alias:
+    - CCSBot::PrintIfWatched
+  - name: HideState_OnUpdate
+    alias:
+    - HideState::OnUpdate
+  - name: CCSBot_Attack
+    alias:
+    - CCSBot::Attack
+  - name: CCSBot_MoveTo
+    alias:
+    - CCSBot::MoveTo
+  - name: CCSBot_InhibitLookAround
+    alias:
+    - CCSBot::InhibitLookAround
+  - name: CCSBot_SetDisposition
+    alias:
+    - CCSBot::SetDisposition
+  - name: CCSBot_Idle
+    alias:
+    - CCSBot::Idle
+  - name: CCSBot_ComputePath
+    alias:
+    - CCSBot::ComputePath
+  - name: CBaseEntity_IsAlive
+    alias:
+    - CBaseEntity::IsAlive
+  - name: CBaseEntity_SetOwner
+    alias:
+    - CBaseEntity::SetOwner
+  - name: CBaseEntity_CollisionRulesChanged
+    alias:
+    - CBaseEntity::CollisionRulesChanged
+    - CollisionRulesChanged
+  - name: CBaseEntity_Use
+    alias:
+    - CBaseEntity::Use
+  - name: CGameSceneNode_PostSpawnKeyValues
+    alias:
+    - CGameSceneNode::PostSpawnKeyValues
+  - name: CBaseEntity_Spawn
+    alias:
+    - CBaseEntity::Spawn
+    - Spawn
+  - name: CBaseEntity_SpawnRadius
+    alias:
+    - CBaseEntity::SpawnRadius
+  - name: CCSPlayer_ItemServices_DropActivePlayerWeapon
+    alias:
+    - CCSPlayer_ItemServices::DropActivePlayerWeapon
+  - name: CCSPlayer_WeaponServices_DropWeapon
+    alias:
+    - CCSPlayer_WeaponServices::DropWeapon
+  - name: CCSPlayer_ItemServices_RemoveWeapons
+    alias:
+    - CCSPlayer_ItemServices::RemoveWeapons
+  - name: CCSPlayer_WeaponServices_SelectItem
+    alias:
+    - CCSPlayer_WeaponServices::SelectItem
+  - name: CEntFireOutputAutoCompletionFunctor_FireOutput
+    alias:
+    - CEntFireOutputAutoCompletionFunctor::FireOutput
+  - name: CEntityInstance_FindOutputsByName
+    alias:
+    - CEntityInstance::FindOutputsByName
+  - name: CEntityInstance_ScriptEntityIO
+    alias:
+    - CEntityInstance::ScriptEntityIO
+  - name: CEntityIOOutput_FireOutputInternal
+    alias:
+    - CEntityIOOutput::FireOutputInternal
+  - name: CEntitySystem_AddEntityIOEvent
+    alias:
+    - CEntitySystem::AddEntityIOEvent
+  - name: CEntitySystem_AddEntityIOEvent2
+    alias:
+    - CEntitySystem::AddEntityIOEvent2
+  - name: CEntitySystem_AddEntityIOEventBuildStruct
+    alias:
+    - CEntitySystem::AddEntityIOEventBuildStruct
+  - name: CEntitySystem_AddEntityIOEventToQueue
+    alias:
+    - CEntitySystem::AddEntityIOEventToQueue
+  - name: CEntitySystem_m_EventQueue
+    alias:
+    - CEntitySystem::m_EventQueue
+  - name: CGameEntitySystem_FindEntityByClassName
+    alias:
+    - CGameEntitySystem::FindEntityByClassName
+  - name: CGameEntitySystem_FindEntityByName
+    alias:
+    - CGameEntitySystem::FindEntityByName
+  - name: CGameEntitySystem_OnAddEntity
+    alias:
+    - CGameEntitySystem::OnAddEntity
+  - name: CGameEntitySystem_BuildResourceManifest_ManifestNameOrGroupName
+    alias:
+    - CGameEntitySystem::BuildResourceManifest_ManifestNameOrGroupName
+  - name: CGameEntitySystem_BuildResourceManifest_KeyValuesVectors
+    alias:
+    - CGameEntitySystem::BuildResourceManifest_KeyValuesVectors
+  - name: CGameEntitySystem_FindEntityProcedural
+    alias:
+    - CGameEntitySystem::FindEntityProcedural
+  - name: CGameEntitySystem_Spawn
+    alias:
+    - CGameEntitySystem::Spawn
+  - name: CEntitySystem_Spawn
+    alias:
+    - CEntitySystem::Spawn
+  - name: CBodyGameSystem_SpawnDependencyIsland
+    alias:
+    - CBodyGameSystem::SpawnDependencyIsland
+  - name: CGameEntitySystem_CheckGlobalState
+    alias:
+    - CGameEntitySystem::CheckGlobalState
+  - name: IGameSystem_OnBuildGameSessionManifest
+    alias:
+    - IGameSystem::BuildGameSessionManifest
+  - name: IGameSystem_OnServerPreEntityThink
+    alias:
+    - IGameSystem::OnServerPreEntityThink
+  - name: IGameSystem_OnServerPostEntityThink
+    alias:
+    - IGameSystem::OnServerPostEntityThink
+  - name: IGameSystem_OnServerPreClientUpdate
+    alias:
+    - IGameSystem::ServerPreClientUpdate
+  - name: IGameSystem_OnServerAdvanceTick
+    alias:
+    - IGameSystem::ServerAdvanceTick
+  - name: IGameSystem_OnServerGamePostSimulate
+    alias:
+    - IGameSystem::ServerGamePostSimulate
+  - name: IGameSystem_OnServerPostAdvanceTick
+    alias:
+    - IGameSystem::ServerPostAdvanceTick
+  - name: IGameSystem_OnServerPreBeginAsyncPostTickWork
+    alias:
+    - IGameSystem::OnServerPreBeginAsyncPostTickWork
+  - name: IGameSystem_OnServerBeginAsyncPostTickWork
+    alias:
+    - IGameSystem::OnServerBeginAsyncPostTickWork
+  - name: IGameSystem_OnServerPreEndAsyncPostTickWork
+    alias:
+    - IGameSystem::OnServerPreEndAsyncPostTickWork
+  - name: IGameSystem_OnServerPostEndAsyncPostTickWork
+    alias:
+    - IGameSystem::OnServerPostEndAsyncPostTickWork
+  - name: IGameSystem_OnSaveGame
+    alias:
+    - IGameSystem::OnSaveGame
+  - name: IGameSystem_OnRestoreGame
+    alias:
+    - IGameSystem::OnRestoreGame
+  - name: IGameSystem_OnOutOfGameFrameBoundary
+    alias:
+    - IGameSystem::OnOutOfGameFrameBoundary
+  - name: CSource2GameClients_StartHLTVServer
+    alias:
+    - CSource2GameClients::StartHLTVServer
+  - name: LegacyGameEventListener
+    alias:
+    - GetLegacyGameEventListener
+  - name: CPhysicsGameSystem_ProcessContactEvents
+    alias:
+    - CPhysicsGameSystem::ProcessContactEvents
+  - name: CBaseEntity_PhysicsDispatchStartTouch
+    alias:
+    - CBaseEntity::PhysicsDispatchStartTouch
+  - name: CBaseEntity_PhysicsNotifyOtherOfEndTouch
+    alias:
+    - CBaseEntity::PhysicsNotifyOtherOfEndTouch
+  - name: CBaseEntity_PhysicsDispatchTouch
+    alias:
+    - CBaseEntity::PhysicsDispatchTouch
+  - name: CBaseEntity_StartTouch
+    alias:
+    - CBaseEntity::StartTouch
+    - StartTouch
+  - name: CBaseEntity_Touch
+    alias:
+    - CBaseEntity::Touch
+    - Touch
+  - name: CBaseEntity_EndTouch
+    alias:
+    - CBaseEntity::EndTouch
+    - EndTouch
+  - name: IVPhys2World_GetTouchingList
+    alias:
+    - IVPhys2World::GetTouchingList
+    - CVPhys2World::GetTouchingList
+  - name: CTriggerPush_Touch
+    alias:
+    - CTriggerPush::Touch
+    - TriggerPush_Touch
+  - name: CPhysBox_Use
+    alias:
+    - CPhysBox::Use
+  - name: CBaseEntity_SetGroundEntity
+    alias:
+    - SetGroundEntity
+  - name: CBaseEntity_GetHammerUniqueId
+    alias:
+    - CBaseEntity::GetHammerUniqueId
+    - GetHammerUniqueId
+  - name: CBaseEntity_IsPlayerPawn
+    alias:
+    - CBaseEntity::IsPlayerPawn
+    - IsEntityPawn
+    - IsPlayerPawn
+  - name: CBaseEntity_IsPlayerController
+    alias:
+    - CBaseEntity::IsPlayerController
+    - IsEntityController
+    - IsPlayerController
+  - name: CBaseTrigger_StartTouch
+    alias:
+    - CBaseTrigger::StartTouch
+  - name: CBaseTrigger_EndTouch
+    alias:
+    - CBaseTrigger::EndTouch
+  - name: CBaseTrigger_PassesTriggerFilters
+    alias:
+    - CBaseTrigger::PassesTriggerFilters
+    - PassesTriggerFilters
+  - name: CBaseAnimGraph_GetAnimationController
+    alias:
+    - CBaseAnimGraph::GetAnimationController
+  - name: CBaseAnimGraph_m_skeletonInstance
+    alias:
+    - CBaseAnimGraph::m_skeletonInstance
+  - name: CGameSceneNode_PreInstanceSpawn
+    alias:
+    - CGameSceneNode::PreInstanceSpawn
+  - name: CGameSceneNode_GetSkeletonInstance
+    alias:
+    - CGameSceneNode::GetSkeletonInstance
+  - name: CSkeletonInstance_m_animationController
+    alias:
+    - CSkeletonInstance::m_animationController
+  - name: CSkeletonInstance_PostDataUpdate
+    alias:
+    - CSkeletonInstance::PostDataUpdate
+  - name: CGameSceneNode_PostDataUpdate
+    alias:
+    - CGameSceneNode::PostDataUpdate
+  - name: CGameSceneNode_UpdateEntityForHierarchyChange
+    alias:
+    - CGameSceneNode::UpdateEntityForHierarchyChange
+  - name: CPointTeleportAPI_TeleportEntityInternal
+    alias:
+    - CPointTeleportAPI::TeleportEntityInternal
+  - name: CBaseEntity_Teleport
+    alias:
+    - CBaseEntity::Teleport
+  - name: CPointTeleport_Activate
+    alias:
+    - CPointTeleport::Activate
+  - name: CBaseEntity_Activate
+    alias:
+    - CBaseEntity::Activate
+    - Activate
+  - name: CBaseEntity_DrawDebugTextOverlays
+    alias:
+    - CBaseEntity::DrawDebugTextOverlays
+  - name: CRagdollProp_DrawEntityDebugOverlays
+    alias:
+    - CRagdollProp::DrawEntityDebugOverlays
+  - name: CBaseEntity_ReloadPrivateScripts
+    alias:
+    - CBaseEntity::ReloadPrivateScripts
+  - name: CCheckTransmitInfo_m_nPlayerSlot
+    alias:
+    - CCheckTransmitInfo::m_nPlayerSlot
+    - CheckTransmitPlayerSlot
+  - name: CDedicatedServerWorkshopManager_SwitchToWorkshopMapGroup
+    alias:
+    - CDedicatedServerWorkshopManager::SwitchToWorkshopMapGroup
+  - name: IGameTypes_CreateWorkshopMapGroup
+    alias:
+    - IGameTypes::CreateWorkshopMapGroup
+  - name: CSpawnGroupMgrGameSystem_GetSpawnGroups
+    alias:
+    - CSpawnGroupMgrGameSystem::GetSpawnGroups
+    - GetSpawnGroups
+  - name: CSpawnGroupMgrGameSystem_DumpSpawnGroups
+    alias:
+    - CSpawnGroupMgrGameSystem::DumpSpawnGroups
+    - DumpSpawnGroups
+  - name: CSpawnGroupMgrGameSystem_SpawnGroupSpawnEntitiesInternal
+    alias:
+    - CSpawnGroupMgrGameSystem::SpawnGroupSpawnEntitiesInternal
+    - SpawnGroupSpawnEntitiesInternal
+  - name: IGameSystem_OnPreSpawnGroupLoad
+    alias:
+    - IGameSystem::OnPreSpawnGroupLoad
+  - name: IGameSystem_OnPostSpawnGroupLoad
+    alias:
+    - IGameSystem::OnPostSpawnGroupLoad
+  - name: CSpawnGroupMgrGameSystem_SpawnGroupShutdown
+    alias:
+    - CSpawnGroupMgrGameSystem::SpawnGroupShutdown
+    - SpawnGroupShutdown
+  - name: CSpawnGroupMgrGameSystem_SpawnGroupActuallyShutdown
+    alias:
+    - CSpawnGroupMgrGameSystem::SpawnGroupActuallyShutdown
+    - SpawnGroupActuallyShutdown
+  - name: IGameSystem_OnPreSpawnGroupUnload
+    alias:
+    - IGameSystem::OnPreSpawnGroupUnload
+  - name: IGameSystem_OnPostSpawnGroupUnload
+    alias:
+    - IGameSystem::OnPostSpawnGroupUnload
+  - name: CLoadingSpawnGroup_CreateEntityToSpawn
+    alias:
+    - CLoadingSpawnGroup::CreateEntityToSpawn
+  - name: CSpawnGroupMgrGameSystem_OnSpawnGroupPrecache
+    alias:
+    - CSpawnGroupMgrGameSystem::OnSpawnGroupPrecache
+    - SpawnGroupPrecache
+  - name: CSpawnGroupMgrGameSystem_AllocateSpawnGroup
+    alias:
+    - CSpawnGroupMgrGameSystem::AllocateSpawnGroup
+  - name: CSpawnGroupMgrGameSystem_ReleaseSpawnGroup
+    alias:
+    - CSpawnGroupMgrGameSystem::ReleaseSpawnGroup
+  - name: CSpawnGroupMgrGameSystem_SpawnGroupInit
+    alias:
+    - CSpawnGroupMgrGameSystem::SpawnGroupInit
+  - name: CSpawnGroupMgrGameSystem_CreateLoadingSpawnGroup
+    alias:
+    - CSpawnGroupMgrGameSystem::CreateLoadingSpawnGroup
+  - name: CSpawnGroupMgrGameSystem_CreateLoadingSpawnGroupForSaveFile
+    alias:
+    - CSpawnGroupMgrGameSystem::CreateLoadingSpawnGroupForSaveFile
+  - name: CSpawnGroupMgrGameSystem_SpawnGroupSpawnEntities
+    alias:
+    - CSpawnGroupMgrGameSystem::SpawnGroupSpawnEntities
+  - name: CSpawnGroupMgrGameSystem_SetActiveSpawnGroup
+    alias:
+    - CSpawnGroupMgrGameSystem::SetActiveSpawnGroup
+  - name: CSpawnGroupMgrGameSystem_UnloadSpawnGroup
+    alias:
+    - CSpawnGroupMgrGameSystem::UnloadSpawnGroup
+  - name: CSpawnGroupMgrGameSystem_SaveGame_Start
+    alias:
+    - CSpawnGroupMgrGameSystem::SaveGame_Start
+  - name: IGameSystem_OnSpawnGroupPrecache
+    alias:
+    - IGameSystem::OnSpawnGroupPrecache
+  - name: IGameSystem_OnSpawnGroupUncache
+    alias:
+    - IGameSystem::OnSpawnGroupUncache
+  - name: CBaseFilter_InputTestActivator
+    alias:
+    - CBaseFilter::InputTestActivator
+  - name: CGamePlayerEquip_InputTriggerForAllPlayers
+    alias:
+    - CGamePlayerEquip::InputTriggerForAllPlayers
+  - name: CGamePlayerEquip_InputTriggerForActivatedPlayer
+    alias:
+    - CGamePlayerEquip::InputTriggerForActivatedPlayer
+  - name: CNavMesh_GetNearestNavArea
+    alias:
+    - CNavMesh::GetNearestNavArea
+  - name: CCSBotManager_AddBot
+    alias:
+    - CCSBotManager::AddBot
+  - name: BotAdd_CommandHandler
+    alias:
+    - CCSBotManager::BotAddCommand
+  - name: BotKill_CommandHandler
+    alias:
+    - CCSBotManager::BotKillCommand
+  - name: EntInfo_CommandHandler
+    alias:
+    - CC_Ent_Info
+  - name: CEntitySystem_DestroyEntityImmediate
+    alias:
+    - CEntitySystem::DestroyEntityImmediate
+  - name: CEntitySystem_OnRemoveEntityFromDatabase
+    alias:
+    - CEntitySystem::OnRemoveEntityFromDatabase
+  - name: CEntitySystem_DoDestructEntity
+    alias:
+    - CEntitySystem::DoDestructEntity
+  - name: CEntitySystem_UpdateOnRemove
+    alias:
+    - CEntitySystem::UpdateOnRemove
+  - name: ClientPrintToController
+    alias:
+    - ClientPrint
+  - name: CCSBotManager_AddBot_BotNavIgnore
+    alias:
+    - BotNavIgnore
+  - name: CEnvHudHint_API_ShowHudHint
+    alias:
+    - CEnvHudHint_API::ShowHudHint
+  - name: UTIL_GetPlayerControllerForEntity
+    alias:
+    - UTIL_GetPlayerControllerForEntity
+  - name: CEntitySystem_ctor
+    alias:
+    - CEntitySystem::CEntitySystem
+  - name: CGameEntitySystem_ctor
+    alias:
+    - CGameEntitySystem::CGameEntitySystem
+  - name: CEntitySystem_RegisterAccessor
+    alias:
+    - CEntitySystem::RegisterAccessor
+  - name: CEntitySystem_Init
+    alias:
+    - CEntitySystem::Init
+  - name: CEntitySystem_ProcessEntityRegistration
+    alias:
+    - CEntitySystem::ProcessEntityRegistration
+  - name: CEntitySystem_PostCreateEntitySystem
+    alias:
+    - CEntitySystem::PostCreateEntitySystem
+  - name: CSource2EntitySystem_StaticInit
+    alias:
+    - CSource2EntitySystem::StaticInit
+  - name: CSpawnGroupEntityFilterRegistrar_RegisterSpawnGroupEntityFilters
+    alias:
+    - CSpawnGroupEntityFilterRegistrar::RegisterSpawnGroupEntityFilters
+  - name: CGameEntitySystem_m_spawnGroupEntityFilters
+    alias:
+    - CGameEntitySystem::m_spawnGroupEntityFilters
+  - name: CGameEntitySystem_m_pEntity2Networkables
+    alias:
+    - CGameEntitySystem::m_pEntity2Networkables
+  - name: CEntity2NetworkClasses_ServerClass_InitEntity2NetworkClasses
+    alias:
+    - CEntity2NetworkClasses<ServerClass>::InitEntity2NetworkClasses
+  - name: CEntitySystem_m_Symbols
+    alias:
+    - CEntitySystem::m_Symbols
+  - name: CEntitySystem_m_pNetworkFieldChangedEventQueue
+    alias:
+    - CEntitySystem::m_pNetworkFieldChangedEventQueue
+  - name: CEntitySystem_m_pNetworkFieldScratchData
+    alias:
+    - CEntitySystem::m_pNetworkFieldScratchData
+  - name: CEntitySystem_m_pFieldChangeLimitSpew
+    alias:
+    - CEntitySystem::m_pFieldChangeLimitSpew
+  - name: CEntitySystem_m_ComponentUnserializerInfoAllocator
+    alias:
+    - CEntitySystem::m_ComponentUnserializerInfoAllocator
+  - name: CEntitySystem_m_EntityMaterialAttributes
+    alias:
+    - CEntitySystem::m_EntityMaterialAttributes
+  - name: CEntitySystem_m_flChangeCallbackSpewThreshold
+    alias:
+    - CEntitySystem::m_flChangeCallbackSpewThreshold
+  - name: CEntitySystem_ClearEntityDatabase
+    alias:
+    - CEntitySystem::ClearEntityDatabase
+  - name: INetworkMessages_SetNetworkSerializationContextData
+    alias:
+    - INetworkMessages::SetNetworkSerializationContextData
+  - name: CFlattenedSerializers_CreateFieldChangedEventQueue
+    alias:
+    - CFlattenedSerializers::CreateFieldChangedEventQueue
+  - name: INetworkMessages_RegisterSchemaTypeOverride
+    alias:
+    - INetworkMessages::RegisterSchemaTypeOverride
+  - name: PolymorphicHelper_t__SetPolymorphicPointer
+    alias:
+    - PolymorphicHelper_t::SetPolymorphicPointer
+  - name: CSceneEntity_GetScriptDesc
+    alias:
+    - CSceneEntity::GetScriptDesc
+  - name: CEntityInstance_GetScriptDesc
+    alias:
+    - CEntityInstance::GetScriptDesc
+  - name: CEntityInstance_Spawn
+    alias:
+    - CEntityInstance::Spawn
+  - name: CEntityInstance_Activate
+    alias:
+    - CEntityInstance::Activate
+  - name: CEntityInstance_Precache
+    alias:
+    - CEntityInstance::Precache
+  - name: CEntityInstance_GetDataDescMap
+    alias:
+    - CEntityInstance::GetDataDescMap
+  - name: CEntityInstance_ReloadPrivateScripts
+    alias:
+    - CEntityInstance::ReloadPrivateScripts
+  - name: CEntityInstance_ValidatePrivateScriptScope
+    alias:
+    - CEntityInstance::ValidatePrivateScriptScope
+  - name: CEntityInstance_NetworkStateChanged
+    alias:
+    - CEntityInstance::NetworkStateChanged
+  - name: CEntityInstance_FullEdictChanged
+    alias:
+    - CEntityInstance::FullEdictChanged
+  - name: CEntityInstance_NetworkUpdateState
+    alias:
+    - CEntityInstance::NetworkUpdateState
+  - name: CEntityInstance_NetworkStateChangedLog
+    alias:
+    - CEntityInstance::NetworkStateChangedLog
+  - name: CEntityInstance_DrawDebugTextOverlays
+    alias:
+    - CEntityInstance::DrawDebugTextOverlays
+  - name: CEntityInstance_DrawEntityDebugOverlays
+    alias:
+    - CEntityInstance::DrawEntityDebugOverlays
+  - name: CEntityInstance_PostDataUpdateDelta
+    alias:
+    - CEntityInstance::PostDataUpdateDelta
+  - name: CEntityInstance_PreDataUpdate
+    alias:
+    - CEntityInstance::PreDataUpdate
+  - name: CEntityInstance_PostDataUpdate
+    alias:
+    - CEntityInstance::PostDataUpdate
+  - name: CEntityInstance_PostDataUpdatePreserve
+    alias:
+    - CEntityInstance::PostDataUpdatePreserve
+  - name: CEntityInstance_Connect
+    alias:
+    - CEntityInstance::Connect
+  - name: CEntityInstance_UpdateOnRemove
+    alias:
+    - CEntityInstance::UpdateOnRemove
+  - name: CEntityInstance_Disconnect
+    alias:
+    - CEntityInstance::Disconnect
+  - name: CEntityInstance_AddedToEntityDatabase
+    alias:
+    - CEntityInstance::AddedToEntityDatabase
+  - name: CEntityInstance_OnSetDormant
+    alias:
+    - CEntityInstance::OnSetDormant
+  - name: CEntityInstance_Schema_DynamicBinding
+    alias:
+    - CEntityInstance::Schema_DynamicBinding
+  - name: CEntitySystem_OnRemoveEntity
+    alias:
+    - CEntitySystem::OnRemoveEntity
+  - name: CEntityComponentHelperT_Free
+    alias:
+    - CEntityComponentHelperT::Free
+  - name: CScriptedSequence_SynchronizeSequence
+    alias:
+    - CScriptedSequence::SynchronizeSequence
+  - name: CNetworkUtlVectorEmbedded_NetworkStateChanged_m_vecRenderAttributes
+    alias:
+    - CNetworkUtlVectorEmbedded<CRenderAttribute>::NetworkStateChanged_m_vecRenderAttributes
+  - name: CNetworkUtlVectorEmbedded_NetworkStateChanged_m_perRoundStats
+    alias:
+    - CNetworkUtlVectorEmbedded<CSPerRoundStats_t>::NetworkStateChanged_m_perRoundStats
+  - name: CUtlVectorEmbeddedNetworkVar_CSPerRoundStats_t_NetworkVar_m_perRoundStats_SetCount
+    alias:
+    - CUtlVectorEmbeddedNetworkVar<CSPerRoundStats_t, NetworkVar>::SetCount
+  - name: CNetworkUtlVectorEmbedded_TryLateResolve_m_vecRenderAttributes
+    alias:
+    - CNetworkUtlVectorEmbedded<CRenderAttribute>::TryLateResolve
+  - name: INetworkMessages_GetLoggingChannel
+    alias:
+    - INetworkMessages::GetLoggingChannel
+  - name: CPhysicsEntitySolver_PhysEnableEntityCollisions
+    alias:
+    - CPhysicsEntitySolver::PhysEnableEntityCollisions
+  - name: CLoopModeGame_StaticInit
+    alias:
+    - CLoopModeGame::StaticInit
+  - name: CLoopModeFactory_CLoopModeGame_Init
+    alias:
+    - CLoopModeFactory<CLoopModeGame>::Init
+  - name: CLoopModeFactory_CLoopModeGame_Shutdown
+    alias:
+    - CLoopModeFactory<CLoopModeGame>::Shutdown
+  - name: CLoopModeGame_OnLoopActivate
+    alias:
+    - CLoopModeGame::OnLoopActivate
+  - name: ILoopMode_OnLoopActivate
+    alias:
+    - ILoopMode::OnLoopActivate
+  - name: CLoopModeGame_AddViewsToSceneSystem
+    alias:
+    - CLoopModeGame::AddViewsToSceneSystem
+  - name: ILoopMode_AddViewsToSceneSystem
+    alias:
+    - ILoopMode::AddViewsToSceneSystem
+  - name: CLoopModeGame_LoopInitInternal
+    alias:
+    - CLoopModeGame::LoopInitInternal
+  - name: CLoopModeGame_LoopInit
+    alias:
+    - CLoopModeGame::LoopInit
+  - name: ILoopMode_LoopInit
+    alias:
+    - ILoopMode::LoopInit
+  - name: ILoopMode_LoopShutdown
+    alias:
+    - ILoopMode::LoopShutdown
+  - name: CLoopModeGame_RegisterEventMapInternal
+    alias:
+    - CLoopModeGame::RegisterEventMapInternal
+  - name: CLoopModeGame_OnServerAdvanceTick
+    alias:
+    - CLoopModeGame::OnServerAdvanceTick
+  - name: CLoopModeGame_OnServerBeginSimulate
+    alias:
+    - CLoopModeGame::OnServerBeginSimulate
+  - name: CLoopModeGame_OnServerPostSimulate
+    alias:
+    - CLoopModeGame::OnServerPostSimulate
+  - name: CLoopModeGame_OnServerPostAdvanceTick
+    alias:
+    - CLoopModeGame::OnServerPostAdvanceTick
+  - name: CLoopModeGame_OnServerBeginAsyncPostTickWork
+    alias:
+    - CLoopModeGame::OnServerBeginAsyncPostTickWork
+  - name: CLoopModeGame_OnServerEndAsyncPostTickWork
+    alias:
+    - CLoopModeGame::OnServerEndAsyncPostTickWork
+  - name: CLoopModeGame_OnFrameBoundary
+    alias:
+    - CLoopModeGame::OnFrameBoundary
+  - name: CLoopModeGame_ReceivedServerInfo
+    alias:
+    - CLoopModeGame::ReceivedServerInfo
+  - name: CLoopModeGame_SetWorldSession
+    alias:
+    - CLoopModeGame::SetWorldSession
+  - name: CLoopModeGame_SetGameSystemState
+    alias:
+    - CLoopModeGame::SetGameSystemState
+  - name: IGameSystem_DestroyAllGameSystems
+    alias:
+    - IGameSystem::DestroyAllGameSystems
+  - name: IGameSystem_ShutdownAllSystems
+    alias:
+    - IGameSystem::ShutdownAllSystems
+  - name: IGameSystem_LoopDestroyAllSystems
+    alias:
+    - IGameSystem::LoopDestroyAllSystems
+  - name: IGameSystem_LoopPreShutdownAllSystems
+    alias:
+    - IGameSystem::LoopPreShutdownAllSystems
+  - name: CLoopModeGame_Shutdown
+    alias:
+    - CLoopModeGame::Shutdown
+  - name: CLoopModeGame_LoopShutdown
+    alias:
+    - CLoopModeGame::LoopShutdown
+  - name: CLoopModeGame_ShutdownServer
+    alias:
+    - CLoopModeGame::ShutdownServer
+  - name: CLoopModeGame_OnLoopDeactivate
+    alias:
+    - CLoopModeGame::OnLoopDeactivate
+  - name: ILoopMode_OnLoopDeactivate
+    alias:
+    - ILoopMode::OnLoopDeactivate
+  - name: CPlayerCommandQueue_ctor
+    alias:
+    - CPlayerCommandQueue::CPlayerCommandQueue
+  - name: IGameResourceService_SetEntityResourceManifestHandler
+    alias:
+    - IGameResourceService::SetEntityResourceManifestHandler
+  - name: CNetworkSerializerBindingBuildFilter_GetFieldPriority
+    alias:
+    - CNetworkSerializerBindingBuildFilter::GetFieldPriority
+  - name: CEntitySystem_FindComponentTypeByName
+    alias:
+    - CEntitySystem::FindComponentTypeByName
+- name: networksystem
+  symbols:
+  - name: INetworkMessages_GetFieldChangeCallbackOrderCount
+    alias:
+    - INetworkMessages::GetFieldChangeCallbackOrderCount
+  - name: INetworkMessages_GetFieldChangeCallbackPriorities
+    alias:
+    - INetworkMessages::GetFieldChangeCallbackPriorities

--- a/gamesymbols/14171.metadata.yaml
+++ b/gamesymbols/14171.metadata.yaml
@@ -1,0 +1,2879 @@
+modules:
+- name: networksystem
+  symbols:
+  - name: CNetworkMessages_RegisterNetworkCategory
+    alias:
+    - CNetworkMessages::RegisterNetworkCategory
+  - name: CNetworkMessages_AssociateNetMessageWithChannelCategoryAbstract
+    alias:
+    - CNetworkMessages::AssociateNetMessageWithChannelCategoryAbstract
+  - name: CNetworkMessages_FindOrCreateNetMessage
+    alias:
+    - CNetworkMessages::FindOrCreateNetMessage
+  - name: CNetworkMessages_SerializeInternal
+    alias:
+    - CNetworkMessages::SerializeInternal
+  - name: CNetworkMessages_UnserializeMessageInternal
+    alias:
+    - CNetworkMessages::UnserializeMessageInternal
+  - name: CNetworkMessages_SerializeMessageInternal
+    alias:
+    - CNetworkMessages::SerializeMessageInternal
+  - name: CNetworkMessages_UnserializeFromStream
+    alias:
+    - CNetworkMessages::UnserializeFromStream
+  - name: CNetworkMessages_AllocateAndCopyConstructNetMessageAbstract
+    alias:
+    - CNetworkMessages::AllocateAndCopyConstructNetMessageAbstract
+  - name: CNetworkMessages_DeallocateNetMessageAbstract
+    alias:
+    - CNetworkMessages::DeallocateNetMessageAbstract
+  - name: CNetworkMessages_RegisterNetworkFieldSerializer
+    alias:
+    - CNetworkMessages::RegisterNetworkFieldSerializer
+  - name: CNetworkMessages_RegisterNetworkArrayFieldSerializer
+    alias:
+    - CNetworkMessages::RegisterNetworkArrayFieldSerializer
+  - name: CNetworkMessages_AssociateNetMessageGroupIdWithChannelCategory
+    alias:
+    - CNetworkMessages::AssociateNetMessageGroupIdWithChannelCategory
+  - name: CNetworkMessages_RegisterNetworkFieldChangeCallbackInternal
+    alias:
+    - CNetworkMessages::RegisterNetworkFieldChangeCallbackInternal
+  - name: CNetworkMessages_AllowAdditionalMessageRegistration
+    alias:
+    - CNetworkMessages::AllowAdditionalMessageRegistration
+  - name: CNetworkMessages_IsAdditionalMessageRegistrationAllowed
+    alias:
+    - CNetworkMessages::IsAdditionalMessageRegistrationAllowed
+  - name: CNetworkMessages_RegisterFieldChangeCallbackPriority
+    alias:
+    - CNetworkMessages::RegisterFieldChangeCallbackPriority
+  - name: CNetworkMessages_ComputeOrderForPriority
+    alias:
+    - CNetworkMessages::ComputeOrderForPriority
+  - name: CNetworkMessages_dtor
+    alias:
+    - CNetworkMessages::~CNetworkMessages
+  - name: CNetworkMessages_GetIsForServer
+    alias:
+    - CNetworkMessages::GetIsForServer
+  - name: CNetworkMessages_GetNetworkSerializationContextData
+    alias:
+    - CNetworkMessages::GetNetworkSerializationContextData
+  - name: CNetChan_ParseMessagesDemoInternal
+    alias:
+    - CNetChan::ParseMessagesDemoInternal
+  - name: CNetChan_ParseNetMessageShowFilter
+    alias:
+    - CNetChan::ParseNetMessageShowFilter
+  - name: CNetworkMessages_FindNetworkMessagePartial
+    alias:
+    - CNetworkMessages::FindNetworkMessagePartial
+  - name: CNetworkMessages_FindNetworkMessage
+    alias:
+    - CNetworkMessages::FindNetworkMessage
+  - name: CNetworkMessages_FindNetworkGroup
+    alias:
+    - CNetworkMessages::FindNetworkGroup
+  - name: CNetworkSystem_SendNetworkStats
+    alias:
+    - CNetworkSystem::SendNetworkStats
+  - name: CNetworkMessages_GetNetworkGroupCount
+    alias:
+    - CNetworkMessages::GetNetworkGroupCount
+  - name: CNetworkMessages_GetNetworkGroupName
+    alias:
+    - CNetworkMessages::GetNetworkGroupName
+  - name: CNetworkMessages_GetNetworkGroupColor
+    alias:
+    - CNetworkMessages::GetNetworkGroupColor
+  - name: CNetworkMessages_ConfirmAllMessageHandlersInstalled
+    alias:
+    - CNetworkMessages::ConfirmAllMessageHandlersInstalled
+- name: engine
+  symbols:
+  - name: CServerSideClient_IsHearingClient
+    alias:
+    - IsHearingClient
+  - name: CGameResourceService_BuildResourceManifest
+    alias:
+    - CGameResourceService::BuildResourceManifest
+    - BuildResourceManifest
+  - name: CGameResourceService_m_pEntitySystem
+    alias:
+    - GameEntitySystem
+  - name: CGameResourceService_LoadGameResourceManifestNamed
+    alias:
+    - CGameResourceService::LoadGameResourceManifestNamed
+  - name: CGameResourceService_LoadGameResourceManifestGroup
+    alias:
+    - CGameResourceService::LoadGameResourceManifestGroup
+  - name: CGameResourceService_GetResourceManifestDebugName
+    alias:
+    - CGameResourceService::GetResourceManifestDebugName
+  - name: CGameResourceService_PrecacheEntitiesAndConfirmResourcesAreLoaded
+    alias:
+    - CGameResourceService::PrecacheEntitiesAndConfirmResourcesAreLoaded
+  - name: CGameResourceService_LoadGameResourceManifest_IEntityResourceManifest
+    alias:
+    - CGameResourceService::LoadGameResourceManifest
+  - name: CGameResourceService_DescribeContents
+    alias:
+    - CGameResourceService::DescribeContents
+  - name: CGameResourceService_AppendToGameResourceManifest
+    alias:
+    - CGameResourceService::AppendToGameResourceManifest
+  - name: CGameResourceService_RegisterEventMap
+    alias:
+    - CGameResourceService::RegisterEventMap
+  - name: IEntityResourceManifestBuilder_BuildResourceManifest_ManifestNameOrGroupName
+    alias:
+    - IEntityResourceManifestBuilder::BuildResourceManifest
+  - name: CServerSideClientBase_ClientPrintf
+    alias:
+    - CServerSideClientBase::ClientPrintf
+    - ClientPrintf
+  - name: CNetworkGameServer_ClientList
+    alias:
+    - CNetworkGameServer::ClientList
+  - name: CNetworkGameServerBase_SendPeerList
+    alias:
+    - CNetworkGameServerBase::SendPeerList
+  - name: CNetworkGameServerBase_ConnectClient
+    alias:
+    - CNetworkGameServerBase::ConnectClient
+  - name: CNetworkGameServerBase_ServerSimulateInternal
+    alias:
+    - CNetworkGameServerBase::ServerSimulateInternal
+  - name: CNetworkGameServerBase_ServerSimulate
+    alias:
+    - CNetworkGameServerBase::ServerSimulate
+  - name: CNetworkGameServerBase_ServerPollNetworking
+    alias:
+    - CNetworkGameServerBase::ServerPollNetworking
+  - name: CNetworkGameServerBase_BroadcastMessage
+    alias:
+    - CNetworkGameServerBase::BroadcastMessage
+  - name: CNetworkGameServerBase_BroadcastPrintf
+    alias:
+    - CNetworkGameServerBase::BroadcastPrintf
+  - name: CNetworkGameServerBase_ReserveServerForQueuedGame
+    alias:
+    - CNetworkGameServerBase::ReserveServerForQueuedGame
+  - name: CNetworkGameServerBase_FinishChangeLevel
+    alias:
+    - CNetworkGameServerBase::FinishChangeLevel
+  - name: CNetworkGameServerBase_StartChangeLevel
+    alias:
+    - CNetworkGameServerBase::StartChangeLevel
+  - name: CNetworkGameServerBase_SetServerState
+    alias:
+    - CNetworkGameServerBase::SetServerState
+  - name: CNetworkGameServer_GetFreeClient
+    alias:
+    - CNetworkGameServer::GetFreeClient
+    - GetFreeClient
+  - name: CNetworkGameServerBase_CreateFakeClient
+    alias:
+    - CNetworkGameServerBase::CreateFakeClient
+  - name: CNetworkGameServerBase_UserInfoChanged
+    alias:
+    - CNetworkGameServerBase::UserInfoChanged
+  - name: CNetworkGameServerBase_GetPlayerNetworkIDString
+    alias:
+    - CNetworkGameServerBase::GetPlayerNetworkIDString
+  - name: CNetworkGameServerBase_StartHLTVMaster
+    alias:
+    - CNetworkGameServerBase::StartHLTVMaster
+  - name: CNetworkGameServerBase_RegisterLoadingSpawnGroups
+    alias:
+    - CNetworkGameServerBase::RegisterLoadingSpawnGroups
+  - name: CNetworkServerSpawnGroupCreatePrerequisites_Init
+    alias:
+    - CNetworkServerSpawnGroupCreatePrerequisites::Init
+  - name: CNetworkGameServerBase_LoadSpawnGroup
+    alias:
+    - CNetworkGameServerBase::LoadSpawnGroup
+  - name: CNetworkGameServerBase_SpawnGroupThink
+    alias:
+    - CNetworkGameServerBase::SpawnGroupThink
+  - name: CNetworkGameServerBase_PrintSpawnGroupStatus
+    alias:
+    - CNetworkGameServerBase::PrintSpawnGroupStatus
+  - name: CNetworkGameServerBase_AsyncUnloadSpawnGroup
+    alias:
+    - CNetworkGameServerBase::AsyncUnloadSpawnGroup
+  - name: CNetworkGameServerBase_AsyncUnloadSpawnGroupInternal
+    alias:
+    - CNetworkGameServerBase::AsyncUnloadSpawnGroupInternal
+  - name: CNetworkGameServer_PrepareForAssetLoad
+    alias:
+    - CNetworkGameServer::PrepareForAssetLoad
+  - name: CNetworkGameServerBase_IsSaveRestoreAllowed
+    alias:
+    - CNetworkGameServerBase::IsSaveRestoreAllowed
+  - name: CNetworkGameServerBase_Init
+    alias:
+    - CNetworkGameServerBase::Init
+  - name: CNetworkGameServerBase_Shutdown
+    alias:
+    - CNetworkGameServerBase::Shutdown
+  - name: CNetworkGameServerBase_ShutdownInternal
+    alias:
+    - CNetworkGameServerBase::ShutdownInternal
+  - name: CNetworkGameServer_ActivateServer
+    alias:
+    - CNetworkGameServer::ActivateServer
+  - name: CNetworkGameServer_DirectUpdate
+    alias:
+    - CNetworkGameServer::DirectUpdate
+  - name: CNetworkGameServer_Init
+    alias:
+    - CNetworkGameServer::Init
+  - name: CNetworkGameServer_Shutdown
+    alias:
+    - CNetworkGameServer::Shutdown
+  - name: CNetworkGameServer_SpawnServer
+    alias:
+    - CNetworkGameServer::SpawnServer
+  - name: CNetworkGameServerBase_GetMaxClients
+    alias:
+    - CNetworkGameServerBase::GetMaxClients
+  - name: CNetworkGameServerBase_SetMaxClients
+    alias:
+    - CNetworkGameServerBase::SetMaxClients
+  - name: CNetworkGameServerBase_CheckTimeouts
+    alias:
+    - CNetworkGameServerBase::CheckTimeouts
+  - name: CNetworkGameServerBase_OnKickById
+    alias:
+    - CNetworkGameServerBase::OnKickById
+  - name: CNetworkGameServerBase_OnKickByName
+    alias:
+    - CNetworkGameServerBase::OnKickByName
+  - name: CNetworkGameClient_SendMovePacket
+    alias:
+    - CNetworkGameClient::SendMovePacket
+    - SendMovePacket
+  - name: CNetworkGameClient_SendMove
+    alias:
+    - CNetworkGameClient::SendMove
+    - SendMove
+  - name: INetworkMessages_Serialize
+    alias:
+    - INetworkMessages::Serialize
+  - name: CDemoRecorder_ParseMessage
+    alias:
+    - CDemoRecorder::ParseMessage
+  - name: CDemoRecorder_WriteSpawnGroups
+    alias:
+    - CDemoRecorder::WriteSpawnGroups
+  - name: INetworkMessages_SerializeAbstract
+    alias:
+    - INetworkMessages::SerializeAbstract
+  - name: INetworkMessages_GetNetMessageInfo
+    alias:
+    - INetworkMessages::GetNetMessageInfo
+  - name: INetworkMessages_FindNetworkMessageById
+    alias:
+    - INetworkMessages::FindNetworkMessageById
+  - name: CNetChan_ProcessMessages
+    alias:
+    - CNetChan::ProcessMessages
+  - name: CNetChan_ParseMessagesDemo
+    alias:
+    - CNetChan::ParseMessagesDemo
+  - name: CNetworkGameClient_ProcessPacketEntitiesInternal
+    alias:
+    - CNetworkGameClient::ProcessPacketEntitiesInternal
+  - name: CNetworkGameClient_ProcessPacketEntities
+    alias:
+    - CNetworkGameClient::ProcessPacketEntities
+    - ProcessPacketEntities
+  - name: CNetworkGameClient_RecordEntityBandwidth
+    alias:
+    - CNetworkGameClient::RecordEntityBandwidth
+    - RecordEntityBandwidth
+  - name: CNetworkGameClient_PrintNetStats
+    alias:
+    - CNetworkGameClient::PrintNetStats
+  - name: CMsgSource2NetworkFlowQuality_PrintStats
+    alias:
+    - CMsgSource2NetworkFlowQuality::PrintStats
+  - name: CNetworkGameClient_DisconnectGame
+    alias:
+    - CNetworkGameClient::DisconnectGame
+  - name: INetworkMessages_FindNetworkGroup
+    alias:
+    - INetworkMessages::FindNetworkGroup
+  - name: INetworkClientService_IsActive
+    alias:
+    - INetworkClientService::IsActive
+  - name: INetworkClientService_IsConnected
+    alias:
+    - INetworkClientService::IsConnected
+  - name: CNetworkClientService_ReceivedServerInfo
+    alias:
+    - CNetworkClientService::ReceivedServerInfo
+  - name: CNetworkClientService_SplitScreenConnect
+    alias:
+    - CNetworkClientService::SplitScreenConnect
+  - name: CNetworkClientService_SendNetMessage
+    alias:
+    - CNetworkClientService::SendNetMessage
+  - name: CNetworkClientService_SendStringCmd
+    alias:
+    - CNetworkClientService::SendStringCmd
+  - name: CNetworkClientService_StartChangeLevel
+    alias:
+    - CNetworkClientService::StartChangeLevel
+  - name: CNetworkClientService_FinishChangeLevel
+    alias:
+    - CNetworkClientService::FinishChangeLevel
+  - name: CNetworkClientService_PrintConnectionStatus
+    alias:
+    - CNetworkClientService::PrintConnectionStatus
+  - name: CNetworkClientService_OnStatus
+    alias:
+    - CNetworkClientService::OnStatus
+  - name: CNetworkClientService_ServerCmd
+    alias:
+    - CNetworkClientService::ServerCmd
+  - name: CNetworkClientService_GetDisconnectReason
+    alias:
+    - CNetworkClientService::GetDisconnectReason
+  - name: CNetworkClientService_PrintSpawnGroupStatus
+    alias:
+    - CNetworkClientService::PrintSpawnGroupStatus
+  - name: CNetworkClientService_IsActive
+    alias:
+    - CNetworkClientService::IsActive
+  - name: CNetworkClientService_IsConnected
+    alias:
+    - CNetworkClientService::IsConnected
+  - name: CNetworkClientService_ClockDriftAdjustFrameTime
+    alias:
+    - CNetworkClientService::ClockDriftAdjustFrameTime
+  - name: CNetworkClientService_Init
+    alias:
+    - CNetworkClientService::Init
+  - name: CNetworkClientService_Shutdown
+    alias:
+    - CNetworkClientService::Shutdown
+  - name: CNetworkClientService_DisconnectGameNow
+    alias:
+    - CNetworkClientService::DisconnectGameNow
+  - name: CGameClientConnectPrerequisite_ctor
+    alias:
+    - CGameClientConnectPrerequisite::CGameClientConnectPrerequisite
+  - name: CNetworkClientService_AddClientPrerequisites
+    alias:
+    - CNetworkClientService::AddClientPrerequisites
+  - name: CNetworkClientService_AllocateRemoteConnectionClient
+    alias:
+    - CNetworkClientService::AllocateRemoteConnectionClient
+  - name: CNetworkServerService_Init
+    alias:
+    - CNetworkServerService::Init
+  - name: CNetworkServerService_StartupServer
+    alias:
+    - CNetworkServerService::StartupServer
+  - name: CNetworkServerService_RegisterEventMapInternal
+    alias:
+    - CNetworkServerService::RegisterEventMapInternal
+  - name: CNetworkServerService_OnServerAdvanceTick
+    alias:
+    - CNetworkServerService::OnServerAdvanceTick
+  - name: CNetworkServerService_OnServerPollNetworking
+    alias:
+    - CNetworkServerService::OnServerPollNetworking
+  - name: CNetworkServerService_OnServerProcessNetworking
+    alias:
+    - CNetworkServerService::OnServerProcessNetworking
+  - name: CNetworkServerService_OnServerBeginSimulate
+    alias:
+    - CNetworkServerService::OnServerBeginSimulate
+  - name: CNetworkServerService_OnServerEndSimulate
+    alias:
+    - CNetworkServerService::OnServerEndSimulate
+  - name: CNetworkServerService_OnServerPostSimulate
+    alias:
+    - CNetworkServerService::OnServerPostSimulate
+  - name: CNetworkServerService_OnServerPostAdvanceTick
+    alias:
+    - CNetworkServerService::OnServerPostAdvanceTick
+  - name: CNetworkServerService_OnFrameBoundary
+    alias:
+    - CNetworkServerService::OnFrameBoundary
+  - name: CNetworkServerService_OnClientPollNetworking
+    alias:
+    - CNetworkServerService::OnClientPollNetworking
+  - name: CNetworkServerService_OnSimpleLoopFrameUpdate
+    alias:
+    - CNetworkServerService::OnSimpleLoopFrameUpdate
+  - name: CNetworkServerService_OnKickByIdHLTV
+    alias:
+    - CNetworkServerService::OnKickByIdHLTV
+  - name: CNetworkServerService_DisconnectGameNow
+    alias:
+    - CNetworkServerService::DisconnectGameNow
+  - name: INetworkGameServer_GetMaxClients
+    alias:
+    - INetworkGameServer::GetMaxClients
+  - name: INetworkGameServer_PreWorldUpdate
+    alias:
+    - INetworkGameServer::PreWorldUpdate
+  - name: CNetworkGameServer_PreWorldUpdate
+    alias:
+    - CNetworkGameServer::PreWorldUpdate
+  - name: INetworkGameServer_ServerEndSimulate
+    alias:
+    - INetworkGameServer::ServerEndSimulate
+  - name: CNetworkGameServerBase_ServerEndSimulate
+    alias:
+    - CNetworkGameServerBase::ServerEndSimulate
+  - name: INetworkGameServer_ServerPostSimulate
+    alias:
+    - INetworkGameServer::ServerPostSimulate
+  - name: CNetworkGameServerBase_ServerPostSimulate
+    alias:
+    - CNetworkGameServerBase::ServerPostSimulate
+  - name: INetworkGameServer_ServerAdvanceTick
+    alias:
+    - INetworkGameServer::ServerAdvanceTick
+  - name: CNetworkGameServerBase_ServerAdvanceTick
+    alias:
+    - CNetworkGameServerBase::ServerAdvanceTick
+  - name: INetworkGameServer_ServerProcessNetworking
+    alias:
+    - INetworkGameServer::ServerProcessNetworking
+  - name: CNetworkGameServerBase_ServerProcessNetworking
+    alias:
+    - CNetworkGameServerBase::ServerProcessNetworking
+  - name: INetworkGameServer_GetTimescale
+    alias:
+    - INetworkGameServer::GetTimescale
+  - name: CNetworkGameServerBase_GetTimescale
+    alias:
+    - CNetworkGameServerBase::GetTimescale
+  - name: ISource2Server_PreWorldUpdate
+    alias:
+    - ISource2Server::PreWorldUpdate
+  - name: ISource2Server_OutOfGameFrameBoundary
+    alias:
+    - ISource2Server::OutOfGameFrameBoundary
+  - name: INetworkMessages_SetIsForServer
+    alias:
+    - INetworkMessages::SetIsForServer
+  - name: CEngineClient_DumpNetStats
+    alias:
+    - CEngineClient::DumpNetStats
+  - name: CEngineServer_DumpNetStats
+    alias:
+    - CEngineServer::DumpNetStats
+  - name: CEngineServer_ClientPrintf
+    alias:
+    - CEngineServer::ClientPrintf
+  - name: CEngineServer_GetFrameTimeAmnesty
+    alias:
+    - CEngineServer::GetFrameTimeAmnesty
+  - name: CEngineServer_ShowFrameTimeReport
+    alias:
+    - CEngineServer::ShowFrameTimeReport
+  - name: CEngineServer_SetFrameTimeAmnesty
+    alias:
+    - CEngineServer::SetFrameTimeAmnesty
+  - name: CEngineServer_GetSteamUniverse
+    alias:
+    - CEngineServer::GetSteamUniverse
+  - name: CEngineServer_ChangeLevel
+    alias:
+    - CEngineServer::ChangeLevel
+  - name: CMapListService_IsMapValid
+    alias:
+    - CMapListService::IsMapValid
+    - IMapListService::IsMapValid
+  - name: CEngineServer_IsMapValid
+    alias:
+    - CEngineServer::IsMapValid
+  - name: CEngineServer_PrecacheGeneric
+    alias:
+    - CEngineServer::PrecacheGeneric
+  - name: CEngineServer_ClientCommand
+    alias:
+    - CEngineServer::ClientCommand
+  - name: CEngineServer_GetClientConVarValue
+    alias:
+    - CEngineServer::GetClientConVarValue
+  - name: CEngineServer_SetFakeClientConVarValue
+    alias:
+    - CEngineServer::SetFakeClientConVarValue
+  - name: CEngineServer_CreateFakeClient
+    alias:
+    - CEngineServer::CreateFakeClient
+  - name: CEngineServer_GetPlayerInfo
+    alias:
+    - CEngineServer::GetPlayerInfo
+  - name: CEngineServer_ClientCommandKeyValues
+    alias:
+    - CEngineServer::ClientCommandKeyValues
+  - name: CLog_Print
+    alias:
+    - CLog::Print
+  - name: CEngineServer_LogPrint
+    alias:
+    - CEngineServer::LogPrint
+  - name: CEngineServer_KickClient
+    alias:
+    - CEngineServer::KickClient
+  - name: CEngineServer_IsDedicatedServer
+    alias:
+    - CEngineServer::IsDedicatedServer
+  - name: CEngineServer_ServerCommand
+    alias:
+    - CEngineServer::ServerCommand
+  - name: CLoopTypeClientSimple_ActivateEngineServices
+    alias:
+    - CLoopTypeClientServer::ActivateEngineServices
+  - name: CLoopTypeClientServer_LoopTypeInit
+    alias:
+    - CLoopTypeClientServer::LoopTypeInit
+  - name: CLoopTypeClientServer_AdvanceTime
+    alias:
+    - CLoopTypeClientServer::AdvanceTime
+  - name: CLoopTypeClientServer_Update
+    alias:
+    - CLoopTypeClientServer::Update
+  - name: CLoopTypeClientServer_ActivateLoop
+    alias:
+    - CLoopTypeClientServer::ActivateLoop
+  - name: CLoopTypeClientServer_AllocateLoopMode
+    alias:
+    - CLoopTypeClientServer::AllocateLoopMode
+  - name: CLoopTypeClientServer_WritePerfStats
+    alias:
+    - CLoopTypeClientServer::WritePerfStats
+  - name: CLoopTypeClientServer_DeactivateLoop
+    alias:
+    - CLoopTypeClientServer::DeactivateLoop
+  - name: CLoopTypeClientServer_OutputListeners
+    alias:
+    - CLoopTypeClientServer::OutputListeners
+  - name: CLoopTypeSimple_FrameUpdate
+    alias:
+    - CLoopTypeSimple::FrameUpdate
+  - name: CLoopTypeClientServerService_OnLoopActivate
+    alias:
+    - CLoopTypeClientServerService::OnLoopActivate
+  - name: CLoopTypeSimpleService_OnLoopActivate
+    alias:
+    - CLoopTypeSimpleService::OnLoopActivate
+  - name: CLoopTypeClientServerService_HandleInputEvent
+    alias:
+    - CLoopTypeClientServerService::HandleInputEvent
+  - name: ILoopMode_HandleInputEvent
+    alias:
+    - ILoopMode::HandleInputEvent
+  - name: ILoopType_AddEngineService
+    alias:
+    - ILoopType::AddEngineService
+  - name: CLoopTypeBase_DeallocateLoopMode
+    alias:
+    - CLoopTypeBase::DeallocateLoopMode
+  - name: CLoopTypeBase_EngineLoop
+    alias:
+    - CLoopTypeBase::EngineLoop
+  - name: CLoopTypeBase_FrameUpdate
+    alias:
+    - CLoopTypeBase::FrameUpdate
+  - name: CLoopTypeBase_ActivateLoop
+    alias:
+    - CLoopTypeBase::ActivateLoop
+  - name: CLoopTypeBase_AllocateLoopMode
+    alias:
+    - CLoopTypeBase::AllocateLoopMode
+  - name: CLoopTypeBase_DeactivateLoop
+    alias:
+    - CLoopTypeBase::DeactivateLoop
+  - name: CLoopTypeBase_LoopTypeInit
+    alias:
+    - CLoopTypeBase::LoopTypeInit
+  - name: CLoopTypeBase_LoopTypeShutdown
+    alias:
+    - CLoopTypeBase::LoopTypeShutdown
+  - name: CLoopTypeBase_GetClientServerMode
+    alias:
+    - CLoopTypeBase::GetClientServerMode
+  - name: CLoopTypeBase_GetImplType
+    alias:
+    - CLoopTypeBase::GetImplType
+  - name: CLoopTypeBase_AddDependentServices
+    alias:
+    - CLoopTypeBase::AddDependentServices
+  - name: CLoopTypeBase_GenerateServiceDependencies
+    alias:
+    - CLoopTypeBase::GenerateServiceDependencies
+  - name: CLoopTypeBase_GenerateSecondaryDependencies
+    alias:
+    - CLoopTypeBase::GenerateSecondaryDependencies
+  - name: CLoopTypeBase_LoadDependentServices
+    alias:
+    - CLoopTypeBase::LoadDependentServices
+  - name: IEngineService_GetServiceDependencies
+    alias:
+    - IEngineService::GetServiceDependencies
+  - name: IEngineService_GetName
+    alias:
+    - IEngineService::GetName
+  - name: ILoopModeFactory_GetLoopModeType
+    alias:
+    - ILoopModeFactory::GetLoopModeType
+  - name: ILoopModeFactory_Shutdown
+    alias:
+    - ILoopModeFactory::Shutdown
+  - name: CEngineServiceMgr_RegisterEngineService
+    alias:
+    - CEngineServiceMgr::RegisterEngineService
+  - name: CEngineServiceMgr_RegisterLoopMode
+    alias:
+    - CEngineServiceMgr::RegisterLoopMode
+  - name: CEngineServiceMgr_UnregisterLoopMode
+    alias:
+    - CEngineServiceMgr::UnregisterLoopMode
+  - name: CEngineServiceMgr_UnregisterEngineService
+    alias:
+    - CEngineServiceMgr::UnregisterEngineService
+  - name: CEngineServiceMgr_SwitchToLoop
+    alias:
+    - CEngineServiceMgr::SwitchToLoop
+  - name: CEngineServiceMgr_PrintStatus
+    alias:
+    - CEngineServiceMgr::PrintStatus
+  - name: CEngineServiceMgr__MainLoop
+    alias:
+    - CEngineServiceMgr::_MainLoop
+  - name: CEngineServiceMgr_DeactivateLoop
+    alias:
+    - CEngineServiceMgr::DeactivateLoop
+  - name: CEngineServiceMgr_Shutdown
+    alias:
+    - CEngineServiceMgr::Shutdown
+  - name: CEngineServiceMgr_GetActiveLoopClientServerMode
+    alias:
+    - CEngineServiceMgr::GetActiveLoopClientServerMode
+  - name: CEngineServiceMgr_GetEventDispatcher
+    alias:
+    - CEngineServiceMgr::GetEventDispatcher
+  - name: CEngineGameUI_Shutdown
+    alias:
+    - CEngineGameUI::Shutdown
+  - name: IAppSystem_Shutdown
+    alias:
+    - IAppSystem::Shutdown
+  - name: CSplitScreenService_AddSplitScreenUser
+    alias:
+    - CSplitScreenService::AddSplitScreenUser
+  - name: CSplitScreenService_LoadUserConfiguration
+    alias:
+    - CSplitScreenService::LoadUserConfiguration
+  - name: CHLTVClient_ProcessSetConVar
+    alias:
+    - CHLTVClient::ProcessSetConVar
+  - name: CServerSideClientBase_ProcessTick
+    alias:
+    - CServerSideClientBase::ProcessTick
+  - name: CServerSideClientBase_ProcessStringCmd
+    alias:
+    - CServerSideClientBase::ProcessStringCmd
+  - name: CServerSideClientBase_MarkSpawnGroupLoadCompleted
+    alias:
+    - CServerSideClientBase::MarkSpawnGroupLoadCompleted
+  - name: CServerSideClientBase_ProcessSpawnGroup_LoadCompleted
+    alias:
+    - CServerSideClientBase::ProcessSpawnGroup_LoadCompleted
+  - name: CServerSideClientBase_ProcessClientInfo
+    alias:
+    - CServerSideClientBase::ProcessClientInfo
+  - name: CServerSideClientBase_ProcessBaselineAck
+    alias:
+    - CServerSideClientBase::ProcessBaselineAck
+  - name: CServerSideClientBase_ProcessSplitPlayerConnectInternal
+    alias:
+    - CServerSideClientBase::ProcessSplitPlayerConnectInternal
+  - name: CServerSideClientBase_ProcessSplitPlayerConnect
+    alias:
+    - CServerSideClientBase::ProcessSplitPlayerConnect
+  - name: CServerSideClientBase_GetUserIDString
+    alias:
+    - CServerSideClientBase::GetUserIDString
+  - name: CServerSideClientBase_GetNetworkIDString
+    alias:
+    - CServerSideClientBase::GetNetworkIDString
+  - name: CServerSideClientBase_Connect
+    alias:
+    - CServerSideClientBase::Connect
+  - name: CServerSideClientBase_GetPlayerInfo
+    alias:
+    - CServerSideClientBase::GetPlayerInfo
+  - name: CNetworkGameServer_GetPlayerNetworkIDString
+    alias:
+    - CNetworkGameServer::GetPlayerNetworkIDString
+  - name: CNetworkGameServerBase_RemoveClientFromGame
+    alias:
+    - CNetworkGameServerBase::RemoveClientFromGame
+  - name: CEngineServer_GetPlayerNetworkIDString
+    alias:
+    - CEngineServer::GetPlayerNetworkIDString
+  - name: CNetworkGameClientBase_ServerCmd
+    alias:
+    - CNetworkGameClientBase::ServerCmd
+  - name: CNetworkGameClientBase_ProcessSetConVar
+    alias:
+    - CNetworkGameClientBase::ProcessSetConVar
+  - name: CNetworkGameClientBase_SendStringCmd
+    alias:
+    - CNetworkGameClientBase::SendStringCmd
+  - name: CNetworkGameClientBase_StartChangeLevel
+    alias:
+    - CNetworkGameClientBase::StartChangeLevel
+  - name: CNetworkGameClientBase_FinishChangeLevel
+    alias:
+    - CNetworkGameClientBase::FinishChangeLevel
+  - name: CNetworkGameClientBase_DeferActivate
+    alias:
+    - CNetworkGameClientBase::DeferActivate
+  - name: CNetworkGameClientBase_ClockDrift_AdjustFrameTime
+    alias:
+    - CNetworkGameClientBase::ClockDrift_AdjustFrameTime
+  - name: CNetworkGameClientBase_Connect
+    alias:
+    - CNetworkGameClientBase::Connect
+  - name: CNetworkGameClientBase_DisconnectGame
+    alias:
+    - CNetworkGameClientBase::DisconnectGame
+  - name: CNetSupportImpl_Connect
+    alias:
+    - CNetSupportImpl::Connect
+- name: client
+  symbols:
+  - name: CLoopModeGame_RegisterEventMapInternal
+    alias:
+    - CLoopModeGame::RegisterEventMapInternal
+  - name: CLoopModeGame_OnClientPollNetworking
+    alias:
+    - CLoopModeGame::OnClientPollNetworking
+  - name: CLoopModeGame_OnClientAdvanceTick
+    alias:
+    - CLoopModeGame::OnClientAdvanceTick
+  - name: CLoopModeGame_OnClientPostAdvanceTick
+    alias:
+    - CLoopModeGame::OnClientPostAdvanceTick
+  - name: CLoopModeGame_OnClientPreSimulate
+    alias:
+    - CLoopModeGame::OnClientPreSimulate
+  - name: CLoopModeGame_OnClientPreOutput
+    alias:
+    - CLoopModeGame::OnClientPreOutput
+  - name: CLoopModeGame_OnClientPreOutputParallelWithServer
+    alias:
+    - CLoopModeGame::OnClientPreOutputParallelWithServer
+  - name: CLoopModeGame_OnClientPostOutput
+    alias:
+    - CLoopModeGame::OnClientPostOutput
+  - name: CLoopModeGame_OnClientFrameSimulate
+    alias:
+    - CLoopModeGame::OnClientFrameSimulate
+  - name: CLoopModeGame_OnClientAdvanceNonRenderedFrame
+    alias:
+    - CLoopModeGame::OnClientAdvanceNonRenderedFrame
+  - name: CLoopModeGame_OnClientPostSimulate
+    alias:
+    - CLoopModeGame::OnClientPostSimulate
+  - name: CLoopModeGame_OnClientPauseSimulate
+    alias:
+    - CLoopModeGame::OnClientPauseSimulate
+  - name: CLoopModeGame_OnClientSimulate
+    alias:
+    - CLoopModeGame::OnClientSimulate
+  - name: CLoopModeGame_OnPostDataUpdate
+    alias:
+    - CLoopModeGame::OnPostDataUpdate
+  - name: CLoopModeGame_OnPreDataUpdate
+    alias:
+    - CLoopModeGame::OnPreDataUpdate
+  - name: CLoopModeGame_OnFrameBoundary
+    alias:
+    - CLoopModeGame::OnFrameBoundary
+  - name: CLoopModeGame_StaticInit
+    alias:
+    - CLoopModeGame::StaticInit
+  - name: CLoopModeFactory_CLoopModeGame_Init
+    alias:
+    - CLoopModeFactory<CLoopModeGame>::Init
+  - name: CLoopModeFactory_CLoopModeGame_Shutdown
+    alias:
+    - CLoopModeFactory<CLoopModeGame>::Shutdown
+  - name: CLoopModeGame_OnLoopActivate
+    alias:
+    - CLoopModeGame::OnLoopActivate
+  - name: ILoopMode_OnLoopActivate
+    alias:
+    - ILoopMode::OnLoopActivate
+  - name: CLoopModeGame_AddViewsToSceneSystem
+    alias:
+    - CLoopModeGame::AddViewsToSceneSystem
+  - name: ILoopMode_AddViewsToSceneSystem
+    alias:
+    - ILoopMode::AddViewsToSceneSystem
+  - name: CLoopModeGame_LoopInitInternal
+    alias:
+    - CLoopModeGame::LoopInitInternal
+  - name: CLoopModeGame_LoopInit
+    alias:
+    - CLoopModeGame::LoopInit
+  - name: ILoopMode_LoopInit
+    alias:
+    - ILoopMode::LoopInit
+  - name: ILoopMode_LoopShutdown
+    alias:
+    - ILoopMode::LoopShutdown
+  - name: CLoopModeGame_ReceivedServerInfo
+    alias:
+    - CLoopModeGame::ReceivedServerInfo
+  - name: CLoopModeGame_RegisterEventMap
+    alias:
+    - CLoopModeGame::RegisterEventMap
+  - name: ILoopMode_RegisterEventMap
+    alias:
+    - ILoopMode::RegisterEventMap
+  - name: CLoopModeGame_SetWorldSession
+    alias:
+    - CLoopModeGame::SetWorldSession
+  - name: CLoopModeGame_SetGameSystemState
+    alias:
+    - CLoopModeGame::SetGameSystemState
+  - name: CLoopModeGame_LoopShutdown
+    alias:
+    - CLoopModeGame::LoopShutdown
+  - name: IGameSystem_AddByName
+    alias:
+    - IGameSystem::AddByName
+  - name: IGameSystem_Add
+    alias:
+    - IGameSystem::Add
+  - name: IGameSystem_PostInit
+    alias:
+    - IGameSystem::PostInit
+  - name: IGameSystem_InitAllSystems
+    alias:
+    - IGameSystem::InitAllSystems
+  - name: IGameSystem_LoopInitAllSystems
+    alias:
+    - IGameSystem::LoopInitAllSystems
+  - name: IGameSystemFactory_PostInit
+    alias:
+    - IGameSystemFactory::PostInit
+  - name: IGameSystemFactory_GetStaticGameSystem
+    alias:
+    - IGameSystemFactory::GetStaticGameSystem
+  - name: IGameSystemFactory_ShouldAutoAdd
+    alias:
+    - IGameSystemFactory::ShouldAutoAdd
+  - name: IGameSystemFactory_CreateGameSystem
+    alias:
+    - IGameSystemFactory::CreateGameSystem
+  - name: IGameSystemFactory_IsReallocating
+    alias:
+    - IGameSystemFactory::IsReallocating
+  - name: IGameSystem_SetName
+    alias:
+    - IGameSystem::SetName
+  - name: CSpawnGroupMgrGameSystem_DoesGameSystemReallocate
+    alias:
+    - IGameSystem::DoesGameSystemReallocate
+  - name: IGameSystem_DestroyAllGameSystems
+    alias:
+    - IGameSystem::DestroyAllGameSystems
+  - name: IGameSystem_ShutdownAllSystems
+    alias:
+    - IGameSystem::ShutdownAllSystems
+  - name: IGameSystem_LoopDestroyAllSystems
+    alias:
+    - IGameSystem::LoopDestroyAllSystems
+  - name: IGameSystem_LoopPreShutdownAllSystems
+    alias:
+    - IGameSystem::LoopPreShutdownAllSystems
+  - name: IGameSystem_OnClientPollNetworking
+    alias:
+    - IGameSystem::OnClientPollNetworking
+  - name: IGameSystem_OnClientGamePostSimulate
+    alias:
+    - IGameSystem::ClientGamePostSimulate
+  - name: IGameSystem_OnClientPauseSimulate
+    alias:
+    - IGameSystem::OnClientPauseSimulate
+  - name: IGameSystem_OnClientPreUpdate
+    alias:
+    - IGameSystem::OnClientPreUpdate
+  - name: IGameSystem_OnClientPostUpdate
+    alias:
+    - IGameSystem::OnClientPostUpdate
+  - name: IGameSystem_OnClientPostDataUpdate
+    alias:
+    - IGameSystem::OnClientPostDataUpdate
+  - name: IGameSystem_OnGameFrameBoundary
+    alias:
+    - IGameSystem::OnGameFrameBoundary
+  - name: IGameSystem_OnClientAdvanceNonRenderedFrame
+    alias:
+    - IGameSystem::OnClientAdvanceNonRenderedFrame
+  - name: IGameSystem_OnClientFrameSimulate
+    alias:
+    - IGameSystem::OnClientFrameSimulate
+  - name: IGameSystem_OnClientAdvanceTick
+    alias:
+    - IGameSystem::ClientAdvanceTick
+  - name: IGameSystem_OnClientPostAdvanceTick
+    alias:
+    - IGameSystem::ClientPostAdvanceTick
+  - name: IGameSystem_OnClientPostRender
+    alias:
+    - IGameSystem::OnClientPostRender
+  - name: IGameSystem_OnClientPreRender
+    alias:
+    - IGameSystem::OnClientPreRender
+  - name: IGameSystem_OnClientPreRenderAlt
+    alias:
+    - IGameSystem::OnClientPreRenderAlt
+  - name: CSource2Client_OnDisconnect
+    alias:
+    - CSource2Client::OnDisconnect
+  - name: IGameSystem_OnClientDisconnect
+    alias:
+    - IGameSystem::OnClientDisconnect
+  - name: IGameSystem_OnClientPreEntityThink
+    alias:
+    - IGameSystem::OnClientPreEntityThink
+  - name: CSteamworksGameStats_OnReceivedSessionID
+    alias:
+    - CSteamworksGameStats::OnReceivedSessionID
+  - name: IGameSystem_GetName
+    alias:
+    - IGameSystem::GetName
+  - name: IGameSystemFactory_DestroyGameSystem
+    alias:
+    - IGameSystemFactory::DestroyGameSystem
+  - name: IGameSystemFactory_Init
+    alias:
+    - IGameSystemFactory::Init
+  - name: IGameSystemFactory_GetPriority
+    alias:
+    - IGameSystemFactory::GetPriority
+  - name: IGameSystemFactory_Shutdown
+    alias:
+    - IGameSystemFactory::Shutdown
+  - name: IGameSystemFactory_SetGlobalPtr
+    alias:
+    - IGameSystemFactory::SetGlobalPtr
+  - name: CPrediction_PostNetworkDataReceived
+    alias:
+    - CPrediction::PostNetworkDataReceived
+  - name: IEngineServiceMgr_GetActiveLoopClientServerMode
+    alias:
+    - IEngineServiceMgr::GetActiveLoopClientServerMode
+  - name: IEngineServiceMgr_GetEventDispatcher
+    alias:
+    - IEngineServiceMgr::GetEventDispatcher
+  - name: ClientModeCSNormal_Update
+    alias:
+    - ClientModeCSNormal::Update
+  - name: CEntitySystem_ctor
+    alias:
+    - CEntitySystem::CEntitySystem
+  - name: CGameEntitySystem_ctor
+    alias:
+    - CGameEntitySystem::CGameEntitySystem
+  - name: CEntitySystem_Init
+    alias:
+    - CEntitySystem::Init
+  - name: CEntitySystem_PostCreateEntitySystem
+    alias:
+    - CEntitySystem::PostCreateEntitySystem
+  - name: CSource2EntitySystem_StaticInit
+    alias:
+    - CSource2EntitySystem::StaticInit
+  - name: CGameSystemReallocatingFactory_CSource2EntitySystem_Init
+    alias:
+    - CGameSystemReallocatingFactory<CSource2EntitySystem>::Init
+  - name: CGameSystemReallocatingFactory_CSource2EntitySystem_CreateGameSystem
+    alias:
+    - CGameSystemReallocatingFactory<CSource2EntitySystem>::CreateGameSystem
+  - name: CSkeletonInstance_PostDataUpdate
+    alias:
+    - CSkeletonInstance::PostDataUpdate
+  - name: CSkeletonInstance_m_modelState
+    alias:
+    - CSkeletonInstance::m_modelState
+  - name: CSkeletonInstance_m_modelState_m_hModel
+    alias:
+    - CSkeletonInstance::m_modelState.m_hModel
+  - name: CModelState_SetupJointState
+    alias:
+    - CModelState::SetupJointState
+  - name: CModelState_m_nTotalTransformCount
+    alias:
+    - CModelState::m_nTotalTransformCount
+  - name: CModelState_m_nBoneCount
+    alias:
+    - CModelState::m_nBoneCount
+  - name: CModelState_m_nAttachmentCount
+    alias:
+    - CModelState::m_nAttachmentCount
+  - name: IVEngineClient2_GetNetworkClient
+    alias:
+    - IVEngineClient2::GetNetworkClient
+  - name: INetworkClient_GetLocalAddress
+    alias:
+    - INetworkClient::GetLocalAddress
+  - name: INetworkClientService_IsConnected
+    alias:
+    - INetworkClientService::IsConnected
+  - name: INetworkClientService_SendNetMessage
+    alias:
+    - INetworkClientService::SendNetMessage
+  - name: IGameResourceService_SetEntityResourceManifestHandler
+    alias:
+    - IGameResourceService::SetEntityResourceManifestHandler
+  - name: CNetworkSerializerBindingBuildFilter_GetFieldPriority
+    alias:
+    - CNetworkSerializerBindingBuildFilter::GetFieldPriority
+- name: server
+  symbols:
+  - name: CSource2Server_OnStreamEntitiesFromFileCompleted
+    alias:
+    - CSource2Server::OnStreamEntitiesFromFileCompleted
+  - name: CSource2Server_PreWorldUpdate
+    alias:
+    - CSource2Server::PreWorldUpdate
+  - name: CSource2Server_OutOfGameFrameBoundary
+    alias:
+    - CSource2Server::OutOfGameFrameBoundary
+  - name: CGameSystemReallocatingFactory_CSource2EntitySystem_Init
+    alias:
+    - CGameSystemReallocatingFactory<CSource2EntitySystem>::Init
+  - name: CGameSystemReallocatingFactory_CSource2EntitySystem_CreateGameSystem
+    alias:
+    - CGameSystemReallocatingFactory<CSource2EntitySystem>::CreateGameSystem
+  - name: IGameSystemFactory_Init
+    alias:
+    - IGameSystemFactory::Init
+  - name: IGameSystemFactory_Shutdown
+    alias:
+    - IGameSystemFactory::Shutdown
+  - name: IGameSystemFactory_SetGlobalPtr
+    alias:
+    - IGameSystemFactory::SetGlobalPtr
+  - name: CGameSystemReallocatingFactory_CSpawnGroupMgrGameSystem_DestroyGameSystem
+    alias:
+    - CGameSystemReallocatingFactory<CSpawnGroupMgrGameSystem>::Deallocate
+  - name: IGameSystem_SetGameSystemGlobalPtrs
+    alias:
+    - IGameSystem::SetGameSystemGlobalPtrs
+  - name: IGameSystem_vdtor
+    alias:
+    - IGameSystem::~IGameSystem
+  - name: IGameSystem_OnGameInit
+    alias:
+    - IGameSystem::GameInit
+  - name: CMultiplayRules_ctor
+    alias:
+    - CMultiplayRules::CMultiplayRules
+  - name: CGameMoney_OnMoneySpent
+    alias:
+    - CGameMoney::OnMoneySpent
+  - name: CGameMoney_m_DataMap
+    alias:
+    - CGameMoney::m_DataMap
+  - name: CGameMoney_GetDataDescMap
+    alias:
+    - CGameMoney::GetDataDescMap
+  - name: CCSPlayer_UseServices_OnUseImpl
+    alias:
+    - CCSPlayer_UseServices::OnUseImpl
+  - name: CCSPlayer_UseServices_OnUse
+    alias:
+    - CCSPlayer_UseServices::OnUse
+  - name: CCSPlayer_MovementServices_ProcessMovement
+    alias:
+    - CCSPlayer_MovementServices::ProcessMovement
+    - ProcessMovement
+  - name: CCSPlayer_MovementServices_CheckMovingGround
+    alias:
+    - CCSPlayer_MovementServices::CheckMovingGround
+    - CheckMovingGround
+  - name: CCSPlayer_MovementServices_WalkMove
+    alias:
+    - CCSPlayer_MovementServices::WalkMove
+    - WalkMove
+  - name: CCSPlayer_MovementServices_FullWalkMove
+    alias:
+    - CCSPlayer_MovementServices::FullWalkMove
+    - FullWalkMove
+  - name: CCSPlayer_MovementServices_CheckVelocity
+    alias:
+    - CCSPlayer_MovementServices::CheckVelocity
+    - CheckVelocity
+  - name: CCSPlayer_MovementServices_WaterMove
+    alias:
+    - CCSPlayer_MovementServices::WaterMove
+    - WaterMove
+  - name: CCSPlayer_MovementServices_FullWalkMove_SpeedClamp
+    alias:
+    - ServerMovementUnlock
+  - name: CCSPlayer_MovementServices_CheckJumpButton
+    alias:
+    - CCSPlayer_MovementServices::CheckJumpButton
+  - name: CCSPlayer_MovementServices_CheckJumpButton_WaterPatch
+    alias:
+    - CheckJumpButtonWater
+    - FixWaterFloorJump
+  - name: CPlayer_MovementServices_PlayWaterStepSound
+    alias:
+    - CPlayer_MovementServices::PlayWaterStepSound
+  - name: CPlayer_MovementServices_ForceButtons
+    alias:
+    - CPlayer_MovementServices::ForceButtons
+  - name: CPlayer_MovementServices_ForceButtonState
+    alias:
+    - CPlayer_MovementServices::ForceButtonState
+  - name: CPlayer_MovementServices_s_pRunCommandPawn
+    alias:
+    - CPlayer_MovementServices::s_pRunCommandPawn
+  - name: CEntityInstance_m_pEntity
+    alias:
+    - CEntityInstance::m_pEntity
+  - name: CEntityInstance_m_hPrivateScope
+    alias:
+    - CEntityInstance::m_hPrivateScope
+  - name: CEntityInstance_m_CScriptComponent
+    alias:
+    - CEntityInstance::m_CScriptComponent
+  - name: CEntityInstance_m_pKeyValues
+    alias:
+    - CEntityInstance::m_pKeyValues
+  - name: CEntityInstance_m_iszPrivateVScripts
+    alias:
+    - CEntityInstance::m_iszPrivateVScripts
+  - name: CBaseEntity_OnRestore
+    alias:
+    - CBaseEntity::OnRestore
+  - name: CEntityInstance_OnRestore
+    alias:
+    - CEntityInstance::OnRestore
+  - name: CBaseEntity_ctor
+    alias:
+    - CBaseEntity::CBaseEntity
+  - name: CBaseEntity_dtor
+    alias:
+    - CBaseEntity::~CBaseEntity
+  - name: CBaseEntity_vdtor
+    alias:
+    - CBaseEntity::~CBaseEntity (virtual)
+  - name: CEntityInstance_vdtor
+    alias:
+    - CEntityInstance::~CEntityInstance (virtual)
+  - name: CEntitySaveRestoreBlockHandler_PreSave
+    alias:
+    - CEntitySaveRestoreBlockHandler::PreSave
+  - name: CEntitySaveRestoreBlockHandler_SaveInternal
+    alias:
+    - CEntitySaveRestoreBlockHandler::SaveInternal
+  - name: CEntitySaveRestoreBlockHandler_Save
+    alias:
+    - CEntitySaveRestoreBlockHandler::Save
+  - name: CEntitySaveRestoreBlockHandler_Restore
+    alias:
+    - CEntitySaveRestoreBlockHandler::Restore
+  - name: CEntitySaveRestoreBlockHandler_DoRestoreEntity
+    alias:
+    - CEntitySaveRestoreBlockHandler::DoRestoreEntity
+  - name: CEntitySaveRestoreBlockHandler_RestoreEntity
+    alias:
+    - CEntitySaveRestoreBlockHandler::RestoreEntity
+  - name: CreateEntityTransitionList
+    alias:
+    - CreateEntityTransitionList
+  - name: CEntitySaveRestoreBlockHandler_WriteSaveHeaders
+    alias:
+    - CEntitySaveRestoreBlockHandler::WriteSaveHeaders
+  - name: CEntitySaveRestoreBlockHandler_ReadRestoreHeaders
+    alias:
+    - CEntitySaveRestoreBlockHandler::ReadRestoreHeaders
+  - name: CEntity2SaveRestore_StreamEntitiesFromFile
+    alias:
+    - CEntity2SaveRestore::StreamEntitiesFromFile
+  - name: CSaveRestoreBlockSet_PreRestore
+    alias:
+    - CSaveRestoreBlockSet::PreRestore
+  - name: CSaveRestoreBlockSet_PostRestore
+    alias:
+    - CSaveRestoreBlockSet::PostRestore
+  - name: CEntitySaveRestoreBlockHandler_PreRestore
+    alias:
+    - CEntitySaveRestoreBlockHandler::PreRestore
+  - name: CEntitySaveRestoreBlockHandler_PostRestore
+    alias:
+    - CEntitySaveRestoreBlockHandler::PostRestore
+  - name: CEntitySystem_ForceSetInPVSCallsIntoQueue
+    alias:
+    - CEntitySystem::ForceSetInPVSCallsIntoQueue
+  - name: CEntitySystem_ExecuteQueuedSetInPVS
+    alias:
+    - CEntitySystem::ExecuteQueuedSetInPVS
+  - name: CEntitySystem_m_nSuppressDormancyChangeCount
+    alias:
+    - CEntitySystem::m_nSuppressDormancyChangeCount
+  - name: CEntitySystem_m_nExecuteQueuedCreationDepth
+    alias:
+    - CEntitySystem::m_nExecuteQueuedCreationDepth
+  - name: CEntitySystem_m_queuedDormancyChanges
+    alias:
+    - CEntitySystem::m_queuedDormancyChanges
+  - name: CEntitySystem_SetInPVS
+    alias:
+    - CEntitySystem::SetInPVS
+  - name: CEntitySystem_OnSetDormant
+    alias:
+    - CEntitySystem::OnSetDormant
+  - name: CEntitySystem_BuildResourceManifestForEntity
+    alias:
+    - CEntitySystem::BuildResourceManifestForEntity
+  - name: CEntityInstance_ObjectCaps
+    alias:
+    - CEntityInstance::ObjectCaps
+  - name: CEntityInstance_Save
+    alias:
+    - CEntityInstance::Save
+  - name: CEntityInstance_Restore
+    alias:
+    - CEntityInstance::Restore
+  - name: CEntitySaveRestoreBlockHandler_SaveInitEntities
+    alias:
+    - CEntitySaveRestoreBlockHandler::SaveInitEntities
+  - name: CEntityInstance_OnSave
+    alias:
+    - CEntityInstance::OnSave
+  - name: CEntityInstance_RequiredEdictIndex
+    alias:
+    - CEntityInstance::RequiredEdictIndex
+  - name: PolymorphicHelper_t__SetPolymorphicPointer
+    alias:
+    - PolymorphicHelper_t::SetPolymorphicPointer
+  - name: CEntityInstance_AddChangeAccessorPathPolymorphic
+    alias:
+    - CEntityInstance::AddChangeAccessorPathPolymorphic
+  - name: CEntityInstance_AssignChangeAccessorPathIdsPolymorphic
+    alias:
+    - CEntityInstance::AssignChangeAccessorPathIdsPolymorphic
+  - name: CEntityInstance_AddChangeAccessorPath
+    alias:
+    - CEntityInstance::AddChangeAccessorPath
+  - name: CEntityInstance_AssignChangeAccessorPathIds
+    alias:
+    - CEntityInstance::AssignChangeAccessorPathIds
+  - name: CEntityInstance_GetChangeAccessorPathInfo_2
+    alias:
+    - CEntityInstance::GetChangeAccessorPathInfo_2
+  - name: CBaseEntity_GetChangeAccessorPathInfo_2
+    alias:
+    - CBaseEntity::GetChangeAccessorPathInfo_2
+  - name: CBaseEntity_GetChangeAccessorPathInfo_1
+    alias:
+    - CBaseEntity::GetChangeAccessorPathInfo_1
+  - name: CMomentaryRotButton_Use
+    alias:
+    - CMomentaryRotButton::Use
+  - name: CBaseEntity_TakeDamageOld
+    alias:
+    - CBaseEntity::TakeDamageOld
+  - name: CBaseEntity_OnTakeDamage
+    alias:
+    - CBasePlayerPawn::OnTakeDamage
+  - name: CBasePlayerPawn_OnTakeDamage_Alive
+    alias:
+    - CBasePlayerPawn::OnTakeDamage_Alive
+  - name: CBasePlayerPawn_OnTakeDamage_Dying
+    alias:
+    - CBasePlayerPawn::OnTakeDamage_Dying
+  - name: CBasePlayerPawn_OnTakeDamage_Dead
+    alias:
+    - CBasePlayerPawn::OnTakeDamage_Dead
+  - name: CBasePlayerPawn_OnTakeDamage
+    alias:
+    - CBasePlayerPawn::OnTakeDamage
+  - name: CCSPlayerPawn_OnTakeDamage_Alive
+    alias:
+    - CCSPlayerPawn::OnTakeDamage_Alive
+  - name: CCSPlayerPawn_OnTakeDamage_Dying
+    alias:
+    - CCSPlayerPawn::OnTakeDamage_Dying
+  - name: CCSPlayerPawn_OnTakeDamage_Dead
+    alias:
+    - CCSPlayerPawn::OnTakeDamage_Dead
+  - name: CFlashbangProjectile_Spawn
+    alias:
+    - CFlashbangProjectile::Spawn
+  - name: CSmokeGrenadeProjectile_Create
+    alias:
+    - CSmokeGrenadeProjectile::Create
+  - name: CEntitySystem_QueueDestroyEntity
+    alias:
+    - CEntitySystem::QueueDestroyEntity
+  - name: CEntitySystem_ExecuteQueuedDeletion
+    alias:
+    - CEntitySystem::ExecuteQueuedDeletion
+  - name: CEntitySystem_m_nExecuteQueuedDeletionDepth
+    alias:
+    - CEntitySystem::m_nExecuteQueuedDeletionDepth
+  - name: CBaseModelEntity_SetModel
+    alias:
+    - CBaseModelEntity::SetModel
+  - name: CBaseModelEntity_SetRenderAttribute
+    alias:
+    - CBaseModelEntity::SetRenderAttribute
+  - name: CBaseEntity_GetScriptDescInternal
+    alias:
+    - CBaseEntity::GetScriptDescInternal
+  - name: CBaseModelEntity_GetScriptDescInternal
+    alias:
+    - CBaseModelEntity::GetScriptDescInternal
+  - name: CBaseModelEntity_GetModelScale
+    alias:
+    - CBaseModelEntity::GetModelScale
+  - name: CBaseModelEntity_Script_SetModelScale
+    alias:
+    - CBaseModelEntity::Script_SetModelScale
+  - name: CBaseModelEntity_ScriptLookupAttachment
+    alias:
+    - CBaseModelEntity::ScriptLookupAttachment
+  - name: CBaseModelEntity_ScriptGetAttachmentOrigin
+    alias:
+    - CBaseModelEntity::ScriptGetAttachmentOrigin
+  - name: CBaseModelEntity_ScriptGetAttachmentAngles
+    alias:
+    - CBaseModelEntity::ScriptGetAttachmentAngles
+  - name: CBaseModelEntity_ScriptGetAttachmentForward
+    alias:
+    - CBaseModelEntity::ScriptGetAttachmentForward
+  - name: CBaseModelEntity_ScriptSetSize
+    alias:
+    - CBaseModelEntity::ScriptSetSize
+  - name: CBaseModelEntity_ScriptSetModel
+    alias:
+    - CBaseModelEntity::ScriptSetModel
+  - name: CBaseModelEntity_ScriptGetRenderAlpha
+    alias:
+    - CBaseModelEntity::ScriptGetRenderAlpha
+  - name: CBaseModelEntity_ScriptSetRenderAlpha
+    alias:
+    - CBaseModelEntity::ScriptSetRenderAlpha
+  - name: CBaseModelEntity_ScriptSetRenderMode
+    alias:
+    - CBaseModelEntity::ScriptSetRenderMode
+  - name: CBaseModelEntity_ScriptSetRenderColor
+    alias:
+    - CBaseModelEntity::ScriptSetRenderColor
+  - name: CBaseModelEntity_ScriptGetRenderColor
+    alias:
+    - CBaseModelEntity::ScriptGetRenderColor
+  - name: CBaseModelEntity_ScriptSetMaterialGroup
+    alias:
+    - CBaseModelEntity::ScriptSetMaterialGroup
+  - name: CBaseModelEntity_ScriptSetMaterialGroupHash
+    alias:
+    - CBaseModelEntity::ScriptSetMaterialGroupHash
+  - name: CBaseModelEntity_ScriptGetMaterialGroupHash
+    alias:
+    - CBaseModelEntity::ScriptGetMaterialGroupHash
+  - name: CBaseModelEntity_ScriptSetSingleMeshGroup
+    alias:
+    - CBaseModelEntity::ScriptSetSingleMeshGroup
+  - name: CBaseModelEntity_ScriptSetMeshGroupMask
+    alias:
+    - CBaseModelEntity::ScriptSetMeshGroupMask
+  - name: CBaseModelEntity_ScriptGetMeshGroupMask
+    alias:
+    - CBaseModelEntity::ScriptGetMeshGroupMask
+  - name: CBaseModelEntity_ScriptSetBodygroupByName
+    alias:
+    - CBaseModelEntity::ScriptSetBodygroupByName
+  - name: CBaseModelEntity_Script_SetBodygroup
+    alias:
+    - CBaseModelEntity::Script_SetBodygroup
+  - name: CBaseModelEntity_Script_SetSkin
+    alias:
+    - CBaseModelEntity::Script_SetSkin
+  - name: CEntityInstance_NetworkUpdateState_thunk
+    alias:
+    - CEntityInstance::NetworkUpdateState_thunk
+  - name: CBaseEntity_SetGravityScale
+    alias:
+    - CBaseEntity::SetGravityScale
+  - name: CTriggerGravity_GravityTouch
+    alias:
+    - CTriggerGravity::GravityTouch
+  - name: CTriggerGravity_GetTouchFunction
+    alias:
+    - CTriggerGravity::GetTouchFunction
+  - name: CBasePlayerController_HandleCommand_JoinTeam
+    alias:
+    - CBasePlayerController::HandleCommand_JoinTeam
+  - name: CBasePlayerController_SetPlayerName
+    alias:
+    - CBasePlayerController::SetPlayerName
+  - name: CBasePlayerController_ProcessUsercmds
+    alias:
+    - ProcessUsercmds
+  - name: CBasePlayerController_SetPawn
+    alias:
+    - CBasePlayerController::SetPawn
+  - name: CBasePlayerController_GetPawn
+    alias:
+    - CBasePlayerController::GetPawn
+  - name: CBasePlayerController_Connect
+    alias:
+    - CBasePlayerController::Connect
+  - name: CSource2GameClients_ClientDisconnect
+    alias:
+    - CSource2GameClients::ClientDisconnect
+  - name: CSource2GameClients_ClientPutInServer
+    alias:
+    - CSource2GameClients::ClientPutInServer
+  - name: CSource2GameClients_ClientConnect
+    alias:
+    - CSource2GameClients::ClientConnect
+  - name: CSource2GameClients_ClientActive
+    alias:
+    - CSource2GameClients::ClientActive
+  - name: CSource2GameClients_ClientFullyConnect
+    alias:
+    - CSource2GameClients::ClientFullyConnect
+  - name: CSource2GameClients_ClientCommand
+    alias:
+    - CSource2GameClients::ClientCommand
+  - name: CSource2GameClients_ProcessUsercmds
+    alias:
+    - CSource2GameClients::ProcessUsercmds
+  - name: CSource2GameClients_GetBugReportInfo
+    alias:
+    - CSource2GameClients::GetBugReportInfo
+  - name: CSource2GameClients_ClientDiagnostic
+    alias:
+    - CSource2GameClients::ClientDiagnostic
+  - name: CSource2GameClients_SendHLTVStatusMessage
+    alias:
+    - CSource2GameClients::SendHLTVStatusMessage
+  - name: CSource2GameClients_OnClientConnected
+    alias:
+    - CSource2GameClients::OnClientConnected
+  - name: CGameRules_FindPickerEntity
+    alias:
+    - CGameRules::FindPickerEntity
+  - name: CCSGameRules_FindPickerEntity
+    alias:
+    - CCSGameRules::FindPickerEntity
+  - name: CCSGameRules_TerminateRound
+    alias:
+    - CCSGameRules::TerminateRound
+    - CGameRules::TerminateRound
+    - CGameRules_TerminateRound
+  - name: CCSGameRules_GoToIntermission
+    alias:
+    - CCSGameRules::GoToIntermission
+  - name: CEntityInstance_AcceptInput
+    alias:
+    - CEntityInstance::AcceptInput
+    - AcceptInput
+  - name: CEntityIdentity_AcceptInput
+    alias:
+    - CEntityIdentity::AcceptInput
+  - name: CEntityIdentity_AcceptInputInternal
+    alias:
+    - CEntityIdentity::AcceptInputInternal
+  - name: CEntityInstance_ScriptAcceptInput
+    alias:
+    - CEntityInstance::ScriptAcceptInput
+  - name: CEntityIdentity_SetEntityName
+    alias:
+    - CEntityIdentity::SetEntityName
+  - name: CEntitySystem_RemoveEntityFromNameMap
+    alias:
+    - CEntitySystem::RemoveEntityFromNameMap
+  - name: CEntitySystem_AddEntityToNameMap
+    alias:
+    - CEntitySystem::AddEntityToNameMap
+  - name: ScriptBinding_Entity_SetEntityName
+    alias:
+    - Entity::SetEntityName
+  - name: CBtActionCoordinatedBuy_Update
+    alias:
+    - CBtActionCoordinatedBuy::Update
+  - name: CCSPlayer_ItemServices_CanAcquire
+    alias:
+    - CCSPlayer_ItemServices::CanAcquire
+  - name: CCSPlayer_ItemServices_GiveDefaultItems
+    alias:
+    - CCSPlayer_ItemServices::GiveDefaultItems
+  - name: CCSPlayer_ItemServices_GiveNamedItem
+    alias:
+    - CCSPlayer_ItemServices::GiveNamedItem
+  - name: CCSPlayer_ItemServices_GiveNamedItemBool
+    alias:
+    - CCSPlayer_ItemServices::GiveNamedItemBool
+  - name: CCSPlayer_WeaponServices_CanUse
+    alias:
+    - CCSPlayer_WeaponServices::CanUse
+  - name: CCSPlayer_WeaponServices_PickupItem
+    alias:
+    - CCSPlayer_WeaponServices::PickupItem
+  - name: CCSPlayer_WeaponServices_EquipWeapon
+    alias:
+    - CCSPlayer_WeaponServices::EquipWeapon
+  - name: CCSPlayer_WeaponServices_Weapon_GetSlot
+    alias:
+    - CCSPlayer_WeaponServices_Weapon_GetSlot
+  - name: CCSPlayerController_ChangeTeam
+    alias:
+    - CCSPlayerController::ChangeTeam
+  - name: CCSPlayerController_GetThinkFunction
+    alias:
+    - CCSPlayerController::GetThinkFunction
+  - name: CCSPlayerController_PlayerForceTeamThink
+    alias:
+    - PlayerForceTeamThink
+    - CCSPlayerController::PlayerForceTeamThink
+  - name: CCSPlayerController_ResetForceTeamThink
+    alias:
+    - ResetForceTeamThink
+    - CCSPlayerController::ResetForceTeamThink
+  - name: CCSPlayerController_ResourceDataThink
+    alias:
+    - ResourceDataThink
+    - CCSPlayerController::ResourceDataThink
+  - name: CCSPlayerController_InventoryUpdateThink
+    alias:
+    - InventoryUpdateThink
+    - CCSPlayerController::InventoryUpdateThink
+  - name: g_CCSPlayerController_PlayerForceTeamThink
+    alias:
+    - g_CCSPlayerController::PlayerForceTeamThink
+  - name: g_CCSPlayerController_ResetForceTeamThink
+    alias:
+    - g_CCSPlayerController::ResetForceTeamThink
+  - name: g_CCSPlayerController_ResourceDataThink
+    alias:
+    - g_CCSPlayerController::ResourceDataThink
+  - name: g_CCSPlayerController_InventoryUpdateThink
+    alias:
+    - g_CCSPlayerController::InventoryUpdateThink
+  - name: CCSGameRules__sm_mapGcBanInformation
+    alias:
+    - CCSGameRules::sm_mapGcBanInformation
+  - name: CCSGameRules_BeginRound
+    alias:
+    - CCSGameRules::BeginRound
+  - name: CCSGameRules_PlayerSpawn
+    alias:
+    - CCSGameRules::PlayerSpawn
+  - name: CBasePlayerController_Respawn
+    alias:
+    - CBasePlayerController::Respawn
+  - name: CCSPlayerController_Respawn
+    alias:
+    - CCSPlayerController::Respawn
+  - name: CCSPlayerController_Connect
+    alias:
+    - CCSPlayerController::Connect
+  - name: CCSPlayerController_SwitchTeam
+    alias:
+    - CCSPlayerController::SwitchTeam
+  - name: CCSPlayerPawnBase_OnSetDormant
+    alias:
+    - CCSPlayerPawnBase::OnSetDormant
+  - name: CCSPlayerPawnBase_CheckForIdle
+    alias:
+    - CCSPlayerPawnBase::CheckForIdle
+  - name: CCSPlayerPawnBase_CheckForIdleInternal
+    alias:
+    - CCSPlayerPawnBase::CheckForIdleInternal
+  - name: CCSPlayerPawn_PostThink
+    alias:
+    - CCSPlayerPawnBase::PostThink
+    - CCSPlayerPawn::PostThink
+    - CCSPlayerPawnBase_PostThink
+    - CCSPlayerPawn_PostThink
+    - PostThink
+  - name: CCSPlayerPawn_OnSwitchWeapons
+    alias:
+    - CCSPlayerPawn::OnSwitchWeapons
+  - name: CCSPlayerPawn_ProcessSuicideAsKillReward
+    alias:
+    - CCSPlayerPawn::ProcessSuicideAsKillReward
+  - name: CGameRules_ClientSettingsChanged
+    alias:
+    - CGameRules::ClientSettingsChanged
+  - name: CGameRulesGameSystem_OnGameInit
+    alias:
+    - CGameRulesGameSystem::GameInit
+  - name: CGameRulesGameSystem_OnGameShutdown
+    alias:
+    - CGameRulesGameSystem::GameShutdown
+  - name: IGameSystem_OnGameShutdown
+    alias:
+    - IGameSystem::GameShutdown
+  - name: IGameSystem_OnGamePostInit
+    alias:
+    - IGameSystem::GamePostInit
+  - name: IGameSystem_OnGamePreShutdown
+    alias:
+    - IGameSystem::GamePreShutdown
+  - name: CMultiplayRules_ClientDisconnected
+    alias:
+    - CMultiplayRules::ClientDisconnected
+  - name: CSource2Server_Init
+    alias:
+    - CSource2Server::Init
+  - name: CSource2Server_ApplyGameSettings
+    alias:
+    - CSource2Server::ApplyGameSettings
+  - name: CSource2Server_WriteSignonMessages
+    alias:
+    - CSource2Server::WriteSignonMessages
+  - name: CSource2Server_GameCreateNetworkStringTables
+    alias:
+    - CSource2Server::GameCreateNetworkStringTables
+  - name: CSource2Server_GetMatchmakingGameData
+    alias:
+    - CSource2Server::GetMatchmakingGameData
+  - name: CSource2Server_GameServerSteamAPIActivated
+    alias:
+    - CSource2Server::GameServerSteamAPIActivated
+  - name: CSource2Server_GameServerSteamAPIDeactivated
+    alias:
+    - CSource2Server::GameServerSteamAPIDeactivated
+  - name: CSource2Server_OnHostNameChanged
+    alias:
+    - CSource2Server::OnHostNameChanged
+  - name: CSource2Server_GetLevelsFromSaveFile
+    alias:
+    - CSource2Server::GetLevelsFromSaveFile
+  - name: CSource2Server_ServerConVarChanged
+    alias:
+    - CSource2Server::ServerConVarChanged
+  - name: CSource2Server_Save
+    alias:
+    - CSource2Server::Save
+  - name: CSource2Server_Connect
+    alias:
+    - CSource2Server::Connect
+  - name: CSource2Server_PreShutdown
+    alias:
+    - CSource2Server::PreShutdown
+  - name: IAppSystem_Connect
+    alias:
+    - IAppSystem::Connect
+  - name: IAppSystem_PreShutdown
+    alias:
+    - IAppSystem::PreShutdown
+  - name: IVEngineServer2_ServerCommand
+    alias:
+    - IVEngineServer2::ServerCommand
+  - name: IVEngineServer2_IsDedicatedServer
+    alias:
+    - IVEngineServer2::IsDedicatedServer
+  - name: CSource2Server_Shutdown
+    alias:
+    - CSource2Server::Shutdown
+  - name: CGameEventManager_Shutdown
+    alias:
+    - CGameEventManager::Shutdown
+  - name: CLoopModeRegistry_UnregisterLoopModes
+    alias:
+    - CLoopModeRegistry::UnregisterLoopModes
+  - name: CEngineServiceRegistry_UnregisterEngineServices
+    alias:
+    - CEngineServiceRegistry::UnregisterEngineServices
+  - name: IEngineServiceMgr_UnregisterLoopMode
+    alias:
+    - IEngineServiceMgr::UnregisterLoopMode
+  - name: IEngineServiceMgr_UnregisterEngineService
+    alias:
+    - IEngineServiceMgr::UnregisterEngineService
+  - name: CSource2Server_GameFrame
+    alias:
+    - CSource2Server::GameFrame
+  - name: CGameEventManager_Init
+    alias:
+    - CGameEventManager::Init
+  - name: CTakeDamageInfo_HitGroupInfo
+    alias:
+    - CTakeDamageInfo::HitGroupInfo
+    - CTakeDamageInfo::HitGroup
+    - CTakeDamageInfo_HitGroup
+  - name: CEntitySystem_RegisterEntityClass
+    alias:
+    - CEntitySystem::RegisterEntityClass
+  - name: CEntitySystem_CreateEntityByName
+    alias:
+    - CEntitySystem::CreateEntityByName
+  - name: CEntitySystem_CreateEntity
+    alias:
+    - CEntitySystem::CreateEntity
+  - name: CEntitySystem_AddEntityToEntityDataBase
+    alias:
+    - CEntitySystem::AddEntityToEntityDataBase
+  - name: CEntitySystem_OnAddEntity
+    alias:
+    - CEntitySystem::OnAddEntity
+  - name: CEntitySystem_OnEntityParentChanged
+    alias:
+    - CEntitySystem::OnEntityParentChanged
+  - name: CEntitySystem_PrecacheEntity
+    alias:
+    - CEntitySystem::PrecacheEntity
+  - name: CEntitySystem_InvokePrecacheCallback
+    alias:
+    - CEntitySystem::InvokePrecacheCallback
+  - name: CEntitySystem_DestroyEntity
+    alias:
+    - CEntitySystem::DestroyEntity
+  - name: CConcreteEntityList_AllocEntity
+    alias:
+    - CConcreteEntityList::AllocEntity
+  - name: CEntitySystem_ConstructEntity
+    alias:
+    - CEntitySystem::ConstructEntity
+  - name: CEntitySystem_DoConstructEntity
+    alias:
+    - CEntitySystem::DoConstructEntity
+  - name: CEntitySystem_GetSpawnGroupWorldId
+    alias:
+    - CEntitySystem::GetSpawnGroupWorldId
+  - name: CEntitySystem_FindClassByDesignName
+    alias:
+    - CEntitySystem::FindClassByDesignName
+  - name: CEntitySystem_m_EntityList
+    alias:
+    - CEntitySystem::m_EntityList
+  - name: CEntitySystem_m_entityNames
+    alias:
+    - CEntitySystem::m_entityNames
+  - name: CEntitySystem_m_entityComponentHelpers
+    alias:
+    - CEntitySystem::m_entityComponentHelpers
+  - name: CEntitySystem_m_DataDescKeyUnserializers
+    alias:
+    - CEntitySystem::m_DataDescKeyUnserializers
+  - name: CEntitySystem_m_EntityPostSpawnCallback
+    alias:
+    - CEntitySystem::m_EntityPostSpawnCallback
+  - name: CEntityIdentity_FreeAttributes
+    alias:
+    - CEntityIdentity::FreeAttributes
+  - name: CConcreteEntityList_FreeEntity
+    alias:
+    - CConcreteEntityList::FreeEntity
+  - name: UTIL_CreateEntityByName
+    alias:
+    - CreateEntityByName
+  - name: CBaseEntity_DispatchSpawn
+    alias:
+    - CBaseEntity::DispatchSpawn
+    - DispatchSpawn
+  - name: CEntitySystem_QueueSpawnEntity
+    alias:
+    - CEntitySystem::QueueSpawnEntity
+  - name: CEntitySystem_HelperExecuteQueuedSpawn
+    alias:
+    - CEntitySystem::HelperExecuteQueuedSpawn
+  - name: CEntitySystem_SortEntities
+    alias:
+    - CEntitySystem::SortEntities
+  - name: CGameEntitySystem_SortEntities
+    alias:
+    - CGameEntitySystem::SortEntities
+  - name: CEntitySystem_InstallCreationWrapperCallbacks
+    alias:
+    - CEntitySystem::InstallCreationWrapperCallbacks
+  - name: CEntitySystem_ExecuteQueuedCreation
+    alias:
+    - CEntitySystem::ExecuteQueuedCreation
+  - name: CEntitySystem_ExecuteQueuedActivates
+    alias:
+    - CEntitySystem::ExecuteQueuedActivates
+  - name: CEntitySystem_ExecuteQueuedPostDataUpdateAndActivates
+    alias:
+    - CEntitySystem::ExecuteQueuedPostDataUpdateAndActivates
+  - name: CEntitySystem_Activate
+    alias:
+    - CEntitySystem::Activate
+  - name: CEntitySystem_PostDataUpdate
+    alias:
+    - CEntitySystem::PostDataUpdate
+  - name: CBaseEntity_NetworkStateChangedLog
+    alias:
+    - CBaseEntity::NetworkStateChangedLog
+  - name: CBaseEntity_NetworkStateChanged
+    alias:
+    - CBaseEntity::NetworkStateChanged
+  - name: CBaseEntity_FullEdictChanged
+    alias:
+    - CBaseEntity::FullEdictChanged
+  - name: CBaseEntity_m_NetworkTransmitComponent
+    alias:
+    - CBaseEntity::m_NetworkTransmitComponent
+  - name: CNetworkTransmitComponent_StateChanged
+    alias:
+    - CNetworkTransmitComponent::StateChanged
+  - name: CNetworkTransmitComponent_m_nStateFlags
+    alias:
+    - CNetworkTransmitComponent::m_nStateFlags
+  - name: CInferno_InfernoThink
+    alias:
+    - CInferno::InfernoThink
+  - name: CPhysExplosion_Activate
+    alias:
+    - CPhysExplosion::Activate
+  - name: CPhysExplosion_Explode
+    alias:
+    - CPhysExplosion::Explode
+  - name: UTIL_SayTextFilter2
+    alias:
+    - UTIL_SayText2Filter
+  - name: CCSWeaponBase_ItemPostFrame_ProcessReloadAction
+    alias:
+    - CCSWeaponBase::ItemPostFrame::ProcessReloadAction
+  - name: CCSPlayer_WeaponServices_HandleDropWeapon
+    alias:
+    - CCSPlayer_WeaponServices::HandleDropWeapon
+  - name: CCSPlayer_UseServices_BumpWeapon
+    alias:
+    - CCSPlayer_UseServices::BumpWeapon
+  - name: CCSPlayerPawn_HandleDropWeapon
+    alias:
+    - CCSPlayerPawn::HandleDropWeapon
+  - name: CCSPlayerPawn_ClientCommand
+    alias:
+    - CCSPlayerPawn::ClientCommand
+  - name: CCSPlayerPawn_SprayPaint
+    alias:
+    - CCSPlayerPawn::SprayPaint
+  - name: CEntitySpawner_CPlayerSprayDecal_Spawn
+    alias:
+    - CEntitySpawner<CPlayerSprayDecal>::Spawn
+  - name: CEntityKeyValuesAllocator_GetTempBuffer
+    alias:
+    - CEntityKeyValuesAllocator::GetTempBuffer
+  - name: CEntityKeyValues_LoadFromContext
+    alias:
+    - CEntityKeyValues::LoadFromContext
+  - name: CEntityKeyValues_Initialized
+    alias:
+    - CEntityKeyValues::Initialized
+  - name: CEntitySystem_m_nEntityKeyValuesAllocatorRefCount
+    alias:
+    - CEntitySystem::m_nEntityKeyValuesAllocatorRefCount
+  - name: CEntitySystem_AddRefKeyValues
+    alias:
+    - CEntitySystem::AddRefKeyValues
+  - name: CEntitySystem_ReleaseKeyValues
+    alias:
+    - CEntitySystem::ReleaseKeyValues
+  - name: CCSPlayerController_HandleCommandDrop
+    alias:
+    - CCSPlayerController::HandleCommandDrop
+  - name: IGameSystem_InitAllSystems
+    alias:
+    - IGameSystem::InitAllSystems
+  - name: IGameSystem_LoopInitAllSystems
+    alias:
+    - IGameSystem::LoopInitAllSystems
+  - name: IGameSystem_LoopPostInitAllSystems
+    alias:
+    - IGameSystem::LoopPostInitAllSystems
+  - name: IGameSystem_PostInit
+    alias:
+    - IGameSystem::PostInit
+  - name: IGameSystemFactory_PostInit
+    alias:
+    - IGameSystemFactory::PostInit
+  - name: IGameSystemFactory_GetStaticGameSystem
+    alias:
+    - IGameSystemFactory::GetStaticGameSystem
+  - name: IGameSystem_InitAllSystems_pFirst
+    alias:
+    - IGameSystem::InitAllSystems::pFirst
+    - IGameSystem::InitAllSystems->pFirst
+  - name: IGameSystem_LoopPostInitAllSystems_pEventDispatcher
+    alias:
+    - IGameSystem::LoopPostInitAllSystems::pEventDispatcher
+    - IGameSystem::LoopPostInitAllSystems->pEventDispatcher
+  - name: IGameSystem_LoopDestroyAllSystems_s_GameSystems
+    alias:
+    - IGameSystem::LoopDestroyAllSystems::s_GameSystems
+    - IGameSystem::LoopDestroyAllSystems->s_GameSystems
+  - name: CSource2GameEntities_CheckTransmit
+    alias:
+    - CSource2GameEntities::CheckTransmit
+    - ISource2GameEntities::CheckTransmit
+    - ISource2GameEntities_CheckTransmit
+    - CheckTransmit
+  - name: CBaseEntity_EmitSoundFilter
+    alias:
+    - CBaseEntity::EmitSoundFilter
+  - name: CBaseEntity_ScriptInputKill
+    alias:
+    - CBaseEntity::ScriptInputKill
+  - name: CBaseEntity_ScriptGetForward
+    alias:
+    - CBaseEntity::ScriptGetForward
+  - name: CBaseEntity_ScriptGetRight
+    alias:
+    - CBaseEntity::ScriptGetRight
+  - name: CBaseEntity_ScriptGetLeft
+    alias:
+    - CBaseEntity::ScriptGetLeft
+  - name: CBaseEntity_ScriptGetUp
+    alias:
+    - CBaseEntity::ScriptGetUp
+  - name: CBaseEntity_ScriptGetModelName
+    alias:
+    - CBaseEntity::ScriptGetModelName
+  - name: CBaseEntity_ScriptGetMoveParent
+    alias:
+    - CBaseEntity::ScriptGetMoveParent
+  - name: CBaseEntity_ScriptGetRootMoveParent
+    alias:
+    - CBaseEntity::ScriptGetRootMoveParent
+  - name: CBaseEntity_ScriptFirstMoveChild
+    alias:
+    - CBaseEntity::ScriptFirstMoveChild
+  - name: CBaseEntity_ScriptNextMovePeer
+    alias:
+    - CBaseEntity::ScriptNextMovePeer
+  - name: CBaseEntity_ScriptGetOwnerEntity
+    alias:
+    - CBaseEntity::ScriptGetOwnerEntity
+  - name: CBaseEntity_Script_GetChildren
+    alias:
+    - CBaseEntity::Script_GetChildren
+  - name: CBaseEntity_ScriptSetParent
+    alias:
+    - CBaseEntity::ScriptSetParent
+  - name: CBaseEntity_ScriptEyePosition
+    alias:
+    - CBaseEntity::ScriptEyePosition
+  - name: CBaseEntity_ScriptSetAngles
+    alias:
+    - CBaseEntity::ScriptSetAngles
+  - name: CBaseEntity_ScriptSetAbsAngles
+    alias:
+    - CBaseEntity::ScriptSetAbsAngles
+  - name: CBaseEntity_ScriptGetAngles
+    alias:
+    - CBaseEntity::ScriptGetAngles
+  - name: CBaseEntity_ScriptEyeAngles
+    alias:
+    - CBaseEntity::ScriptEyeAngles
+  - name: CBaseEntity_ScriptSetOrigin
+    alias:
+    - CBaseEntity::ScriptSetOrigin
+  - name: CBaseEntity_ScriptSetLocalAngles
+    alias:
+    - CBaseEntity::ScriptSetLocalAngles
+  - name: CBaseEntity_ScriptGetLocalAngles
+    alias:
+    - CBaseEntity::ScriptGetLocalAngles
+  - name: CBaseEntity_ScriptSetLocalOrigin
+    alias:
+    - CBaseEntity::ScriptSetLocalOrigin
+  - name: CBaseEntity_ScriptGetLocalOrigin
+    alias:
+    - CBaseEntity::ScriptGetLocalOrigin
+  - name: CBaseEntity_ScriptTransformPointEntityToWorld
+    alias:
+    - CBaseEntity::ScriptTransformPointEntityToWorld
+  - name: CBaseEntity_ScriptTransformPointWorldToEntity
+    alias:
+    - CBaseEntity::ScriptTransformPointWorldToEntity
+  - name: CBaseEntity_ScriptSetForward
+    alias:
+    - CBaseEntity::ScriptSetForward
+  - name: CBaseEntity_ScriptGetBoundingMins
+    alias:
+    - CBaseEntity::ScriptGetBoundingMins
+  - name: CBaseEntity_ScriptGetBoundingMaxs
+    alias:
+    - CBaseEntity::ScriptGetBoundingMaxs
+  - name: CBaseEntity_ScriptGetBounds
+    alias:
+    - CBaseEntity::ScriptGetBounds
+  - name: CBaseEntity_ScriptGetLocalAngularVelocity_OBSOLETE
+    alias:
+    - CBaseEntity::ScriptGetLocalAngularVelocity_OBSOLETE
+  - name: CBaseEntity_ScriptSetLocalAngularVelocity_OBSOLETE
+    alias:
+    - CBaseEntity::ScriptSetLocalAngularVelocity_OBSOLETE
+  - name: CBaseEntity_ScriptAddEffects
+    alias:
+    - CBaseEntity::ScriptAddEffects
+  - name: CBaseEntity_ScriptRemoveEffects
+    alias:
+    - CBaseEntity::ScriptRemoveEffects
+  - name: CBaseEntity_ScriptSetAttributeFloatValue
+    alias:
+    - CBaseEntity::ScriptSetAttributeFloatValue
+  - name: CBaseEntity_ScriptGetAttributeFloatValue
+    alias:
+    - CBaseEntity::ScriptGetAttributeFloatValue
+  - name: CBaseEntity_ScriptSetAttributeIntValue
+    alias:
+    - CBaseEntity::ScriptSetAttributeIntValue
+  - name: CBaseEntity_ScriptGetAttributeIntValue
+    alias:
+    - CBaseEntity::ScriptGetAttributeIntValue
+  - name: CBaseEntity_ScriptHasAttribute
+    alias:
+    - CBaseEntity::ScriptHasAttribute
+  - name: CBaseEntity_ScriptDeleteAttribute
+    alias:
+    - CBaseEntity::ScriptDeleteAttribute
+  - name: CBaseEntity_GetScriptOwnerEntity
+    alias:
+    - CBaseEntity::GetScriptOwnerEntity
+  - name: CBaseEntity_SetScriptOwnerEntity
+    alias:
+    - CBaseEntity::SetScriptOwnerEntity
+  - name: CBaseEntity_ScriptSetEntityName
+    alias:
+    - CBaseEntity::ScriptSetEntityName
+  - name: CBaseEntity_ScriptGetMass
+    alias:
+    - CBaseEntity::ScriptGetMass
+  - name: CBaseEntity_ScriptSetMass
+    alias:
+    - CBaseEntity::ScriptSetMass
+  - name: CBaseEntity_ScriptGetSpawnGroupHandle
+    alias:
+    - CBaseEntity::ScriptGetSpawnGroupHandle
+  - name: CBaseEntity_GetAbsAngles
+    alias:
+    - CBaseEntity::GetAbsAngles
+  - name: CBaseEntity_Script_GetTeamNumber
+    alias:
+    - CBaseEntity::Script_GetTeamNumber
+  - name: CBaseEntity_Script_FollowEntity
+    alias:
+    - CBaseEntity::Script_FollowEntity
+  - name: CBaseEntity_Script_FollowEntityMerge
+    alias:
+    - CBaseEntity::Script_FollowEntityMerge
+  - name: CBaseEntity_Script_Trigger
+    alias:
+    - CBaseEntity::Script_Trigger
+  - name: CBaseEntity_Script_SetContextThink
+    alias:
+    - CBaseEntity::Script_SetContextThink
+  - name: CBaseEntity_AddContextForScript
+    alias:
+    - CBaseEntity::AddContextForScript
+  - name: CBaseEntity_AddContextForScriptNumeric
+    alias:
+    - CBaseEntity::AddContextForScriptNumeric
+  - name: CBaseEntity_GetContextForScript
+    alias:
+    - CBaseEntity::GetContextForScript
+  - name: CBaseEntity_ScriptGatherCriteria
+    alias:
+    - CBaseEntity::ScriptGatherCriteria
+  - name: CBaseEntity_Script_TakeDamage
+    alias:
+    - CBaseEntity::Script_TakeDamage
+  - name: CBaseEntity_SetGravityScale
+    alias:
+    - CBaseEntity::SetGravityScale
+  - name: CBaseEntity_SetAbsVelocity
+    alias:
+    - CBaseEntity::SetAbsVelocity
+  - name: CBaseEntity_GetAbsVelocity
+    alias:
+    - CBaseEntity::GetAbsVelocity
+  - name: CBaseEntity_Script_ApplyLocalAngularVelocityImpulse
+    alias:
+    - CBaseEntity::Script_ApplyLocalAngularVelocityImpulse
+  - name: CBaseEntity_GetLocalAngularVelocity_OBSOLETE
+    alias:
+    - CBaseEntity::GetLocalAngularVelocity_OBSOLETE
+  - name: CBaseEntity_ScriptEmitSoundParams
+    alias:
+    - CBaseEntity::ScriptEmitSoundParams
+    - CBaseEntity::EmitSoundParams
+    - CBaseEntity_EmitSoundParams
+  - name: CBaseEntity_ScriptStopSound
+    alias:
+    - CBaseEntity::ScriptStopSound
+  - name: CBaseEntity_ScriptSoundDuration
+    alias:
+    - CBaseEntity::ScriptSoundDuration
+  - name: CBaseEntity_ScriptGetAbsOrigin
+    alias:
+    - CBaseEntity::ScriptGetAbsOrigin
+  - name: CBaseEntity_Precache
+    alias:
+    - CBaseEntity::Precache
+    - Precache
+  - name: CEnvEntityIgniter_Precache
+    alias:
+    - CEnvEntityIgniter::Precache
+  - name: CEnvShake_Spawn
+    alias:
+    - CEnvShake::Spawn
+  - name: CBaseEntity_SetMoveType
+    alias:
+    - CBaseEntity::SetMoveType
+  - name: CBasePlayerPawn_CommitSuicide
+    alias:
+    - CBasePlayerPawn::CommitSuicide
+    - CommitSuicide
+  - name: CBaseCombatCharacter_OnKilled
+    alias:
+    - CBaseCombatCharacter::OnKilled
+  - name: CCSPlayerPawn_Event_KilledOther
+    alias:
+    - CCSPlayerPawn::Event_KilledOther
+  - name: CCSPlayerPawn_Event_Killed
+    alias:
+    - CCSPlayerPawn::Event_Killed
+  - name: CBasePlayerPawn_Event_Killed
+    alias:
+    - CBasePlayerPawn::Event_Killed
+  - name: ScriptBinding_CSPlayerPawn_DestroyWeapon
+    alias:
+    - CSPlayerPawn::DestroyWeapon
+  - name: CBasePlayerPawn_RemovePlayerItem
+    alias:
+    - CBasePlayerPawn::RemovePlayerItem
+  - name: CBasePlayerPawn_DropActivePlayerWeapon
+    alias:
+    - CBasePlayerPawn::DropActivePlayerWeapon
+  - name: CBasePlayerPawn_GetEyePosition
+    alias:
+    - CBasePlayerPawn::GetEyePosition
+  - name: CBaseEntity_GetEyePosition
+    alias:
+    - CBaseEntity::GetEyePosition
+  - name: CCSBotManager_BotPlaceCommand
+    alias:
+    - CCSBotManager::BotPlace
+  - name: CBasePlayerPawn_EyeVectors
+    alias:
+    - CBasePlayerPawn::EyeVectors
+  - name: CBasePlayerPawn_GetEyeAngles
+    alias:
+    - CBasePlayerPawn::GetEyeAngles
+  - name: CBaseEntity_GetEyeAngles
+    alias:
+    - CBaseEntity::GetEyeAngles
+  - name: CCSBot_Upkeep
+    alias:
+    - CCSBot::Upkeep
+  - name: CCSBot_SetState
+    alias:
+    - CCSBot::SetState
+  - name: CCSBot_UpdatePathMovement
+    alias:
+    - CCSBot::UpdatePathMovement
+  - name: CCSBot_PrintIfWatched
+    alias:
+    - CCSBot::PrintIfWatched
+  - name: HideState_OnUpdate
+    alias:
+    - HideState::OnUpdate
+  - name: CCSBot_Attack
+    alias:
+    - CCSBot::Attack
+  - name: CCSBot_MoveTo
+    alias:
+    - CCSBot::MoveTo
+  - name: CCSBot_InhibitLookAround
+    alias:
+    - CCSBot::InhibitLookAround
+  - name: CCSBot_SetDisposition
+    alias:
+    - CCSBot::SetDisposition
+  - name: CCSBot_Idle
+    alias:
+    - CCSBot::Idle
+  - name: CCSBot_ComputePath
+    alias:
+    - CCSBot::ComputePath
+  - name: CBaseEntity_IsAlive
+    alias:
+    - CBaseEntity::IsAlive
+  - name: CBaseEntity_SetOwner
+    alias:
+    - CBaseEntity::SetOwner
+  - name: CBaseEntity_CollisionRulesChanged
+    alias:
+    - CBaseEntity::CollisionRulesChanged
+    - CollisionRulesChanged
+  - name: CBaseEntity_Use
+    alias:
+    - CBaseEntity::Use
+  - name: CGameSceneNode_PostSpawnKeyValues
+    alias:
+    - CGameSceneNode::PostSpawnKeyValues
+  - name: CBaseEntity_Spawn
+    alias:
+    - CBaseEntity::Spawn
+    - Spawn
+  - name: CBaseEntity_SpawnRadius
+    alias:
+    - CBaseEntity::SpawnRadius
+  - name: CCSPlayer_ItemServices_DropActivePlayerWeapon
+    alias:
+    - CCSPlayer_ItemServices::DropActivePlayerWeapon
+  - name: CCSPlayer_WeaponServices_DropWeapon
+    alias:
+    - CCSPlayer_WeaponServices::DropWeapon
+  - name: CCSPlayer_ItemServices_RemoveWeapons
+    alias:
+    - CCSPlayer_ItemServices::RemoveWeapons
+  - name: CCSPlayer_WeaponServices_SelectItem
+    alias:
+    - CCSPlayer_WeaponServices::SelectItem
+  - name: CEntFireOutputAutoCompletionFunctor_FireOutput
+    alias:
+    - CEntFireOutputAutoCompletionFunctor::FireOutput
+  - name: CEntityInstance_FindOutputsByName
+    alias:
+    - CEntityInstance::FindOutputsByName
+  - name: CEntityInstance_ScriptEntityIO
+    alias:
+    - CEntityInstance::ScriptEntityIO
+  - name: CEntityIOOutput_FireOutputInternal
+    alias:
+    - CEntityIOOutput::FireOutputInternal
+  - name: CEntitySystem_AddEntityIOEvent
+    alias:
+    - CEntitySystem::AddEntityIOEvent
+  - name: CEntitySystem_AddEntityIOEvent2
+    alias:
+    - CEntitySystem::AddEntityIOEvent2
+  - name: CEntitySystem_AddEntityIOEventBuildStruct
+    alias:
+    - CEntitySystem::AddEntityIOEventBuildStruct
+  - name: CEntitySystem_AddEntityIOEventToQueue
+    alias:
+    - CEntitySystem::AddEntityIOEventToQueue
+  - name: CEntitySystem_m_EventQueue
+    alias:
+    - CEntitySystem::m_EventQueue
+  - name: CGameEntitySystem_FindEntityByClassName
+    alias:
+    - CGameEntitySystem::FindEntityByClassName
+  - name: CGameEntitySystem_FindEntityByName
+    alias:
+    - CGameEntitySystem::FindEntityByName
+  - name: CGameEntitySystem_OnAddEntity
+    alias:
+    - CGameEntitySystem::OnAddEntity
+  - name: CGameEntitySystem_BuildResourceManifest_ManifestNameOrGroupName
+    alias:
+    - CGameEntitySystem::BuildResourceManifest_ManifestNameOrGroupName
+  - name: CGameEntitySystem_BuildResourceManifest_KeyValuesVectors
+    alias:
+    - CGameEntitySystem::BuildResourceManifest_KeyValuesVectors
+  - name: CGameEntitySystem_FindEntityProcedural
+    alias:
+    - CGameEntitySystem::FindEntityProcedural
+  - name: CGameEntitySystem_Spawn
+    alias:
+    - CGameEntitySystem::Spawn
+  - name: CEntitySystem_Spawn
+    alias:
+    - CEntitySystem::Spawn
+  - name: CBodyGameSystem_SpawnDependencyIsland
+    alias:
+    - CBodyGameSystem::SpawnDependencyIsland
+  - name: CGameEntitySystem_CheckGlobalState
+    alias:
+    - CGameEntitySystem::CheckGlobalState
+  - name: IGameSystem_OnBuildGameSessionManifest
+    alias:
+    - IGameSystem::BuildGameSessionManifest
+  - name: IGameSystem_OnServerPreEntityThink
+    alias:
+    - IGameSystem::OnServerPreEntityThink
+  - name: IGameSystem_OnServerPostEntityThink
+    alias:
+    - IGameSystem::OnServerPostEntityThink
+  - name: IGameSystem_OnServerPreClientUpdate
+    alias:
+    - IGameSystem::ServerPreClientUpdate
+  - name: IGameSystem_OnServerAdvanceTick
+    alias:
+    - IGameSystem::ServerAdvanceTick
+  - name: IGameSystem_OnServerGamePostSimulate
+    alias:
+    - IGameSystem::ServerGamePostSimulate
+  - name: IGameSystem_OnServerPostAdvanceTick
+    alias:
+    - IGameSystem::ServerPostAdvanceTick
+  - name: IGameSystem_OnServerPreBeginAsyncPostTickWork
+    alias:
+    - IGameSystem::OnServerPreBeginAsyncPostTickWork
+  - name: IGameSystem_OnServerBeginAsyncPostTickWork
+    alias:
+    - IGameSystem::OnServerBeginAsyncPostTickWork
+  - name: IGameSystem_OnServerPreEndAsyncPostTickWork
+    alias:
+    - IGameSystem::OnServerPreEndAsyncPostTickWork
+  - name: IGameSystem_OnServerPostEndAsyncPostTickWork
+    alias:
+    - IGameSystem::OnServerPostEndAsyncPostTickWork
+  - name: IGameSystem_OnSaveGame
+    alias:
+    - IGameSystem::OnSaveGame
+  - name: IGameSystem_OnRestoreGame
+    alias:
+    - IGameSystem::OnRestoreGame
+  - name: IGameSystem_OnOutOfGameFrameBoundary
+    alias:
+    - IGameSystem::OnOutOfGameFrameBoundary
+  - name: CSource2GameClients_StartHLTVServer
+    alias:
+    - CSource2GameClients::StartHLTVServer
+  - name: LegacyGameEventListener
+    alias:
+    - GetLegacyGameEventListener
+  - name: CPhysicsGameSystem_ProcessContactEvents
+    alias:
+    - CPhysicsGameSystem::ProcessContactEvents
+  - name: CBaseEntity_PhysicsDispatchStartTouch
+    alias:
+    - CBaseEntity::PhysicsDispatchStartTouch
+  - name: CBaseEntity_PhysicsNotifyOtherOfEndTouch
+    alias:
+    - CBaseEntity::PhysicsNotifyOtherOfEndTouch
+  - name: CBaseEntity_PhysicsDispatchTouch
+    alias:
+    - CBaseEntity::PhysicsDispatchTouch
+  - name: CBaseEntity_StartTouch
+    alias:
+    - CBaseEntity::StartTouch
+    - StartTouch
+  - name: CBaseEntity_Touch
+    alias:
+    - CBaseEntity::Touch
+    - Touch
+  - name: CBaseEntity_EndTouch
+    alias:
+    - CBaseEntity::EndTouch
+    - EndTouch
+  - name: IVPhys2World_GetTouchingList
+    alias:
+    - IVPhys2World::GetTouchingList
+    - CVPhys2World::GetTouchingList
+  - name: CTriggerPush_Touch
+    alias:
+    - CTriggerPush::Touch
+    - TriggerPush_Touch
+  - name: CPhysBox_Use
+    alias:
+    - CPhysBox::Use
+  - name: CBaseEntity_SetGroundEntity
+    alias:
+    - SetGroundEntity
+  - name: CBaseEntity_GetHammerUniqueId
+    alias:
+    - CBaseEntity::GetHammerUniqueId
+    - GetHammerUniqueId
+  - name: CBaseEntity_IsPlayerPawn
+    alias:
+    - CBaseEntity::IsPlayerPawn
+    - IsEntityPawn
+    - IsPlayerPawn
+  - name: CBaseEntity_IsPlayerController
+    alias:
+    - CBaseEntity::IsPlayerController
+    - IsEntityController
+    - IsPlayerController
+  - name: CBaseTrigger_StartTouch
+    alias:
+    - CBaseTrigger::StartTouch
+  - name: CBaseTrigger_EndTouch
+    alias:
+    - CBaseTrigger::EndTouch
+  - name: CBaseTrigger_PassesTriggerFilters
+    alias:
+    - CBaseTrigger::PassesTriggerFilters
+    - PassesTriggerFilters
+  - name: CBaseAnimGraph_GetAnimationController
+    alias:
+    - CBaseAnimGraph::GetAnimationController
+  - name: CBaseAnimGraph_m_skeletonInstance
+    alias:
+    - CBaseAnimGraph::m_skeletonInstance
+  - name: CGameSceneNode_PreInstanceSpawn
+    alias:
+    - CGameSceneNode::PreInstanceSpawn
+  - name: CGameSceneNode_GetSkeletonInstance
+    alias:
+    - CGameSceneNode::GetSkeletonInstance
+  - name: CSkeletonInstance_m_animationController
+    alias:
+    - CSkeletonInstance::m_animationController
+  - name: CSkeletonInstance_PostDataUpdate
+    alias:
+    - CSkeletonInstance::PostDataUpdate
+  - name: CGameSceneNode_PostDataUpdate
+    alias:
+    - CGameSceneNode::PostDataUpdate
+  - name: CGameSceneNode_UpdateEntityForHierarchyChange
+    alias:
+    - CGameSceneNode::UpdateEntityForHierarchyChange
+  - name: CPointTeleportAPI_TeleportEntityInternal
+    alias:
+    - CPointTeleportAPI::TeleportEntityInternal
+  - name: CBaseEntity_Teleport
+    alias:
+    - CBaseEntity::Teleport
+  - name: CPointTeleport_Activate
+    alias:
+    - CPointTeleport::Activate
+  - name: CBaseEntity_Activate
+    alias:
+    - CBaseEntity::Activate
+    - Activate
+  - name: CBaseEntity_DrawDebugTextOverlays
+    alias:
+    - CBaseEntity::DrawDebugTextOverlays
+  - name: CRagdollProp_DrawEntityDebugOverlays
+    alias:
+    - CRagdollProp::DrawEntityDebugOverlays
+  - name: CBaseEntity_ReloadPrivateScripts
+    alias:
+    - CBaseEntity::ReloadPrivateScripts
+  - name: CCheckTransmitInfo_m_nPlayerSlot
+    alias:
+    - CCheckTransmitInfo::m_nPlayerSlot
+    - CheckTransmitPlayerSlot
+  - name: CDedicatedServerWorkshopManager_SwitchToWorkshopMapGroup
+    alias:
+    - CDedicatedServerWorkshopManager::SwitchToWorkshopMapGroup
+  - name: IGameTypes_CreateWorkshopMapGroup
+    alias:
+    - IGameTypes::CreateWorkshopMapGroup
+  - name: CSpawnGroupMgrGameSystem_GetSpawnGroups
+    alias:
+    - CSpawnGroupMgrGameSystem::GetSpawnGroups
+    - GetSpawnGroups
+  - name: CSpawnGroupMgrGameSystem_DumpSpawnGroups
+    alias:
+    - CSpawnGroupMgrGameSystem::DumpSpawnGroups
+    - DumpSpawnGroups
+  - name: CSpawnGroupMgrGameSystem_SpawnGroupSpawnEntitiesInternal
+    alias:
+    - CSpawnGroupMgrGameSystem::SpawnGroupSpawnEntitiesInternal
+    - SpawnGroupSpawnEntitiesInternal
+  - name: IGameSystem_OnPreSpawnGroupLoad
+    alias:
+    - IGameSystem::OnPreSpawnGroupLoad
+  - name: IGameSystem_OnPostSpawnGroupLoad
+    alias:
+    - IGameSystem::OnPostSpawnGroupLoad
+  - name: CSpawnGroupMgrGameSystem_SpawnGroupShutdown
+    alias:
+    - CSpawnGroupMgrGameSystem::SpawnGroupShutdown
+    - SpawnGroupShutdown
+  - name: CSpawnGroupMgrGameSystem_SpawnGroupActuallyShutdown
+    alias:
+    - CSpawnGroupMgrGameSystem::SpawnGroupActuallyShutdown
+    - SpawnGroupActuallyShutdown
+  - name: IGameSystem_OnPreSpawnGroupUnload
+    alias:
+    - IGameSystem::OnPreSpawnGroupUnload
+  - name: IGameSystem_OnPostSpawnGroupUnload
+    alias:
+    - IGameSystem::OnPostSpawnGroupUnload
+  - name: CLoadingSpawnGroup_CreateEntityToSpawn
+    alias:
+    - CLoadingSpawnGroup::CreateEntityToSpawn
+  - name: CSpawnGroupMgrGameSystem_OnSpawnGroupPrecache
+    alias:
+    - CSpawnGroupMgrGameSystem::OnSpawnGroupPrecache
+    - SpawnGroupPrecache
+  - name: CSpawnGroupMgrGameSystem_AllocateSpawnGroup
+    alias:
+    - CSpawnGroupMgrGameSystem::AllocateSpawnGroup
+  - name: CSpawnGroupMgrGameSystem_ReleaseSpawnGroup
+    alias:
+    - CSpawnGroupMgrGameSystem::ReleaseSpawnGroup
+  - name: CSpawnGroupMgrGameSystem_SpawnGroupInit
+    alias:
+    - CSpawnGroupMgrGameSystem::SpawnGroupInit
+  - name: CSpawnGroupMgrGameSystem_CreateLoadingSpawnGroup
+    alias:
+    - CSpawnGroupMgrGameSystem::CreateLoadingSpawnGroup
+  - name: CSpawnGroupMgrGameSystem_CreateLoadingSpawnGroupForSaveFile
+    alias:
+    - CSpawnGroupMgrGameSystem::CreateLoadingSpawnGroupForSaveFile
+  - name: CSpawnGroupMgrGameSystem_SpawnGroupSpawnEntities
+    alias:
+    - CSpawnGroupMgrGameSystem::SpawnGroupSpawnEntities
+  - name: CSpawnGroupMgrGameSystem_SetActiveSpawnGroup
+    alias:
+    - CSpawnGroupMgrGameSystem::SetActiveSpawnGroup
+  - name: CSpawnGroupMgrGameSystem_UnloadSpawnGroup
+    alias:
+    - CSpawnGroupMgrGameSystem::UnloadSpawnGroup
+  - name: CSpawnGroupMgrGameSystem_SaveGame_Start
+    alias:
+    - CSpawnGroupMgrGameSystem::SaveGame_Start
+  - name: IGameSystem_OnSpawnGroupPrecache
+    alias:
+    - IGameSystem::OnSpawnGroupPrecache
+  - name: IGameSystem_OnSpawnGroupUncache
+    alias:
+    - IGameSystem::OnSpawnGroupUncache
+  - name: CBaseFilter_InputTestActivator
+    alias:
+    - CBaseFilter::InputTestActivator
+  - name: CGamePlayerEquip_InputTriggerForAllPlayers
+    alias:
+    - CGamePlayerEquip::InputTriggerForAllPlayers
+  - name: CGamePlayerEquip_InputTriggerForActivatedPlayer
+    alias:
+    - CGamePlayerEquip::InputTriggerForActivatedPlayer
+  - name: CNavMesh_GetNearestNavArea
+    alias:
+    - CNavMesh::GetNearestNavArea
+  - name: CCSBotManager_AddBot
+    alias:
+    - CCSBotManager::AddBot
+  - name: BotAdd_CommandHandler
+    alias:
+    - CCSBotManager::BotAddCommand
+  - name: BotKill_CommandHandler
+    alias:
+    - CCSBotManager::BotKillCommand
+  - name: EntInfo_CommandHandler
+    alias:
+    - CC_Ent_Info
+  - name: CEntitySystem_DestroyEntityImmediate
+    alias:
+    - CEntitySystem::DestroyEntityImmediate
+  - name: CEntitySystem_OnRemoveEntityFromDatabase
+    alias:
+    - CEntitySystem::OnRemoveEntityFromDatabase
+  - name: CEntitySystem_DoDestructEntity
+    alias:
+    - CEntitySystem::DoDestructEntity
+  - name: CEntitySystem_UpdateOnRemove
+    alias:
+    - CEntitySystem::UpdateOnRemove
+  - name: ClientPrintToController
+    alias:
+    - ClientPrint
+  - name: CCSBotManager_AddBot_BotNavIgnore
+    alias:
+    - BotNavIgnore
+  - name: CEnvHudHint_API_ShowHudHint
+    alias:
+    - CEnvHudHint_API::ShowHudHint
+  - name: UTIL_GetPlayerControllerForEntity
+    alias:
+    - UTIL_GetPlayerControllerForEntity
+  - name: CEntitySystem_ctor
+    alias:
+    - CEntitySystem::CEntitySystem
+  - name: CGameEntitySystem_ctor
+    alias:
+    - CGameEntitySystem::CGameEntitySystem
+  - name: CEntitySystem_RegisterAccessor
+    alias:
+    - CEntitySystem::RegisterAccessor
+  - name: CEntitySystem_Init
+    alias:
+    - CEntitySystem::Init
+  - name: CEntitySystem_ProcessEntityRegistration
+    alias:
+    - CEntitySystem::ProcessEntityRegistration
+  - name: CEntitySystem_PostCreateEntitySystem
+    alias:
+    - CEntitySystem::PostCreateEntitySystem
+  - name: CSource2EntitySystem_StaticInit
+    alias:
+    - CSource2EntitySystem::StaticInit
+  - name: CSpawnGroupEntityFilterRegistrar_RegisterSpawnGroupEntityFilters
+    alias:
+    - CSpawnGroupEntityFilterRegistrar::RegisterSpawnGroupEntityFilters
+  - name: CGameEntitySystem_m_spawnGroupEntityFilters
+    alias:
+    - CGameEntitySystem::m_spawnGroupEntityFilters
+  - name: CGameEntitySystem_m_pEntity2Networkables
+    alias:
+    - CGameEntitySystem::m_pEntity2Networkables
+  - name: CEntity2NetworkClasses_ServerClass_InitEntity2NetworkClasses
+    alias:
+    - CEntity2NetworkClasses<ServerClass>::InitEntity2NetworkClasses
+  - name: CEntitySystem_m_Symbols
+    alias:
+    - CEntitySystem::m_Symbols
+  - name: CEntitySystem_m_pNetworkFieldChangedEventQueue
+    alias:
+    - CEntitySystem::m_pNetworkFieldChangedEventQueue
+  - name: CEntitySystem_m_pNetworkFieldScratchData
+    alias:
+    - CEntitySystem::m_pNetworkFieldScratchData
+  - name: CEntitySystem_m_pFieldChangeLimitSpew
+    alias:
+    - CEntitySystem::m_pFieldChangeLimitSpew
+  - name: CEntitySystem_m_ComponentUnserializerInfoAllocator
+    alias:
+    - CEntitySystem::m_ComponentUnserializerInfoAllocator
+  - name: CEntitySystem_m_EntityMaterialAttributes
+    alias:
+    - CEntitySystem::m_EntityMaterialAttributes
+  - name: CEntitySystem_m_flChangeCallbackSpewThreshold
+    alias:
+    - CEntitySystem::m_flChangeCallbackSpewThreshold
+  - name: CEntitySystem_ClearEntityDatabase
+    alias:
+    - CEntitySystem::ClearEntityDatabase
+  - name: INetworkMessages_SetNetworkSerializationContextData
+    alias:
+    - INetworkMessages::SetNetworkSerializationContextData
+  - name: CFlattenedSerializers_CreateFieldChangedEventQueue
+    alias:
+    - CFlattenedSerializers::CreateFieldChangedEventQueue
+  - name: INetworkMessages_RegisterSchemaTypeOverride
+    alias:
+    - INetworkMessages::RegisterSchemaTypeOverride
+  - name: PolymorphicHelper_t__SetPolymorphicPointer
+    alias:
+    - PolymorphicHelper_t::SetPolymorphicPointer
+  - name: CSceneEntity_GetScriptDesc
+    alias:
+    - CSceneEntity::GetScriptDesc
+  - name: CEntityInstance_GetScriptDesc
+    alias:
+    - CEntityInstance::GetScriptDesc
+  - name: CEntityInstance_Spawn
+    alias:
+    - CEntityInstance::Spawn
+  - name: CEntityInstance_Activate
+    alias:
+    - CEntityInstance::Activate
+  - name: CEntityInstance_Precache
+    alias:
+    - CEntityInstance::Precache
+  - name: CEntityInstance_GetDataDescMap
+    alias:
+    - CEntityInstance::GetDataDescMap
+  - name: CEntityInstance_ReloadPrivateScripts
+    alias:
+    - CEntityInstance::ReloadPrivateScripts
+  - name: CEntityInstance_ValidatePrivateScriptScope
+    alias:
+    - CEntityInstance::ValidatePrivateScriptScope
+  - name: CEntityInstance_NetworkStateChanged
+    alias:
+    - CEntityInstance::NetworkStateChanged
+  - name: CEntityInstance_FullEdictChanged
+    alias:
+    - CEntityInstance::FullEdictChanged
+  - name: CEntityInstance_NetworkUpdateState
+    alias:
+    - CEntityInstance::NetworkUpdateState
+  - name: CEntityInstance_NetworkStateChangedLog
+    alias:
+    - CEntityInstance::NetworkStateChangedLog
+  - name: CEntityInstance_DrawDebugTextOverlays
+    alias:
+    - CEntityInstance::DrawDebugTextOverlays
+  - name: CEntityInstance_DrawEntityDebugOverlays
+    alias:
+    - CEntityInstance::DrawEntityDebugOverlays
+  - name: CEntityInstance_PostDataUpdateDelta
+    alias:
+    - CEntityInstance::PostDataUpdateDelta
+  - name: CEntityInstance_PreDataUpdate
+    alias:
+    - CEntityInstance::PreDataUpdate
+  - name: CEntityInstance_PostDataUpdate
+    alias:
+    - CEntityInstance::PostDataUpdate
+  - name: CEntityInstance_PostDataUpdatePreserve
+    alias:
+    - CEntityInstance::PostDataUpdatePreserve
+  - name: CEntityInstance_Connect
+    alias:
+    - CEntityInstance::Connect
+  - name: CEntityInstance_UpdateOnRemove
+    alias:
+    - CEntityInstance::UpdateOnRemove
+  - name: CEntityInstance_Disconnect
+    alias:
+    - CEntityInstance::Disconnect
+  - name: CEntityInstance_AddedToEntityDatabase
+    alias:
+    - CEntityInstance::AddedToEntityDatabase
+  - name: CEntityInstance_OnSetDormant
+    alias:
+    - CEntityInstance::OnSetDormant
+  - name: CEntityInstance_Schema_DynamicBinding
+    alias:
+    - CEntityInstance::Schema_DynamicBinding
+  - name: CEntitySystem_OnRemoveEntity
+    alias:
+    - CEntitySystem::OnRemoveEntity
+  - name: CEntityComponentHelperT_Free
+    alias:
+    - CEntityComponentHelperT::Free
+  - name: CScriptedSequence_SynchronizeSequence
+    alias:
+    - CScriptedSequence::SynchronizeSequence
+  - name: CNetworkUtlVectorEmbedded_NetworkStateChanged_m_vecRenderAttributes
+    alias:
+    - CNetworkUtlVectorEmbedded<CRenderAttribute>::NetworkStateChanged_m_vecRenderAttributes
+  - name: CNetworkUtlVectorEmbedded_NetworkStateChanged_m_perRoundStats
+    alias:
+    - CNetworkUtlVectorEmbedded<CSPerRoundStats_t>::NetworkStateChanged_m_perRoundStats
+  - name: CUtlVectorEmbeddedNetworkVar_CSPerRoundStats_t_NetworkVar_m_perRoundStats_SetCount
+    alias:
+    - CUtlVectorEmbeddedNetworkVar<CSPerRoundStats_t, NetworkVar>::SetCount
+  - name: CNetworkUtlVectorEmbedded_TryLateResolve_m_vecRenderAttributes
+    alias:
+    - CNetworkUtlVectorEmbedded<CRenderAttribute>::TryLateResolve
+  - name: INetworkMessages_GetLoggingChannel
+    alias:
+    - INetworkMessages::GetLoggingChannel
+  - name: CPhysicsEntitySolver_PhysEnableEntityCollisions
+    alias:
+    - CPhysicsEntitySolver::PhysEnableEntityCollisions
+  - name: CLoopModeGame_StaticInit
+    alias:
+    - CLoopModeGame::StaticInit
+  - name: CLoopModeFactory_CLoopModeGame_Init
+    alias:
+    - CLoopModeFactory<CLoopModeGame>::Init
+  - name: CLoopModeFactory_CLoopModeGame_Shutdown
+    alias:
+    - CLoopModeFactory<CLoopModeGame>::Shutdown
+  - name: CLoopModeGame_OnLoopActivate
+    alias:
+    - CLoopModeGame::OnLoopActivate
+  - name: ILoopMode_OnLoopActivate
+    alias:
+    - ILoopMode::OnLoopActivate
+  - name: CLoopModeGame_AddViewsToSceneSystem
+    alias:
+    - CLoopModeGame::AddViewsToSceneSystem
+  - name: ILoopMode_AddViewsToSceneSystem
+    alias:
+    - ILoopMode::AddViewsToSceneSystem
+  - name: CLoopModeGame_LoopInitInternal
+    alias:
+    - CLoopModeGame::LoopInitInternal
+  - name: CLoopModeGame_LoopInit
+    alias:
+    - CLoopModeGame::LoopInit
+  - name: ILoopMode_LoopInit
+    alias:
+    - ILoopMode::LoopInit
+  - name: ILoopMode_LoopShutdown
+    alias:
+    - ILoopMode::LoopShutdown
+  - name: CLoopModeGame_RegisterEventMapInternal
+    alias:
+    - CLoopModeGame::RegisterEventMapInternal
+  - name: CLoopModeGame_OnServerAdvanceTick
+    alias:
+    - CLoopModeGame::OnServerAdvanceTick
+  - name: CLoopModeGame_OnServerBeginSimulate
+    alias:
+    - CLoopModeGame::OnServerBeginSimulate
+  - name: CLoopModeGame_OnServerPostSimulate
+    alias:
+    - CLoopModeGame::OnServerPostSimulate
+  - name: CLoopModeGame_OnServerPostAdvanceTick
+    alias:
+    - CLoopModeGame::OnServerPostAdvanceTick
+  - name: CLoopModeGame_OnServerBeginAsyncPostTickWork
+    alias:
+    - CLoopModeGame::OnServerBeginAsyncPostTickWork
+  - name: CLoopModeGame_OnServerEndAsyncPostTickWork
+    alias:
+    - CLoopModeGame::OnServerEndAsyncPostTickWork
+  - name: CLoopModeGame_OnFrameBoundary
+    alias:
+    - CLoopModeGame::OnFrameBoundary
+  - name: CLoopModeGame_ReceivedServerInfo
+    alias:
+    - CLoopModeGame::ReceivedServerInfo
+  - name: CLoopModeGame_SetWorldSession
+    alias:
+    - CLoopModeGame::SetWorldSession
+  - name: CLoopModeGame_SetGameSystemState
+    alias:
+    - CLoopModeGame::SetGameSystemState
+  - name: IGameSystem_DestroyAllGameSystems
+    alias:
+    - IGameSystem::DestroyAllGameSystems
+  - name: IGameSystem_ShutdownAllSystems
+    alias:
+    - IGameSystem::ShutdownAllSystems
+  - name: IGameSystem_LoopDestroyAllSystems
+    alias:
+    - IGameSystem::LoopDestroyAllSystems
+  - name: IGameSystem_LoopPreShutdownAllSystems
+    alias:
+    - IGameSystem::LoopPreShutdownAllSystems
+  - name: CLoopModeGame_Shutdown
+    alias:
+    - CLoopModeGame::Shutdown
+  - name: CLoopModeGame_LoopShutdown
+    alias:
+    - CLoopModeGame::LoopShutdown
+  - name: CLoopModeGame_ShutdownServer
+    alias:
+    - CLoopModeGame::ShutdownServer
+  - name: CLoopModeGame_OnLoopDeactivate
+    alias:
+    - CLoopModeGame::OnLoopDeactivate
+  - name: ILoopMode_OnLoopDeactivate
+    alias:
+    - ILoopMode::OnLoopDeactivate
+  - name: CPlayerCommandQueue_ctor
+    alias:
+    - CPlayerCommandQueue::CPlayerCommandQueue
+  - name: IGameResourceService_SetEntityResourceManifestHandler
+    alias:
+    - IGameResourceService::SetEntityResourceManifestHandler
+  - name: CNetworkSerializerBindingBuildFilter_GetFieldPriority
+    alias:
+    - CNetworkSerializerBindingBuildFilter::GetFieldPriority
+  - name: CEntitySystem_FindComponentTypeByName
+    alias:
+    - CEntitySystem::FindComponentTypeByName
+- name: networksystem
+  symbols:
+  - name: INetworkMessages_GetFieldChangeCallbackOrderCount
+    alias:
+    - INetworkMessages::GetFieldChangeCallbackOrderCount
+  - name: INetworkMessages_GetFieldChangeCallbackPriorities
+    alias:
+    - INetworkMessages::GetFieldChangeCallbackPriorities

--- a/gamesymbols/14172.metadata.yaml
+++ b/gamesymbols/14172.metadata.yaml
@@ -1,0 +1,3418 @@
+modules:
+- name: scenesystem
+  symbols:
+  - name: ISceneSystem_GetWorldsInfo
+    alias:
+    - ISceneSystem::GetWorldsInfo
+  - name: ISceneWorld_GetObjectsInfo
+    alias:
+    - ISceneWorld::GetObjectsInfo
+  - name: ISceneWorld_GetWorldName
+    alias:
+    - ISceneWorld::GetWorldName
+  - name: ISceneSystem_GetObjectBounds
+    alias:
+    - ISceneSystem::GetObjectBounds
+  - name: ISceneSystem_GetObjectClassName
+    alias:
+    - ISceneSystem::GetObjectClassName
+  - name: CSceneObject_pDesc
+    alias:
+    - CSceneObject::pDesc
+  - name: CSceneObject_nFlags
+    alias:
+    - CSceneObject::nFlags
+  - name: CSceneObject_fOriginX
+    alias:
+    - CSceneObject::fOriginX
+  - name: CSceneObject_fOriginY
+    alias:
+    - CSceneObject::fOriginY
+  - name: CSceneObject_fOriginZ
+    alias:
+    - CSceneObject::fOriginZ
+  - name: CSceneObject_nClassIndex
+    alias:
+    - CSceneObject::nClassIndex
+- name: networksystem
+  symbols:
+  - name: CNetworkMessages_RegisterNetworkCategory
+    alias:
+    - CNetworkMessages::RegisterNetworkCategory
+  - name: CNetworkMessages_AssociateNetMessageWithChannelCategoryAbstract
+    alias:
+    - CNetworkMessages::AssociateNetMessageWithChannelCategoryAbstract
+  - name: CNetworkMessages_FindOrCreateNetMessage
+    alias:
+    - CNetworkMessages::FindOrCreateNetMessage
+  - name: CNetworkMessages_SerializeInternal
+    alias:
+    - CNetworkMessages::SerializeInternal
+  - name: CNetworkMessages_UnserializeMessageInternal
+    alias:
+    - CNetworkMessages::UnserializeMessageInternal
+  - name: CNetworkMessages_SerializeMessageInternal
+    alias:
+    - CNetworkMessages::SerializeMessageInternal
+  - name: CNetworkMessages_UnserializeFromStream
+    alias:
+    - CNetworkMessages::UnserializeFromStream
+  - name: CNetworkMessages_AllocateAndCopyConstructNetMessageAbstract
+    alias:
+    - CNetworkMessages::AllocateAndCopyConstructNetMessageAbstract
+  - name: CNetworkMessages_DeallocateNetMessageAbstract
+    alias:
+    - CNetworkMessages::DeallocateNetMessageAbstract
+  - name: CNetworkMessages_RegisterNetworkFieldSerializer
+    alias:
+    - CNetworkMessages::RegisterNetworkFieldSerializer
+  - name: CNetworkMessages_RegisterNetworkArrayFieldSerializer
+    alias:
+    - CNetworkMessages::RegisterNetworkArrayFieldSerializer
+  - name: CNetworkMessages_AssociateNetMessageGroupIdWithChannelCategory
+    alias:
+    - CNetworkMessages::AssociateNetMessageGroupIdWithChannelCategory
+  - name: CNetworkMessages_RegisterNetworkFieldChangeCallbackInternal
+    alias:
+    - CNetworkMessages::RegisterNetworkFieldChangeCallbackInternal
+  - name: CNetworkMessages_AllowAdditionalMessageRegistration
+    alias:
+    - CNetworkMessages::AllowAdditionalMessageRegistration
+  - name: CNetworkMessages_IsAdditionalMessageRegistrationAllowed
+    alias:
+    - CNetworkMessages::IsAdditionalMessageRegistrationAllowed
+  - name: CNetworkMessages_RegisterFieldChangeCallbackPriority
+    alias:
+    - CNetworkMessages::RegisterFieldChangeCallbackPriority
+  - name: CNetworkMessages_ComputeOrderForPriority
+    alias:
+    - CNetworkMessages::ComputeOrderForPriority
+  - name: CNetworkMessages_dtor
+    alias:
+    - CNetworkMessages::~CNetworkMessages
+  - name: CNetworkMessages_GetIsForServer
+    alias:
+    - CNetworkMessages::GetIsForServer
+  - name: CNetworkMessages_GetNetworkSerializationContextData
+    alias:
+    - CNetworkMessages::GetNetworkSerializationContextData
+  - name: CNetChan_ParseMessagesDemoInternal
+    alias:
+    - CNetChan::ParseMessagesDemoInternal
+  - name: CNetChan_ParseNetMessageShowFilter
+    alias:
+    - CNetChan::ParseNetMessageShowFilter
+  - name: CNetworkMessages_FindNetworkMessagePartial
+    alias:
+    - CNetworkMessages::FindNetworkMessagePartial
+  - name: CNetworkMessages_FindNetworkMessage
+    alias:
+    - CNetworkMessages::FindNetworkMessage
+  - name: CNetworkMessages_FindNetworkGroup
+    alias:
+    - CNetworkMessages::FindNetworkGroup
+  - name: CNetworkSystem_SendNetworkStats
+    alias:
+    - CNetworkSystem::SendNetworkStats
+  - name: CNetworkMessages_GetNetworkGroupCount
+    alias:
+    - CNetworkMessages::GetNetworkGroupCount
+  - name: CNetworkMessages_GetNetworkGroupName
+    alias:
+    - CNetworkMessages::GetNetworkGroupName
+  - name: CNetworkMessages_GetNetworkGroupColor
+    alias:
+    - CNetworkMessages::GetNetworkGroupColor
+  - name: CNetworkMessages_ConfirmAllMessageHandlersInstalled
+    alias:
+    - CNetworkMessages::ConfirmAllMessageHandlersInstalled
+- name: engine
+  symbols:
+  - name: CServerSideClient_IsHearingClient
+    alias:
+    - IsHearingClient
+  - name: CServerSideClient_ExecuteStringCommand
+    alias:
+    - CServerSideClient::ExecuteStringCommand
+  - name: CGameResourceService_BuildResourceManifest
+    alias:
+    - CGameResourceService::BuildResourceManifest
+    - BuildResourceManifest
+  - name: CGameResourceService_m_pEntitySystem
+    alias:
+    - GameEntitySystem
+  - name: CGameResourceService_LoadGameResourceManifestNamed
+    alias:
+    - CGameResourceService::LoadGameResourceManifestNamed
+  - name: CGameResourceService_LoadGameResourceManifestGroup
+    alias:
+    - CGameResourceService::LoadGameResourceManifestGroup
+  - name: CGameResourceService_GetResourceManifestDebugName
+    alias:
+    - CGameResourceService::GetResourceManifestDebugName
+  - name: CGameResourceService_PrecacheEntitiesAndConfirmResourcesAreLoaded
+    alias:
+    - CGameResourceService::PrecacheEntitiesAndConfirmResourcesAreLoaded
+  - name: CGameResourceService_LoadGameResourceManifest_IEntityResourceManifest
+    alias:
+    - CGameResourceService::LoadGameResourceManifest
+  - name: CGameResourceService_DescribeContents
+    alias:
+    - CGameResourceService::DescribeContents
+  - name: CGameResourceService_AppendToGameResourceManifest
+    alias:
+    - CGameResourceService::AppendToGameResourceManifest
+  - name: CGameResourceService_RegisterEventMap
+    alias:
+    - CGameResourceService::RegisterEventMap
+  - name: IEntityResourceManifestBuilder_BuildResourceManifest_ManifestNameOrGroupName
+    alias:
+    - IEntityResourceManifestBuilder::BuildResourceManifest
+  - name: CServerSideClientBase_ClientPrintf
+    alias:
+    - CServerSideClientBase::ClientPrintf
+    - ClientPrintf
+  - name: CNetworkGameServer_ClientList
+    alias:
+    - CNetworkGameServer::ClientList
+  - name: CNetworkGameServerBase_SendPeerList
+    alias:
+    - CNetworkGameServerBase::SendPeerList
+  - name: CNetworkGameServerBase_ConnectClient
+    alias:
+    - CNetworkGameServerBase::ConnectClient
+  - name: CNetworkGameServerBase_ServerSimulateInternal
+    alias:
+    - CNetworkGameServerBase::ServerSimulateInternal
+  - name: CNetworkGameServerBase_ServerSimulate
+    alias:
+    - CNetworkGameServerBase::ServerSimulate
+  - name: CNetworkGameServerBase_ServerPollNetworking
+    alias:
+    - CNetworkGameServerBase::ServerPollNetworking
+  - name: CNetworkGameServerBase_BroadcastMessage
+    alias:
+    - CNetworkGameServerBase::BroadcastMessage
+  - name: CNetworkGameServerBase_BroadcastPrintf
+    alias:
+    - CNetworkGameServerBase::BroadcastPrintf
+  - name: CNetworkGameServerBase_WriteDeltaEntities
+    alias:
+    - CNetworkGameServerBase::WriteDeltaEntities
+  - name: CNetworkGameServerBase_ReserveServerForQueuedGame
+    alias:
+    - CNetworkGameServerBase::ReserveServerForQueuedGame
+  - name: CNetworkGameServerBase_FinishChangeLevel
+    alias:
+    - CNetworkGameServerBase::FinishChangeLevel
+  - name: CNetworkGameServerBase_StartChangeLevel
+    alias:
+    - CNetworkGameServerBase::StartChangeLevel
+  - name: CNetworkGameServerBase_SetServerState
+    alias:
+    - CNetworkGameServerBase::SetServerState
+  - name: CNetworkGameServer_GetFreeClient
+    alias:
+    - CNetworkGameServer::GetFreeClient
+    - GetFreeClient
+  - name: CNetworkGameServerBase_CreateFakeClient
+    alias:
+    - CNetworkGameServerBase::CreateFakeClient
+  - name: CNetworkGameServerBase_UserInfoChanged
+    alias:
+    - CNetworkGameServerBase::UserInfoChanged
+  - name: CNetworkGameServerBase_GetPlayerNetworkIDString
+    alias:
+    - CNetworkGameServerBase::GetPlayerNetworkIDString
+  - name: CNetworkGameServerBase_StartHLTVMaster
+    alias:
+    - CNetworkGameServerBase::StartHLTVMaster
+  - name: CNetworkGameServerBase_RegisterLoadingSpawnGroups
+    alias:
+    - CNetworkGameServerBase::RegisterLoadingSpawnGroups
+  - name: CNetworkServerSpawnGroupCreatePrerequisites_Init
+    alias:
+    - CNetworkServerSpawnGroupCreatePrerequisites::Init
+  - name: CNetworkGameServerBase_LoadSpawnGroup
+    alias:
+    - CNetworkGameServerBase::LoadSpawnGroup
+  - name: CNetworkGameServerBase_SpawnGroupThink
+    alias:
+    - CNetworkGameServerBase::SpawnGroupThink
+  - name: CNetworkGameServerBase_PrintSpawnGroupStatus
+    alias:
+    - CNetworkGameServerBase::PrintSpawnGroupStatus
+  - name: CNetworkGameServerBase_AsyncUnloadSpawnGroup
+    alias:
+    - CNetworkGameServerBase::AsyncUnloadSpawnGroup
+  - name: CNetworkGameServerBase_AsyncUnloadSpawnGroupInternal
+    alias:
+    - CNetworkGameServerBase::AsyncUnloadSpawnGroupInternal
+  - name: CNetworkGameServer_PrepareForAssetLoad
+    alias:
+    - CNetworkGameServer::PrepareForAssetLoad
+  - name: CNetworkGameServerBase_IsSaveRestoreAllowed
+    alias:
+    - CNetworkGameServerBase::IsSaveRestoreAllowed
+  - name: CNetworkGameServerBase_Init
+    alias:
+    - CNetworkGameServerBase::Init
+  - name: CNetworkGameServerBase_Shutdown
+    alias:
+    - CNetworkGameServerBase::Shutdown
+  - name: CNetworkGameServerBase_ShutdownInternal
+    alias:
+    - CNetworkGameServerBase::ShutdownInternal
+  - name: CNetworkGameServer_ActivateServer
+    alias:
+    - CNetworkGameServer::ActivateServer
+  - name: CNetworkGameServer_DirectUpdate
+    alias:
+    - CNetworkGameServer::DirectUpdate
+  - name: CNetworkGameServer_Init
+    alias:
+    - CNetworkGameServer::Init
+  - name: CNetworkGameServer_Shutdown
+    alias:
+    - CNetworkGameServer::Shutdown
+  - name: CNetworkGameServer_SpawnServer
+    alias:
+    - CNetworkGameServer::SpawnServer
+  - name: CNetworkGameServerBase_GetMaxClients
+    alias:
+    - CNetworkGameServerBase::GetMaxClients
+  - name: CNetworkGameServerBase_SetMaxClients
+    alias:
+    - CNetworkGameServerBase::SetMaxClients
+  - name: CNetworkGameServerBase_CheckTimeouts
+    alias:
+    - CNetworkGameServerBase::CheckTimeouts
+  - name: CNetworkGameServerBase_OnKickById
+    alias:
+    - CNetworkGameServerBase::OnKickById
+  - name: CNetworkGameServerBase_OnKickByName
+    alias:
+    - CNetworkGameServerBase::OnKickByName
+  - name: CNetworkGameClient_SendMovePacket
+    alias:
+    - CNetworkGameClient::SendMovePacket
+    - SendMovePacket
+  - name: CNetworkGameClient_SendMove
+    alias:
+    - CNetworkGameClient::SendMove
+    - SendMove
+  - name: INetworkMessages_Serialize
+    alias:
+    - INetworkMessages::Serialize
+  - name: CDemoPlayer_SkipToTick
+    alias:
+    - CDemoPlayer::SkipToTick
+  - name: CDemoPlayer_PlayDemo
+    alias:
+    - CDemoPlayer::PlayDemo
+  - name: CDemoPlayer_StopPlayback
+    alias:
+    - CDemoPlayer::StopPlayback
+  - name: CDemoPlayer_StartPlayback
+    alias:
+    - CDemoPlayer::StartPlayback
+  - name: CDemoPlayer_SetIgnorePacketsForResourceLoading
+    alias:
+    - CDemoPlayer::SetIgnorePacketsForResourceLoading
+  - name: CDemoPlayer_InternalReadPacket
+    alias:
+    - CDemoPlayer::InternalReadPacket
+  - name: CDemoPlayer_Pause
+    alias:
+    - CDemoPlayer::Pause
+  - name: CDemoPlayer_m_bIsPlaying
+    alias:
+    - CDemoPlayer::m_bIsPlaying
+  - name: CDemoPlayer_m_bIsPaused
+    alias:
+    - CDemoPlayer::m_bIsPaused
+  - name: CDemoRecorder_ParseMessage
+    alias:
+    - CDemoRecorder::ParseMessage
+  - name: CDemoRecorder_WriteSpawnGroups
+    alias:
+    - CDemoRecorder::WriteSpawnGroups
+  - name: CHLTVDemoRecorder_WriteFrameImmediate
+    alias:
+    - CHLTVDemoRecorder::WriteFrameImmediate
+  - name: INetworkMessages_SerializeAbstract
+    alias:
+    - INetworkMessages::SerializeAbstract
+  - name: INetworkMessages_GetNetMessageInfo
+    alias:
+    - INetworkMessages::GetNetMessageInfo
+  - name: INetworkMessages_FindNetworkMessageById
+    alias:
+    - INetworkMessages::FindNetworkMessageById
+  - name: CNetChan_ProcessMessages
+    alias:
+    - CNetChan::ProcessMessages
+  - name: CNetChan_ParseMessagesDemo
+    alias:
+    - CNetChan::ParseMessagesDemo
+  - name: CNetworkGameClient_ProcessPacketEntitiesInternal
+    alias:
+    - CNetworkGameClient::ProcessPacketEntitiesInternal
+  - name: CNetworkGameClient_ProcessPacketEntities
+    alias:
+    - CNetworkGameClient::ProcessPacketEntities
+    - ProcessPacketEntities
+  - name: CNetworkGameClient_RecordEntityBandwidth
+    alias:
+    - CNetworkGameClient::RecordEntityBandwidth
+    - RecordEntityBandwidth
+  - name: CNetworkGameClient_PrintNetStats
+    alias:
+    - CNetworkGameClient::PrintNetStats
+  - name: CMsgSource2NetworkFlowQuality_PrintStats
+    alias:
+    - CMsgSource2NetworkFlowQuality::PrintStats
+  - name: CNetworkGameClient_SetSignonState
+    alias:
+    - CNetworkGameClient::SetSignonState
+  - name: CNetworkGameClient_ProcessReadPacketEntitiesWorkItems
+    alias:
+    - CNetworkGameClient::ProcessReadPacketEntitiesWorkItems
+  - name: CNetworkGameClient_OnPreserveEntity
+    alias:
+    - CNetworkGameClient::OnPreserveEntity
+  - name: CNetworkGameClient_GetClientNetworkable
+    alias:
+    - CNetworkGameClient::GetClientNetworkable
+  - name: CNetworkGameClient_CopyNewEntity
+    alias:
+    - CNetworkGameClient::CopyNewEntity
+  - name: CNetworkGameClient_CopyExistingEntity
+    alias:
+    - CNetworkGameClient::CopyExistingEntity
+  - name: CNetworkGameClient_OnReceivedUncompressedPacket
+    alias:
+    - CNetworkGameClient::OnReceivedUncompressedPacket
+  - name: CNetworkGameClient_Clear
+    alias:
+    - CNetworkGameClient::Clear
+  - name: CNetworkGameClient_DisconnectGame
+    alias:
+    - CNetworkGameClient::DisconnectGame
+  - name: INetworkMessages_FindNetworkGroup
+    alias:
+    - INetworkMessages::FindNetworkGroup
+  - name: INetworkClientService_IsActive
+    alias:
+    - INetworkClientService::IsActive
+  - name: INetworkClientService_IsConnected
+    alias:
+    - INetworkClientService::IsConnected
+  - name: INetworkClientService_IsPutInServer
+    alias:
+    - INetworkClientService::IsPutInServer
+  - name: INetworkClientService_IsConnecting
+    alias:
+    - INetworkClientService::IsConnecting
+  - name: CInputService_ProcessConVar
+    alias:
+    - CInputService::ProcessConVar
+  - name: CInputService_ProcessCommand
+    alias:
+    - CInputService::ProcessCommand
+  - name: CInputService_IsClientOnlyCommandAllowed
+    alias:
+    - CInputService::IsClientOnlyCommandAllowed
+  - name: CNetworkClientService_ReceivedServerInfo
+    alias:
+    - CNetworkClientService::ReceivedServerInfo
+  - name: CNetworkClientService_SplitScreenConnect
+    alias:
+    - CNetworkClientService::SplitScreenConnect
+  - name: CNetworkClientService_SendNetMessage
+    alias:
+    - CNetworkClientService::SendNetMessage
+  - name: CNetworkClientService_SendStringCmd
+    alias:
+    - CNetworkClientService::SendStringCmd
+  - name: CNetworkClientService_StartChangeLevel
+    alias:
+    - CNetworkClientService::StartChangeLevel
+  - name: CNetworkClientService_FinishChangeLevel
+    alias:
+    - CNetworkClientService::FinishChangeLevel
+  - name: CNetworkClientService_PrintConnectionStatus
+    alias:
+    - CNetworkClientService::PrintConnectionStatus
+  - name: CNetworkClientService_OnStatus
+    alias:
+    - CNetworkClientService::OnStatus
+  - name: CNetworkClientService_ServerCmd
+    alias:
+    - CNetworkClientService::ServerCmd
+  - name: CNetworkClientService_GetDisconnectReason
+    alias:
+    - CNetworkClientService::GetDisconnectReason
+  - name: CNetworkClientService_PrintSpawnGroupStatus
+    alias:
+    - CNetworkClientService::PrintSpawnGroupStatus
+  - name: CNetworkClientService_IsActive
+    alias:
+    - CNetworkClientService::IsActive
+  - name: CNetworkClientService_IsConnected
+    alias:
+    - CNetworkClientService::IsConnected
+  - name: CNetworkClientService_IsPutInServer
+    alias:
+    - CNetworkClientService::IsPutInServer
+  - name: CNetworkClientService_IsConnecting
+    alias:
+    - CNetworkClientService::IsConnecting
+  - name: CEngineSoundServices_ShouldSuppressNonUISounds
+    alias:
+    - CEngineSoundServices::ShouldSuppressNonUISounds
+  - name: CNetworkClientService_ClockDriftAdjustFrameTime
+    alias:
+    - CNetworkClientService::ClockDriftAdjustFrameTime
+  - name: CNetworkClientService_Init
+    alias:
+    - CNetworkClientService::Init
+  - name: CNetworkClientService_Shutdown
+    alias:
+    - CNetworkClientService::Shutdown
+  - name: CNetworkClientService_DisconnectGameNow
+    alias:
+    - CNetworkClientService::DisconnectGameNow
+  - name: CGameClientConnectPrerequisite_ctor
+    alias:
+    - CGameClientConnectPrerequisite::CGameClientConnectPrerequisite
+  - name: CNetworkClientService_AddClientPrerequisites
+    alias:
+    - CNetworkClientService::AddClientPrerequisites
+  - name: CNetworkClientService_AllocateRemoteConnectionClient
+    alias:
+    - CNetworkClientService::AllocateRemoteConnectionClient
+  - name: CNetworkServerService_Init
+    alias:
+    - CNetworkServerService::Init
+  - name: CNetworkServerService_StartupServer
+    alias:
+    - CNetworkServerService::StartupServer
+  - name: CNetworkServerService_RegisterEventMapInternal
+    alias:
+    - CNetworkServerService::RegisterEventMapInternal
+  - name: CNetworkServerService_OnServerAdvanceTick
+    alias:
+    - CNetworkServerService::OnServerAdvanceTick
+  - name: CNetworkServerService_OnServerPollNetworking
+    alias:
+    - CNetworkServerService::OnServerPollNetworking
+  - name: CNetworkServerService_OnServerProcessNetworking
+    alias:
+    - CNetworkServerService::OnServerProcessNetworking
+  - name: CNetworkServerService_OnServerBeginSimulate
+    alias:
+    - CNetworkServerService::OnServerBeginSimulate
+  - name: CNetworkServerService_OnServerEndSimulate
+    alias:
+    - CNetworkServerService::OnServerEndSimulate
+  - name: CNetworkServerService_OnServerPostSimulate
+    alias:
+    - CNetworkServerService::OnServerPostSimulate
+  - name: CNetworkServerService_OnServerPostAdvanceTick
+    alias:
+    - CNetworkServerService::OnServerPostAdvanceTick
+  - name: CNetworkServerService_OnFrameBoundary
+    alias:
+    - CNetworkServerService::OnFrameBoundary
+  - name: CNetworkServerService_OnClientPollNetworking
+    alias:
+    - CNetworkServerService::OnClientPollNetworking
+  - name: CNetworkServerService_OnSimpleLoopFrameUpdate
+    alias:
+    - CNetworkServerService::OnSimpleLoopFrameUpdate
+  - name: CNetworkServerService_OnKickByIdHLTV
+    alias:
+    - CNetworkServerService::OnKickByIdHLTV
+  - name: CNetworkServerService_DisconnectGameNow
+    alias:
+    - CNetworkServerService::DisconnectGameNow
+  - name: INetworkGameServer_GetMaxClients
+    alias:
+    - INetworkGameServer::GetMaxClients
+  - name: INetworkGameServer_PreWorldUpdate
+    alias:
+    - INetworkGameServer::PreWorldUpdate
+  - name: CNetworkGameServer_PreWorldUpdate
+    alias:
+    - CNetworkGameServer::PreWorldUpdate
+  - name: INetworkGameServer_ServerEndSimulate
+    alias:
+    - INetworkGameServer::ServerEndSimulate
+  - name: CNetworkGameServerBase_ServerEndSimulate
+    alias:
+    - CNetworkGameServerBase::ServerEndSimulate
+  - name: INetworkGameServer_ServerPostSimulate
+    alias:
+    - INetworkGameServer::ServerPostSimulate
+  - name: CNetworkGameServerBase_ServerPostSimulate
+    alias:
+    - CNetworkGameServerBase::ServerPostSimulate
+  - name: INetworkGameServer_ServerAdvanceTick
+    alias:
+    - INetworkGameServer::ServerAdvanceTick
+  - name: CNetworkGameServerBase_ServerAdvanceTick
+    alias:
+    - CNetworkGameServerBase::ServerAdvanceTick
+  - name: INetworkGameServer_ServerProcessNetworking
+    alias:
+    - INetworkGameServer::ServerProcessNetworking
+  - name: CNetworkGameServerBase_ServerProcessNetworking
+    alias:
+    - CNetworkGameServerBase::ServerProcessNetworking
+  - name: INetworkGameServer_GetTimescale
+    alias:
+    - INetworkGameServer::GetTimescale
+  - name: CNetworkGameServerBase_GetTimescale
+    alias:
+    - CNetworkGameServerBase::GetTimescale
+  - name: ISource2Server_PreWorldUpdate
+    alias:
+    - ISource2Server::PreWorldUpdate
+  - name: ISource2Server_OutOfGameFrameBoundary
+    alias:
+    - ISource2Server::OutOfGameFrameBoundary
+  - name: INetworkMessages_SetIsForServer
+    alias:
+    - INetworkMessages::SetIsForServer
+  - name: CRenderingWorldSession_FindOrCreateWorldSession
+    alias:
+    - CRenderingWorldSession::FindOrCreateWorldSession
+  - name: CRenderingWorldSession_GetEntityLumpForTemplate
+    alias:
+    - CRenderingWorldSession::GetEntityLumpForTemplate
+  - name: CEngineClient_GetEntityLumpForTemplate
+    alias:
+    - CEngineClient::GetEntityLumpForTemplate
+  - name: CEngineClient_FindOrCreateWorldSession
+    alias:
+    - CEngineClient::FindOrCreateWorldSession
+  - name: CEngineClient_GetStatsAppID
+    alias:
+    - CEngineClient::GetStatsAppID
+  - name: CEngineClient_DumpNetStats
+    alias:
+    - CEngineClient::DumpNetStats
+  - name: CEngineClient_ExecuteClientCmd
+    alias:
+    - CEngineClient::ExecuteClientCmd
+  - name: CEngineClient_IsPlayingDemo
+    alias:
+    - CEngineClient::IsPlayingDemo
+  - name: CInputService_ProcessCommandBuffer
+    alias:
+    - CInputService::ProcessCommandBuffer
+  - name: CInputService_ProcessCommandBuffers
+    alias:
+    - CInputService::ProcessCommandBuffers
+  - name: CInputService_HandleAnalogValueChange
+    alias:
+    - CInputService::HandleAnalogValueChange
+  - name: CInputService_HandleInputEvent
+    alias:
+    - CInputService::HandleInputEvent
+  - name: CEngineClient_ClientCmd_Unrestricted
+    alias:
+    - CEngineClient::ClientCmd_Unrestricted
+  - name: INetworkGameClient_SendStringCmd
+    alias:
+    - INetworkGameClient::SendStringCmd
+  - name: CEngineServer_MakeSpawnGroupActive
+    alias:
+    - CEngineServer::MakeSpawnGroupActive
+  - name: CEngineServer_DumpNetStats
+    alias:
+    - CEngineServer::DumpNetStats
+  - name: CEngineServer_ClientPrintf
+    alias:
+    - CEngineServer::ClientPrintf
+  - name: CEngineServer_GetFrameTimeAmnesty
+    alias:
+    - CEngineServer::GetFrameTimeAmnesty
+  - name: CEngineServer_ShowFrameTimeReport
+    alias:
+    - CEngineServer::ShowFrameTimeReport
+  - name: CEngineServer_SetFrameTimeAmnesty
+    alias:
+    - CEngineServer::SetFrameTimeAmnesty
+  - name: CEngineServer_GetSteamUniverse
+    alias:
+    - CEngineServer::GetSteamUniverse
+  - name: CEngineServer_ChangeLevel
+    alias:
+    - CEngineServer::ChangeLevel
+  - name: CMapListService_IsMapValid
+    alias:
+    - CMapListService::IsMapValid
+    - IMapListService::IsMapValid
+  - name: CEngineServer_IsMapValid
+    alias:
+    - CEngineServer::IsMapValid
+  - name: CEngineServer_PrecacheGeneric
+    alias:
+    - CEngineServer::PrecacheGeneric
+  - name: CEngineServer_ClientCommand
+    alias:
+    - CEngineServer::ClientCommand
+  - name: CEngineServer_GetClientConVarValue
+    alias:
+    - CEngineServer::GetClientConVarValue
+  - name: CEngineServer_SetFakeClientConVarValue
+    alias:
+    - CEngineServer::SetFakeClientConVarValue
+  - name: CEngineServer_CreateFakeClient
+    alias:
+    - CEngineServer::CreateFakeClient
+  - name: CEngineServer_GetPlayerInfo
+    alias:
+    - CEngineServer::GetPlayerInfo
+  - name: CEngineServer_ClientCommandKeyValues
+    alias:
+    - CEngineServer::ClientCommandKeyValues
+  - name: CLog_Print
+    alias:
+    - CLog::Print
+  - name: CEngineServer_LogPrint
+    alias:
+    - CEngineServer::LogPrint
+  - name: CEngineServer_KickClient
+    alias:
+    - CEngineServer::KickClient
+  - name: CEngineServer_IsDedicatedServer
+    alias:
+    - CEngineServer::IsDedicatedServer
+  - name: CEngineServer_GetServerGlobals
+    alias:
+    - CEngineServer::GetServerGlobals
+  - name: CEngineServer_IsLogEnabled
+    alias:
+    - CEngineServer::IsLogEnabled
+  - name: CEngineServer_ServerCommand
+    alias:
+    - CEngineServer::ServerCommand
+  - name: CLoopTypeClientSimple_ActivateEngineServices
+    alias:
+    - CLoopTypeClientServer::ActivateEngineServices
+  - name: CLoopTypeClientServer_LoopTypeInit
+    alias:
+    - CLoopTypeClientServer::LoopTypeInit
+  - name: CLoopTypeClientServer_AdvanceTime
+    alias:
+    - CLoopTypeClientServer::AdvanceTime
+  - name: CLoopTypeClientServer_Update
+    alias:
+    - CLoopTypeClientServer::Update
+  - name: CLoopTypeClientServer_ActivateLoop
+    alias:
+    - CLoopTypeClientServer::ActivateLoop
+  - name: CLoopTypeClientServer_AllocateLoopMode
+    alias:
+    - CLoopTypeClientServer::AllocateLoopMode
+  - name: CLoopTypeClientServer_WritePerfStats
+    alias:
+    - CLoopTypeClientServer::WritePerfStats
+  - name: CLoopTypeClientServer_DeactivateLoop
+    alias:
+    - CLoopTypeClientServer::DeactivateLoop
+  - name: CLoopTypeClientServer_OutputListeners
+    alias:
+    - CLoopTypeClientServer::OutputListeners
+  - name: CLoopTypeSimple_FrameUpdate
+    alias:
+    - CLoopTypeSimple::FrameUpdate
+  - name: CLoopTypeClientServerService_OnLoopActivate
+    alias:
+    - CLoopTypeClientServerService::OnLoopActivate
+  - name: CLoopTypeSimpleService_OnLoopActivate
+    alias:
+    - CLoopTypeSimpleService::OnLoopActivate
+  - name: CLoopTypeClientServerService_HandleInputEvent
+    alias:
+    - CLoopTypeClientServerService::HandleInputEvent
+  - name: ILoopMode_HandleInputEvent
+    alias:
+    - ILoopMode::HandleInputEvent
+  - name: ILoopType_AddEngineService
+    alias:
+    - ILoopType::AddEngineService
+  - name: CLoopTypeBase_DeallocateLoopMode
+    alias:
+    - CLoopTypeBase::DeallocateLoopMode
+  - name: CLoopTypeBase_EngineLoop
+    alias:
+    - CLoopTypeBase::EngineLoop
+  - name: CLoopTypeBase_FrameUpdate
+    alias:
+    - CLoopTypeBase::FrameUpdate
+  - name: CLoopTypeBase_ActivateLoop
+    alias:
+    - CLoopTypeBase::ActivateLoop
+  - name: CLoopTypeBase_AllocateLoopMode
+    alias:
+    - CLoopTypeBase::AllocateLoopMode
+  - name: CLoopTypeBase_DeactivateLoop
+    alias:
+    - CLoopTypeBase::DeactivateLoop
+  - name: CLoopTypeBase_LoopTypeInit
+    alias:
+    - CLoopTypeBase::LoopTypeInit
+  - name: CLoopTypeBase_LoopTypeShutdown
+    alias:
+    - CLoopTypeBase::LoopTypeShutdown
+  - name: CLoopTypeBase_GetClientServerMode
+    alias:
+    - CLoopTypeBase::GetClientServerMode
+  - name: CLoopTypeBase_GetImplType
+    alias:
+    - CLoopTypeBase::GetImplType
+  - name: CLoopTypeBase_AddDependentServices
+    alias:
+    - CLoopTypeBase::AddDependentServices
+  - name: CLoopTypeBase_GenerateServiceDependencies
+    alias:
+    - CLoopTypeBase::GenerateServiceDependencies
+  - name: CLoopTypeBase_GenerateSecondaryDependencies
+    alias:
+    - CLoopTypeBase::GenerateSecondaryDependencies
+  - name: CLoopTypeBase_LoadDependentServices
+    alias:
+    - CLoopTypeBase::LoadDependentServices
+  - name: IEngineService_GetServiceDependencies
+    alias:
+    - IEngineService::GetServiceDependencies
+  - name: IEngineService_GetName
+    alias:
+    - IEngineService::GetName
+  - name: ILoopModeFactory_GetLoopModeType
+    alias:
+    - ILoopModeFactory::GetLoopModeType
+  - name: ILoopModeFactory_Shutdown
+    alias:
+    - ILoopModeFactory::Shutdown
+  - name: CEngineServiceMgr_RegisterEngineService
+    alias:
+    - CEngineServiceMgr::RegisterEngineService
+  - name: CEngineServiceMgr_RegisterLoopMode
+    alias:
+    - CEngineServiceMgr::RegisterLoopMode
+  - name: CEngineServiceMgr_UnregisterLoopMode
+    alias:
+    - CEngineServiceMgr::UnregisterLoopMode
+  - name: CEngineServiceMgr_UnregisterEngineService
+    alias:
+    - CEngineServiceMgr::UnregisterEngineService
+  - name: CEngineServiceMgr_SwitchToLoop
+    alias:
+    - CEngineServiceMgr::SwitchToLoop
+  - name: CEngineServiceMgr_PrintStatus
+    alias:
+    - CEngineServiceMgr::PrintStatus
+  - name: CEngineServiceMgr__MainLoop
+    alias:
+    - CEngineServiceMgr::_MainLoop
+  - name: CEngineServiceMgr_DeactivateLoop
+    alias:
+    - CEngineServiceMgr::DeactivateLoop
+  - name: CEngineServiceMgr_Shutdown
+    alias:
+    - CEngineServiceMgr::Shutdown
+  - name: CEngineServiceMgr_GetActiveLoopClientServerMode
+    alias:
+    - CEngineServiceMgr::GetActiveLoopClientServerMode
+  - name: CEngineServiceMgr_GetEventDispatcher
+    alias:
+    - CEngineServiceMgr::GetEventDispatcher
+  - name: CEngineGameUI_Shutdown
+    alias:
+    - CEngineGameUI::Shutdown
+  - name: IAppSystem_Shutdown
+    alias:
+    - IAppSystem::Shutdown
+  - name: CSplitScreenService_AddSplitScreenUser
+    alias:
+    - CSplitScreenService::AddSplitScreenUser
+  - name: CSplitScreenService_LoadUserConfiguration
+    alias:
+    - CSplitScreenService::LoadUserConfiguration
+  - name: CHLTVClient_ProcessSetConVar
+    alias:
+    - CHLTVClient::ProcessSetConVar
+  - name: CHLTVBroadcast_RecordSnapshot
+    alias:
+    - CHLTVBroadcast::RecordSnapshot
+  - name: CServerSideClientBase_ProcessTick
+    alias:
+    - CServerSideClientBase::ProcessTick
+  - name: CServerSideClientBase_ProcessStringCmd
+    alias:
+    - CServerSideClientBase::ProcessStringCmd
+  - name: CServerSideClientBase_MarkSpawnGroupLoadCompleted
+    alias:
+    - CServerSideClientBase::MarkSpawnGroupLoadCompleted
+  - name: CServerSideClientBase_ProcessSpawnGroup_LoadCompleted
+    alias:
+    - CServerSideClientBase::ProcessSpawnGroup_LoadCompleted
+  - name: CServerSideClientBase_ProcessClientInfo
+    alias:
+    - CServerSideClientBase::ProcessClientInfo
+  - name: CServerSideClientBase_ProcessBaselineAck
+    alias:
+    - CServerSideClientBase::ProcessBaselineAck
+  - name: CServerSideClientBase_ProcessSplitPlayerConnectInternal
+    alias:
+    - CServerSideClientBase::ProcessSplitPlayerConnectInternal
+  - name: CServerSideClientBase_ProcessSplitPlayerConnect
+    alias:
+    - CServerSideClientBase::ProcessSplitPlayerConnect
+  - name: CServerSideClientBase_GetUserIDString
+    alias:
+    - CServerSideClientBase::GetUserIDString
+  - name: CServerSideClientBase_GetNetworkIDString
+    alias:
+    - CServerSideClientBase::GetNetworkIDString
+  - name: CServerSideClientBase_Connect
+    alias:
+    - CServerSideClientBase::Connect
+  - name: CServerSideClientBase_GetPlayerInfo
+    alias:
+    - CServerSideClientBase::GetPlayerInfo
+  - name: CNetworkGameServer_GetPlayerNetworkIDString
+    alias:
+    - CNetworkGameServer::GetPlayerNetworkIDString
+  - name: CNetworkGameServerBase_RemoveClientFromGame
+    alias:
+    - CNetworkGameServerBase::RemoveClientFromGame
+  - name: CEngineServer_GetPlayerNetworkIDString
+    alias:
+    - CEngineServer::GetPlayerNetworkIDString
+  - name: CNetworkGameClientBase_ServerCmd
+    alias:
+    - CNetworkGameClientBase::ServerCmd
+  - name: CNetworkGameClientBase_ProcessSetConVar
+    alias:
+    - CNetworkGameClientBase::ProcessSetConVar
+  - name: CNetworkGameClientBase_SendStringCmd
+    alias:
+    - CNetworkGameClientBase::SendStringCmd
+  - name: CNetworkGameClientBase_StartChangeLevel
+    alias:
+    - CNetworkGameClientBase::StartChangeLevel
+  - name: CNetworkGameClientBase_FinishChangeLevel
+    alias:
+    - CNetworkGameClientBase::FinishChangeLevel
+  - name: CNetworkGameClientBase_DeferActivate
+    alias:
+    - CNetworkGameClientBase::DeferActivate
+  - name: CNetworkGameClientBase_ClockDrift_AdjustFrameTime
+    alias:
+    - CNetworkGameClientBase::ClockDrift_AdjustFrameTime
+  - name: CNetworkGameClientBase_Connect
+    alias:
+    - CNetworkGameClientBase::Connect
+  - name: CNetworkGameClientBase_DisconnectGame
+    alias:
+    - CNetworkGameClientBase::DisconnectGame
+  - name: CNetSupportImpl_Connect
+    alias:
+    - CNetSupportImpl::Connect
+- name: client
+  symbols:
+  - name: CLoopModeGame_RegisterEventMapInternal
+    alias:
+    - CLoopModeGame::RegisterEventMapInternal
+  - name: CLoopModeGame_OnClientPollNetworking
+    alias:
+    - CLoopModeGame::OnClientPollNetworking
+  - name: CLoopModeGame_OnClientAdvanceTick
+    alias:
+    - CLoopModeGame::OnClientAdvanceTick
+  - name: CLoopModeGame_OnClientPostAdvanceTick
+    alias:
+    - CLoopModeGame::OnClientPostAdvanceTick
+  - name: CLoopModeGame_OnClientPreSimulate
+    alias:
+    - CLoopModeGame::OnClientPreSimulate
+  - name: CLoopModeGame_OnClientPreOutput
+    alias:
+    - CLoopModeGame::OnClientPreOutput
+  - name: CLoopModeGame_OnClientPreOutputParallelWithServer
+    alias:
+    - CLoopModeGame::OnClientPreOutputParallelWithServer
+  - name: CLoopModeGame_OnClientPostOutput
+    alias:
+    - CLoopModeGame::OnClientPostOutput
+  - name: CLoopModeGame_OnClientFrameSimulate
+    alias:
+    - CLoopModeGame::OnClientFrameSimulate
+  - name: CLoopModeGame_OnClientAdvanceNonRenderedFrame
+    alias:
+    - CLoopModeGame::OnClientAdvanceNonRenderedFrame
+  - name: CLoopModeGame_OnClientPostSimulate
+    alias:
+    - CLoopModeGame::OnClientPostSimulate
+  - name: CLoopModeGame_OnClientPauseSimulate
+    alias:
+    - CLoopModeGame::OnClientPauseSimulate
+  - name: CLoopModeGame_OnClientSimulate
+    alias:
+    - CLoopModeGame::OnClientSimulate
+  - name: CLoopModeGame_OnPostDataUpdate
+    alias:
+    - CLoopModeGame::OnPostDataUpdate
+  - name: CLoopModeGame_OnPreDataUpdate
+    alias:
+    - CLoopModeGame::OnPreDataUpdate
+  - name: CLoopModeGame_OnFrameBoundary
+    alias:
+    - CLoopModeGame::OnFrameBoundary
+  - name: CLoopModeGame_StaticInit
+    alias:
+    - CLoopModeGame::StaticInit
+  - name: CLoopModeFactory_CLoopModeGame_Init
+    alias:
+    - CLoopModeFactory<CLoopModeGame>::Init
+  - name: CLoopModeFactory_CLoopModeGame_Shutdown
+    alias:
+    - CLoopModeFactory<CLoopModeGame>::Shutdown
+  - name: CLoopModeGame_OnLoopActivate
+    alias:
+    - CLoopModeGame::OnLoopActivate
+  - name: ILoopMode_OnLoopActivate
+    alias:
+    - ILoopMode::OnLoopActivate
+  - name: CLoopModeGame_AddViewsToSceneSystem
+    alias:
+    - CLoopModeGame::AddViewsToSceneSystem
+  - name: ILoopMode_AddViewsToSceneSystem
+    alias:
+    - ILoopMode::AddViewsToSceneSystem
+  - name: CLoopModeGame_LoopInitInternal
+    alias:
+    - CLoopModeGame::LoopInitInternal
+  - name: CLoopModeGame_LoopInit
+    alias:
+    - CLoopModeGame::LoopInit
+  - name: ILoopMode_LoopInit
+    alias:
+    - ILoopMode::LoopInit
+  - name: ILoopMode_LoopShutdown
+    alias:
+    - ILoopMode::LoopShutdown
+  - name: CLoopModeGame_ReceivedServerInfo
+    alias:
+    - CLoopModeGame::ReceivedServerInfo
+  - name: CLoopModeGame_RegisterEventMap
+    alias:
+    - CLoopModeGame::RegisterEventMap
+  - name: ILoopMode_RegisterEventMap
+    alias:
+    - ILoopMode::RegisterEventMap
+  - name: CLoopModeGame_SetWorldSession
+    alias:
+    - CLoopModeGame::SetWorldSession
+  - name: CLoopModeGame_SetGameSystemState
+    alias:
+    - CLoopModeGame::SetGameSystemState
+  - name: CLoopModeGame_LoopShutdown
+    alias:
+    - CLoopModeGame::LoopShutdown
+  - name: IGameSystem_AddByName
+    alias:
+    - IGameSystem::AddByName
+  - name: IGameSystem_Add
+    alias:
+    - IGameSystem::Add
+  - name: IGameSystem_PostInit
+    alias:
+    - IGameSystem::PostInit
+  - name: IGameSystem_InitAllSystems
+    alias:
+    - IGameSystem::InitAllSystems
+  - name: IGameSystem_LoopInitAllSystems
+    alias:
+    - IGameSystem::LoopInitAllSystems
+  - name: IGameSystemFactory_PostInit
+    alias:
+    - IGameSystemFactory::PostInit
+  - name: IGameSystemFactory_GetStaticGameSystem
+    alias:
+    - IGameSystemFactory::GetStaticGameSystem
+  - name: IGameSystemFactory_ShouldAutoAdd
+    alias:
+    - IGameSystemFactory::ShouldAutoAdd
+  - name: IGameSystemFactory_CreateGameSystem
+    alias:
+    - IGameSystemFactory::CreateGameSystem
+  - name: IGameSystemFactory_IsReallocating
+    alias:
+    - IGameSystemFactory::IsReallocating
+  - name: IGameSystem_SetName
+    alias:
+    - IGameSystem::SetName
+  - name: CSpawnGroupMgrGameSystem_DoesGameSystemReallocate
+    alias:
+    - IGameSystem::DoesGameSystemReallocate
+  - name: IGameSystem_DestroyAllGameSystems
+    alias:
+    - IGameSystem::DestroyAllGameSystems
+  - name: IGameSystem_ShutdownAllSystems
+    alias:
+    - IGameSystem::ShutdownAllSystems
+  - name: IGameSystem_LoopDestroyAllSystems
+    alias:
+    - IGameSystem::LoopDestroyAllSystems
+  - name: IGameSystem_LoopPreShutdownAllSystems
+    alias:
+    - IGameSystem::LoopPreShutdownAllSystems
+  - name: IGameSystem_OnClientPollNetworking
+    alias:
+    - IGameSystem::OnClientPollNetworking
+  - name: IGameSystem_OnClientGamePostSimulate
+    alias:
+    - IGameSystem::ClientGamePostSimulate
+  - name: IGameSystem_OnClientPauseSimulate
+    alias:
+    - IGameSystem::OnClientPauseSimulate
+  - name: IGameSystem_OnClientPreUpdate
+    alias:
+    - IGameSystem::OnClientPreUpdate
+  - name: IGameSystem_OnClientPostUpdate
+    alias:
+    - IGameSystem::OnClientPostUpdate
+  - name: IGameSystem_OnClientPostDataUpdate
+    alias:
+    - IGameSystem::OnClientPostDataUpdate
+  - name: IGameSystem_OnGameFrameBoundary
+    alias:
+    - IGameSystem::OnGameFrameBoundary
+  - name: IGameSystem_OnClientAdvanceNonRenderedFrame
+    alias:
+    - IGameSystem::OnClientAdvanceNonRenderedFrame
+  - name: IGameSystem_OnClientFrameSimulate
+    alias:
+    - IGameSystem::OnClientFrameSimulate
+  - name: IGameSystem_OnClientAdvanceTick
+    alias:
+    - IGameSystem::ClientAdvanceTick
+  - name: IGameSystem_OnClientPostAdvanceTick
+    alias:
+    - IGameSystem::ClientPostAdvanceTick
+  - name: IGameSystem_OnClientPostRender
+    alias:
+    - IGameSystem::OnClientPostRender
+  - name: IGameSystem_OnClientPreRender
+    alias:
+    - IGameSystem::OnClientPreRender
+  - name: IGameSystem_OnClientPreRenderAlt
+    alias:
+    - IGameSystem::OnClientPreRenderAlt
+  - name: CSource2Client_Connect
+    alias:
+    - CSource2Client::Connect
+  - name: CBasePlayerController_CheckForLocalPlayer
+    alias:
+    - CBasePlayerController::CheckForLocalPlayer
+  - name: CSource2Client_OnDisconnect
+    alias:
+    - CSource2Client::OnDisconnect
+  - name: IGameSystem_OnClientDisconnect
+    alias:
+    - IGameSystem::OnClientDisconnect
+  - name: IGameSystem_OnClientPreEntityThink
+    alias:
+    - IGameSystem::OnClientPreEntityThink
+  - name: CNetworkGameClient_OnSource1Source1LegacyGameEvent
+    alias:
+    - CNetworkGameClient::OnSource1Source1LegacyGameEvent
+  - name: CMapAnNodeManager_FireGameEvent
+    alias:
+    - CMapAnNodeManager::FireGameEvent
+  - name: C_ServerVoiceHandler_OnServerVoiceData
+    alias:
+    - C_ServerVoiceHandler::OnServerVoiceData
+  - name: IVEngineClient2_IsPlayingDemo
+    alias:
+    - IVEngineClient2::IsPlayingDemo
+  - name: IVEngineClient2_ExecuteClientCmd
+    alias:
+    - IVEngineClient2::ExecuteClientCmd
+  - name: IGameEventManager2_UnserializeEvent
+    alias:
+    - IGameEventManager2::UnserializeEvent
+  - name: IGameEventManager2_FireEventClientSide
+    alias:
+    - IGameEventManager2::FireEventClientSide
+  - name: CGameEventManager_FireEventClientSide
+    alias:
+    - CGameEventManager::FireEventClientSide
+  - name: CGameEventManager_UnserializeEvent
+    alias:
+    - CGameEventManager::UnserializeEvent
+  - name: CSteamworksGameStats_OnReceivedSessionID
+    alias:
+    - CSteamworksGameStats::OnReceivedSessionID
+  - name: IGameSystem_GetName
+    alias:
+    - IGameSystem::GetName
+  - name: IGameSystemFactory_DestroyGameSystem
+    alias:
+    - IGameSystemFactory::DestroyGameSystem
+  - name: IGameSystemFactory_Init
+    alias:
+    - IGameSystemFactory::Init
+  - name: IGameSystemFactory_GetPriority
+    alias:
+    - IGameSystemFactory::GetPriority
+  - name: IGameSystemFactory_Shutdown
+    alias:
+    - IGameSystemFactory::Shutdown
+  - name: IGameSystemFactory_SetGlobalPtr
+    alias:
+    - IGameSystemFactory::SetGlobalPtr
+  - name: CPrediction_PostNetworkDataReceived
+    alias:
+    - CPrediction::PostNetworkDataReceived
+  - name: IEngineServiceMgr_GetActiveLoopClientServerMode
+    alias:
+    - IEngineServiceMgr::GetActiveLoopClientServerMode
+  - name: IEngineServiceMgr_GetEventDispatcher
+    alias:
+    - IEngineServiceMgr::GetEventDispatcher
+  - name: ClientModeCSNormal_Update
+    alias:
+    - ClientModeCSNormal::Update
+  - name: CEntitySystem_ctor
+    alias:
+    - CEntitySystem::CEntitySystem
+  - name: CGameEntitySystem_ctor
+    alias:
+    - CGameEntitySystem::CGameEntitySystem
+  - name: CEntitySystem_Init
+    alias:
+    - CEntitySystem::Init
+  - name: CEntitySystem_PostCreateEntitySystem
+    alias:
+    - CEntitySystem::PostCreateEntitySystem
+  - name: CSource2EntitySystem_StaticInit
+    alias:
+    - CSource2EntitySystem::StaticInit
+  - name: CGameSystemReallocatingFactory_CSource2EntitySystem_Init
+    alias:
+    - CGameSystemReallocatingFactory<CSource2EntitySystem>::Init
+  - name: CGameSystemReallocatingFactory_CSource2EntitySystem_CreateGameSystem
+    alias:
+    - CGameSystemReallocatingFactory<CSource2EntitySystem>::CreateGameSystem
+  - name: CSkeletonInstance_PostDataUpdate
+    alias:
+    - CSkeletonInstance::PostDataUpdate
+  - name: CSkeletonInstance_m_modelState
+    alias:
+    - CSkeletonInstance::m_modelState
+  - name: CSkeletonInstance_m_modelState_m_hModel
+    alias:
+    - CSkeletonInstance::m_modelState.m_hModel
+  - name: CModelState_SetupJointState
+    alias:
+    - CModelState::SetupJointState
+  - name: CModelState_m_nTotalTransformCount
+    alias:
+    - CModelState::m_nTotalTransformCount
+  - name: CModelState_m_nBoneCount
+    alias:
+    - CModelState::m_nBoneCount
+  - name: CModelState_m_nAttachmentCount
+    alias:
+    - CModelState::m_nAttachmentCount
+  - name: IVEngineClient2_GetNetworkClient
+    alias:
+    - IVEngineClient2::GetNetworkClient
+  - name: INetworkClient_GetLocalAddress
+    alias:
+    - INetworkClient::GetLocalAddress
+  - name: INetworkClientService_IsConnected
+    alias:
+    - INetworkClientService::IsConnected
+  - name: INetworkClientService_SendNetMessage
+    alias:
+    - INetworkClientService::SendNetMessage
+  - name: C_GameRules_ctor
+    alias:
+    - C_GameRules::C_GameRules
+  - name: IGameResourceService_SetEntityResourceManifestHandler
+    alias:
+    - IGameResourceService::SetEntityResourceManifestHandler
+  - name: CNetworkSerializerBindingBuildFilter_GetFieldPriority
+    alias:
+    - CNetworkSerializerBindingBuildFilter::GetFieldPriority
+  - name: GameStateAPI_RegisterAPIs
+    alias:
+    - GameStateAPI::RegisterAPIs
+  - name: GameStateAPI_IsLatched
+    alias:
+    - GameStateAPI::IsLatched
+  - name: GameStateAPI_GetPlayerSlot
+    alias:
+    - GameStateAPI::GetPlayerSlot
+  - name: GameStateAPI_GetPlayerName
+    alias:
+    - GameStateAPI::GetPlayerName
+  - name: GameStateAPI_GetPlayerXuidStringFromPlayerSlot
+    alias:
+    - GameStateAPI::GetPlayerXuidStringFromPlayerSlot
+  - name: GameStateAPI_GetLocalPlayerXuid
+    alias:
+    - GameStateAPI::GetLocalPlayerXuid
+  - name: GameStateAPI_GetLocalOrInEyePlayerXuid
+    alias:
+    - GameStateAPI::GetLocalOrInEyePlayerXuid
+  - name: GameStateAPI_GetHudPlayerXuid
+    alias:
+    - GameStateAPI::GetHudPlayerXuid
+  - name: GameStateAPI_GetPlayerTeamName
+    alias:
+    - GameStateAPI::GetPlayerTeamName
+  - name: GameStateAPI_GetPlayerTeamNumber
+    alias:
+    - GameStateAPI::GetPlayerTeamNumber
+  - name: GameStateAPI_GetCoachingTeamNumber
+    alias:
+    - GameStateAPI::GetCoachingTeamNumber
+  - name: GameStateAPI_GetAssociatedTeamNumber
+    alias:
+    - GameStateAPI::GetAssociatedTeamNumber
+  - name: GameStateAPI_IsPlayerConnected
+    alias:
+    - GameStateAPI::IsPlayerConnected
+  - name: GameStateAPI_IsPlayerAlive
+    alias:
+    - GameStateAPI::IsPlayerAlive
+  - name: GameStateAPI_GetPlayerPing
+    alias:
+    - GameStateAPI::GetPlayerPing
+  - name: GameStateAPI_GetPlayerKills
+    alias:
+    - GameStateAPI::GetPlayerKills
+  - name: GameStateAPI_GetPlayerRoundKills
+    alias:
+    - GameStateAPI::GetPlayerRoundKills
+  - name: GameStateAPI_GetPlayerAssists
+    alias:
+    - GameStateAPI::GetPlayerAssists
+  - name: GameStateAPI_GetPlayerDeaths
+    alias:
+    - GameStateAPI::GetPlayerDeaths
+  - name: GameStateAPI_GetPlayerMVPs
+    alias:
+    - GameStateAPI::GetPlayerMVPs
+  - name: GameStateAPI_GetPlayerMoney
+    alias:
+    - GameStateAPI::GetPlayerMoney
+  - name: GameStateAPI_GetPlayerScore
+    alias:
+    - GameStateAPI::GetPlayerScore
+  - name: GameStateAPI_GetPlayerClanTag
+    alias:
+    - GameStateAPI::GetPlayerClanTag
+  - name: GameStateAPI_GetPlayerActiveCoinRank
+    alias:
+    - GameStateAPI::GetPlayerActiveCoinRank
+  - name: GameStateAPI_GetPlayerCompetitiveRankType
+    alias:
+    - GameStateAPI::GetPlayerCompetitiveRankType
+  - name: GameStateAPI_GetPlayerCompetitiveRanking
+    alias:
+    - GameStateAPI::GetPlayerCompetitiveRanking
+  - name: GameStateAPI_GetPlayerCompetitiveWins
+    alias:
+    - GameStateAPI::GetPlayerCompetitiveWins
+  - name: GameStateAPI_GetPlayerPremierRankStatsObject
+    alias:
+    - GameStateAPI::GetPlayerPremierRankStatsObject
+  - name: GameStateAPI_GetPlayerDisplayFlairItem
+    alias:
+    - GameStateAPI::GetPlayerDisplayFlairItem
+  - name: GameStateAPI_GetPlayerStatus
+    alias:
+    - GameStateAPI::GetPlayerStatus
+  - name: GameStateAPI_IsFakePlayer
+    alias:
+    - GameStateAPI::IsFakePlayer
+  - name: GameStateAPI_GetPlayerActiveWeaponItemId
+    alias:
+    - GameStateAPI::GetPlayerActiveWeaponItemId
+  - name: GameStateAPI_IsXuidValid
+    alias:
+    - GameStateAPI::IsXuidValid
+  - name: GameStateAPI_GetPlayerVoiceVolume
+    alias:
+    - GameStateAPI::GetPlayerVoiceVolume
+  - name: GameStateAPI_SetPlayerVoiceVolume
+    alias:
+    - GameStateAPI::SetPlayerVoiceVolume
+  - name: GameStateAPI_GetMapsInMapGroup
+    alias:
+    - GameStateAPI::GetMapsInMapGroup
+  - name: GameStateAPI_GetMapDisplayNameToken
+    alias:
+    - GameStateAPI::GetMapDisplayNameToken
+  - name: GameStateAPI_GetMapsInCurrentMapGroup
+    alias:
+    - GameStateAPI::GetMapsInCurrentMapGroup
+  - name: GameStateAPI_GetPlayerLifetime
+    alias:
+    - GameStateAPI::GetPlayerLifetime
+  - name: GameStateAPI_GetPlayerColor
+    alias:
+    - GameStateAPI::GetPlayerColor
+  - name: GameStateAPI_GetPlayerXpLevel
+    alias:
+    - GameStateAPI::GetPlayerXpLevel
+  - name: GameStateAPI_GetPlayerXpTrailLevel
+    alias:
+    - GameStateAPI::GetPlayerXpTrailLevel
+  - name: GameStateAPI_GetPlayerCommendsLeader
+    alias:
+    - GameStateAPI::GetPlayerCommendsLeader
+  - name: GameStateAPI_GetPlayerCommendsTeacher
+    alias:
+    - GameStateAPI::GetPlayerCommendsTeacher
+  - name: GameStateAPI_GetPlayerCommendsFriendly
+    alias:
+    - GameStateAPI::GetPlayerCommendsFriendly
+  - name: GameStateAPI_HasCommunicationAbuseMute
+    alias:
+    - GameStateAPI::HasCommunicationAbuseMute
+  - name: GameStateAPI_HasCommunicationBan
+    alias:
+    - GameStateAPI::HasCommunicationBan
+  - name: GameStateAPI_ShouldShowHudElements
+    alias:
+    - GameStateAPI::ShouldShowHudElements
+  - name: GameStateAPI_IsQueuedMatchmaking
+    alias:
+    - GameStateAPI::IsQueuedMatchmaking
+  - name: GameStateAPI_GetKickTargets
+    alias:
+    - GameStateAPI::GetKickTargets
+  - name: GameStateAPI_GetPlayerCharacterItemID
+    alias:
+    - GameStateAPI::GetPlayerCharacterItemID
+  - name: GameStateAPI_GetCharacterDefaultCheerByXuid
+    alias:
+    - GameStateAPI::GetCharacterDefaultCheerByXuid
+  - name: GameStateAPI_GetCharacterDefaultDefeatByXuid
+    alias:
+    - GameStateAPI::GetCharacterDefaultDefeatByXuid
+  - name: GameStateAPI_ArePlayersEnemies
+    alias:
+    - GameStateAPI::ArePlayersEnemies
+  - name: GameStateAPI_GetCSGOGameUIStateName
+    alias:
+    - GameStateAPI::GetCSGOGameUIStateName
+  - name: GameStateAPI_IsLocalPlayerPlayingMatch
+    alias:
+    - GameStateAPI::IsLocalPlayerPlayingMatch
+  - name: GameStateAPI_IsConnectedOrConnectingToServer
+    alias:
+    - GameStateAPI::IsConnectedOrConnectingToServer
+  - name: GameStateAPI_AreTeamsPlayingSwitchedSides
+    alias:
+    - GameStateAPI::AreTeamsPlayingSwitchedSides
+  - name: GameStateAPI_AreTeamsPlayingSwitchedSidesInRound
+    alias:
+    - GameStateAPI::AreTeamsPlayingSwitchedSidesInRound
+  - name: GameStateAPI_IsReportCategoryEnabledForSelectedPlayer
+    alias:
+    - GameStateAPI::IsReportCategoryEnabledForSelectedPlayer
+  - name: GameStateAPI_SubmitPlayerReport
+    alias:
+    - GameStateAPI::SubmitPlayerReport
+  - name: GameStateAPI_SubmitServerReport
+    alias:
+    - GameStateAPI::SubmitServerReport
+  - name: GameStateAPI_QueryServersForCommendation
+    alias:
+    - GameStateAPI::QueryServersForCommendation
+  - name: GameStateAPI_GetCommendationTokensAvailable
+    alias:
+    - GameStateAPI::GetCommendationTokensAvailable
+  - name: GameStateAPI_GetMyCommendationsJSOForUser
+    alias:
+    - GameStateAPI::GetMyCommendationsJSOForUser
+  - name: GameStateAPI_SubmitCommendation
+    alias:
+    - GameStateAPI::SubmitCommendation
+  - name: GameStateAPI_IsSelectedPlayerMuted
+    alias:
+    - GameStateAPI::IsSelectedPlayerMuted
+  - name: GameStateAPI_ToggleMute
+    alias:
+    - GameStateAPI::ToggleMute
+  - name: GameStateAPI_GetCrosshairCode
+    alias:
+    - GameStateAPI::GetCrosshairCode
+  - name: GameStateAPI_IsDemoOrHltv
+    alias:
+    - GameStateAPI::IsDemoOrHltv
+  - name: GameStateAPI_IsOverwatch
+    alias:
+    - GameStateAPI::IsOverwatch
+  - name: GameStateAPI_IsLocalPlayerWatchingOwnDemo
+    alias:
+    - GameStateAPI::IsLocalPlayerWatchingOwnDemo
+  - name: GameStateAPI_IsLocalPlayerHLTV
+    alias:
+    - GameStateAPI::IsLocalPlayerHLTV
+  - name: GameStateAPI_IsHLTVAutodirectorOn
+    alias:
+    - GameStateAPI::IsHLTVAutodirectorOn
+  - name: GameStateAPI_SetCasterIsCameraman
+    alias:
+    - GameStateAPI::SetCasterIsCameraman
+  - name: GameStateAPI_SetCasterIsHeard
+    alias:
+    - GameStateAPI::SetCasterIsHeard
+  - name: GameStateAPI_SetCasterControlsXray
+    alias:
+    - GameStateAPI::SetCasterControlsXray
+  - name: GameStateAPI_SetCasterControlsUI
+    alias:
+    - GameStateAPI::SetCasterControlsUI
+  - name: GameStateAPI_GetServerName
+    alias:
+    - GameStateAPI::GetServerName
+  - name: GameStateAPI_GetMapName
+    alias:
+    - GameStateAPI::GetMapName
+  - name: GameStateAPI_GetTournamentEventStage
+    alias:
+    - GameStateAPI::GetTournamentEventStage
+  - name: GameStateAPI_GetGameModeInternalName
+    alias:
+    - GameStateAPI::GetGameModeInternalName
+  - name: GameStateAPI_GetGameModeImagePath
+    alias:
+    - GameStateAPI::GetGameModeImagePath
+  - name: GameStateAPI_GetGameModeName
+    alias:
+    - GameStateAPI::GetGameModeName
+  - name: GameStateAPI_GetViewerCount
+    alias:
+    - GameStateAPI::GetViewerCount
+  - name: GameStateAPI_GetMapBSPName
+    alias:
+    - GameStateAPI::GetMapBSPName
+  - name: GameStateAPI_IsQueuedMatchmakingMode_Team
+    alias:
+    - GameStateAPI::IsQueuedMatchmakingMode_Team
+  - name: GameStateAPI_HasHalfTime
+    alias:
+    - GameStateAPI::HasHalfTime
+  - name: GameStateAPI_GetPlayerModel
+    alias:
+    - GameStateAPI::GetPlayerModel
+  - name: GameStateAPI_GetAllPlayersMatchDataJSO
+    alias:
+    - GameStateAPI::GetAllPlayersMatchDataJSO
+  - name: GameStateAPI_GetPlayerDataJSO
+    alias:
+    - GameStateAPI::GetPlayerDataJSO
+  - name: GameStateAPI_GetTimeDataJSO
+    alias:
+    - GameStateAPI::GetTimeDataJSO
+  - name: GameStateAPI_GetScoreDataJSO
+    alias:
+    - GameStateAPI::GetScoreDataJSO
+  - name: GameStateAPI_GetPlayerStatsJSO
+    alias:
+    - GameStateAPI::GetPlayerStatsJSO
+  - name: GameStateAPI_GetMatchInfoJSO
+    alias:
+    - GameStateAPI::GetMatchInfoJSO
+  - name: GameStateAPI_GetMatchEndWinDataJSO
+    alias:
+    - GameStateAPI::GetMatchEndWinDataJSO
+  - name: GameStateAPI_GetAccoladeLocalizationString
+    alias:
+    - GameStateAPI::GetAccoladeLocalizationString
+  - name: GameStateAPI_GetTeamClanName
+    alias:
+    - GameStateAPI::GetTeamClanName
+  - name: GameStateAPI_GetTeamLogoImagePath
+    alias:
+    - GameStateAPI::GetTeamLogoImagePath
+  - name: GameStateAPI_GetTeamFlagImagePath
+    alias:
+    - GameStateAPI::GetTeamFlagImagePath
+  - name: GameStateAPI_GetTeamTotalPlayerCount
+    alias:
+    - GameStateAPI::GetTeamTotalPlayerCount
+  - name: GameStateAPI_GetTeamLivingPlayerCount
+    alias:
+    - GameStateAPI::GetTeamLivingPlayerCount
+  - name: GameStateAPI_GetTeamNextRoundLossBonus
+    alias:
+    - GameStateAPI::GetTeamNextRoundLossBonus
+  - name: GameStateAPI_GetActiveQuestID
+    alias:
+    - GameStateAPI::GetActiveQuestID
+  - name: GameStateAPI_GetAnnotationsViewingLevel
+    alias:
+    - GameStateAPI::GetAnnotationsViewingLevel
+  - name: GameStateAPI_BIsLocalServerHost
+    alias:
+    - GameStateAPI::BIsLocalServerHost
+- name: server
+  symbols:
+  - name: CSource2Server_OnStreamEntitiesFromFileCompleted
+    alias:
+    - CSource2Server::OnStreamEntitiesFromFileCompleted
+  - name: CSource2Server_PreWorldUpdate
+    alias:
+    - CSource2Server::PreWorldUpdate
+  - name: CSource2Server_OutOfGameFrameBoundary
+    alias:
+    - CSource2Server::OutOfGameFrameBoundary
+  - name: CGameSystemReallocatingFactory_CSource2EntitySystem_Init
+    alias:
+    - CGameSystemReallocatingFactory<CSource2EntitySystem>::Init
+  - name: CGameSystemReallocatingFactory_CSource2EntitySystem_CreateGameSystem
+    alias:
+    - CGameSystemReallocatingFactory<CSource2EntitySystem>::CreateGameSystem
+  - name: IGameSystemFactory_Init
+    alias:
+    - IGameSystemFactory::Init
+  - name: IGameSystemFactory_Shutdown
+    alias:
+    - IGameSystemFactory::Shutdown
+  - name: IGameSystemFactory_SetGlobalPtr
+    alias:
+    - IGameSystemFactory::SetGlobalPtr
+  - name: CGameSystemReallocatingFactory_CSpawnGroupMgrGameSystem_DestroyGameSystem
+    alias:
+    - CGameSystemReallocatingFactory<CSpawnGroupMgrGameSystem>::Deallocate
+  - name: IGameSystem_SetGameSystemGlobalPtrs
+    alias:
+    - IGameSystem::SetGameSystemGlobalPtrs
+  - name: IGameSystem_vdtor
+    alias:
+    - IGameSystem::~IGameSystem
+  - name: IGameSystem_OnGameInit
+    alias:
+    - IGameSystem::GameInit
+  - name: CMultiplayRules_ctor
+    alias:
+    - CMultiplayRules::CMultiplayRules
+  - name: CGameMoney_OnMoneySpent
+    alias:
+    - CGameMoney::OnMoneySpent
+  - name: CGameMoney_m_DataMap
+    alias:
+    - CGameMoney::m_DataMap
+  - name: CGameMoney_GetDataDescMap
+    alias:
+    - CGameMoney::GetDataDescMap
+  - name: CCSPlayer_UseServices_OnUseImpl
+    alias:
+    - CCSPlayer_UseServices::OnUseImpl
+  - name: CCSPlayer_UseServices_OnUse
+    alias:
+    - CCSPlayer_UseServices::OnUse
+  - name: CCSPlayer_MovementServices_ProcessMovement
+    alias:
+    - CCSPlayer_MovementServices::ProcessMovement
+    - ProcessMovement
+  - name: CCSPlayer_MovementServices_CheckMovingGround
+    alias:
+    - CCSPlayer_MovementServices::CheckMovingGround
+    - CheckMovingGround
+  - name: CCSPlayer_MovementServices_WalkMove
+    alias:
+    - CCSPlayer_MovementServices::WalkMove
+    - WalkMove
+  - name: CCSPlayer_MovementServices_FullWalkMove
+    alias:
+    - CCSPlayer_MovementServices::FullWalkMove
+    - FullWalkMove
+  - name: CCSPlayer_MovementServices_CheckVelocity
+    alias:
+    - CCSPlayer_MovementServices::CheckVelocity
+    - CheckVelocity
+  - name: CCSPlayer_MovementServices_WaterMove
+    alias:
+    - CCSPlayer_MovementServices::WaterMove
+    - WaterMove
+  - name: CCSPlayer_MovementServices_FullWalkMove_SpeedClamp
+    alias:
+    - ServerMovementUnlock
+  - name: CCSPlayer_MovementServices_CheckJumpButton
+    alias:
+    - CCSPlayer_MovementServices::CheckJumpButton
+  - name: CCSPlayer_MovementServices_CheckJumpButton_WaterPatch
+    alias:
+    - CheckJumpButtonWater
+    - FixWaterFloorJump
+  - name: CPlayer_MovementServices_PlayWaterStepSound
+    alias:
+    - CPlayer_MovementServices::PlayWaterStepSound
+  - name: CPlayer_MovementServices_ForceButtons
+    alias:
+    - CPlayer_MovementServices::ForceButtons
+  - name: CPlayer_MovementServices_ForceButtonState
+    alias:
+    - CPlayer_MovementServices::ForceButtonState
+  - name: CPlayer_MovementServices_s_pRunCommandPawn
+    alias:
+    - CPlayer_MovementServices::s_pRunCommandPawn
+  - name: CEntityInstance_m_pEntity
+    alias:
+    - CEntityInstance::m_pEntity
+  - name: CEntityInstance_m_hPrivateScope
+    alias:
+    - CEntityInstance::m_hPrivateScope
+  - name: CEntityInstance_m_CScriptComponent
+    alias:
+    - CEntityInstance::m_CScriptComponent
+  - name: CEntityInstance_m_pKeyValues
+    alias:
+    - CEntityInstance::m_pKeyValues
+  - name: CEntityInstance_m_iszPrivateVScripts
+    alias:
+    - CEntityInstance::m_iszPrivateVScripts
+  - name: CBaseEntity_OnRestore
+    alias:
+    - CBaseEntity::OnRestore
+  - name: CEntityInstance_OnRestore
+    alias:
+    - CEntityInstance::OnRestore
+  - name: CBaseEntity_ctor
+    alias:
+    - CBaseEntity::CBaseEntity
+  - name: CBaseEntity_dtor
+    alias:
+    - CBaseEntity::~CBaseEntity
+  - name: CBaseEntity_vdtor
+    alias:
+    - CBaseEntity::~CBaseEntity (virtual)
+  - name: CEntityInstance_vdtor
+    alias:
+    - CEntityInstance::~CEntityInstance (virtual)
+  - name: CEntitySaveRestoreBlockHandler_PreSave
+    alias:
+    - CEntitySaveRestoreBlockHandler::PreSave
+  - name: CEntitySaveRestoreBlockHandler_SaveInternal
+    alias:
+    - CEntitySaveRestoreBlockHandler::SaveInternal
+  - name: CEntitySaveRestoreBlockHandler_Save
+    alias:
+    - CEntitySaveRestoreBlockHandler::Save
+  - name: CEntitySaveRestoreBlockHandler_Restore
+    alias:
+    - CEntitySaveRestoreBlockHandler::Restore
+  - name: CEntitySaveRestoreBlockHandler_DoRestoreEntity
+    alias:
+    - CEntitySaveRestoreBlockHandler::DoRestoreEntity
+  - name: CEntitySaveRestoreBlockHandler_RestoreEntity
+    alias:
+    - CEntitySaveRestoreBlockHandler::RestoreEntity
+  - name: CreateEntityTransitionList
+    alias:
+    - CreateEntityTransitionList
+  - name: CEntitySaveRestoreBlockHandler_WriteSaveHeaders
+    alias:
+    - CEntitySaveRestoreBlockHandler::WriteSaveHeaders
+  - name: CEntitySaveRestoreBlockHandler_ReadRestoreHeaders
+    alias:
+    - CEntitySaveRestoreBlockHandler::ReadRestoreHeaders
+  - name: CEntity2SaveRestore_StreamEntitiesFromFile
+    alias:
+    - CEntity2SaveRestore::StreamEntitiesFromFile
+  - name: CSaveRestoreBlockSet_PreRestore
+    alias:
+    - CSaveRestoreBlockSet::PreRestore
+  - name: CSaveRestoreBlockSet_PostRestore
+    alias:
+    - CSaveRestoreBlockSet::PostRestore
+  - name: CEntitySaveRestoreBlockHandler_PreRestore
+    alias:
+    - CEntitySaveRestoreBlockHandler::PreRestore
+  - name: CEntitySaveRestoreBlockHandler_PostRestore
+    alias:
+    - CEntitySaveRestoreBlockHandler::PostRestore
+  - name: CEntitySystem_ForceSetInPVSCallsIntoQueue
+    alias:
+    - CEntitySystem::ForceSetInPVSCallsIntoQueue
+  - name: CEntitySystem_ExecuteQueuedSetInPVS
+    alias:
+    - CEntitySystem::ExecuteQueuedSetInPVS
+  - name: CEntitySystem_m_nSuppressDormancyChangeCount
+    alias:
+    - CEntitySystem::m_nSuppressDormancyChangeCount
+  - name: CEntitySystem_m_nExecuteQueuedCreationDepth
+    alias:
+    - CEntitySystem::m_nExecuteQueuedCreationDepth
+  - name: CEntitySystem_m_queuedDormancyChanges
+    alias:
+    - CEntitySystem::m_queuedDormancyChanges
+  - name: CEntitySystem_SetInPVS
+    alias:
+    - CEntitySystem::SetInPVS
+  - name: CEntitySystem_OnSetDormant
+    alias:
+    - CEntitySystem::OnSetDormant
+  - name: CEntitySystem_BuildResourceManifestForEntity
+    alias:
+    - CEntitySystem::BuildResourceManifestForEntity
+  - name: CEntityInstance_ObjectCaps
+    alias:
+    - CEntityInstance::ObjectCaps
+  - name: CEntityInstance_Save
+    alias:
+    - CEntityInstance::Save
+  - name: CEntityInstance_Restore
+    alias:
+    - CEntityInstance::Restore
+  - name: CEntitySaveRestoreBlockHandler_SaveInitEntities
+    alias:
+    - CEntitySaveRestoreBlockHandler::SaveInitEntities
+  - name: CEntityInstance_OnSave
+    alias:
+    - CEntityInstance::OnSave
+  - name: CEntityInstance_RequiredEdictIndex
+    alias:
+    - CEntityInstance::RequiredEdictIndex
+  - name: PolymorphicHelper_t__SetPolymorphicPointer
+    alias:
+    - PolymorphicHelper_t::SetPolymorphicPointer
+  - name: CEntityInstance_AddChangeAccessorPathPolymorphic
+    alias:
+    - CEntityInstance::AddChangeAccessorPathPolymorphic
+  - name: CEntityInstance_AssignChangeAccessorPathIdsPolymorphic
+    alias:
+    - CEntityInstance::AssignChangeAccessorPathIdsPolymorphic
+  - name: CEntityInstance_AddChangeAccessorPath
+    alias:
+    - CEntityInstance::AddChangeAccessorPath
+  - name: CEntityInstance_AssignChangeAccessorPathIds
+    alias:
+    - CEntityInstance::AssignChangeAccessorPathIds
+  - name: CEntityInstance_GetChangeAccessorPathInfo_2
+    alias:
+    - CEntityInstance::GetChangeAccessorPathInfo_2
+  - name: CBaseEntity_GetChangeAccessorPathInfo_2
+    alias:
+    - CBaseEntity::GetChangeAccessorPathInfo_2
+  - name: CBaseEntity_GetChangeAccessorPathInfo_1
+    alias:
+    - CBaseEntity::GetChangeAccessorPathInfo_1
+  - name: CMomentaryRotButton_Use
+    alias:
+    - CMomentaryRotButton::Use
+  - name: CBaseEntity_TakeDamageOld
+    alias:
+    - CBaseEntity::TakeDamageOld
+  - name: CBaseEntity_OnTakeDamage
+    alias:
+    - CBasePlayerPawn::OnTakeDamage
+  - name: CBasePlayerPawn_OnTakeDamage_Alive
+    alias:
+    - CBasePlayerPawn::OnTakeDamage_Alive
+  - name: CBasePlayerPawn_OnTakeDamage_Dying
+    alias:
+    - CBasePlayerPawn::OnTakeDamage_Dying
+  - name: CBasePlayerPawn_OnTakeDamage_Dead
+    alias:
+    - CBasePlayerPawn::OnTakeDamage_Dead
+  - name: CBasePlayerPawn_OnTakeDamage
+    alias:
+    - CBasePlayerPawn::OnTakeDamage
+  - name: CCSPlayerPawn_OnTakeDamage_Alive
+    alias:
+    - CCSPlayerPawn::OnTakeDamage_Alive
+  - name: CCSPlayerPawn_OnTakeDamage_Dying
+    alias:
+    - CCSPlayerPawn::OnTakeDamage_Dying
+  - name: CCSPlayerPawn_OnTakeDamage_Dead
+    alias:
+    - CCSPlayerPawn::OnTakeDamage_Dead
+  - name: CFlashbangProjectile_Spawn
+    alias:
+    - CFlashbangProjectile::Spawn
+  - name: CSmokeGrenadeProjectile_Create
+    alias:
+    - CSmokeGrenadeProjectile::Create
+  - name: CEntitySystem_QueueDestroyEntity
+    alias:
+    - CEntitySystem::QueueDestroyEntity
+  - name: CEntitySystem_ExecuteQueuedDeletion
+    alias:
+    - CEntitySystem::ExecuteQueuedDeletion
+  - name: CEntitySystem_m_nExecuteQueuedDeletionDepth
+    alias:
+    - CEntitySystem::m_nExecuteQueuedDeletionDepth
+  - name: CBaseModelEntity_SetModel
+    alias:
+    - CBaseModelEntity::SetModel
+  - name: CBaseModelEntity_SetRenderAttribute
+    alias:
+    - CBaseModelEntity::SetRenderAttribute
+  - name: CBaseEntity_GetScriptDescInternal
+    alias:
+    - CBaseEntity::GetScriptDescInternal
+  - name: CBaseModelEntity_GetScriptDescInternal
+    alias:
+    - CBaseModelEntity::GetScriptDescInternal
+  - name: CBaseModelEntity_GetModelScale
+    alias:
+    - CBaseModelEntity::GetModelScale
+  - name: CBaseModelEntity_Script_SetModelScale
+    alias:
+    - CBaseModelEntity::Script_SetModelScale
+  - name: CBaseModelEntity_ScriptLookupAttachment
+    alias:
+    - CBaseModelEntity::ScriptLookupAttachment
+  - name: CBaseModelEntity_ScriptGetAttachmentOrigin
+    alias:
+    - CBaseModelEntity::ScriptGetAttachmentOrigin
+  - name: CBaseModelEntity_ScriptGetAttachmentAngles
+    alias:
+    - CBaseModelEntity::ScriptGetAttachmentAngles
+  - name: CBaseModelEntity_ScriptGetAttachmentForward
+    alias:
+    - CBaseModelEntity::ScriptGetAttachmentForward
+  - name: CBaseModelEntity_ScriptSetSize
+    alias:
+    - CBaseModelEntity::ScriptSetSize
+  - name: CBaseModelEntity_ScriptSetModel
+    alias:
+    - CBaseModelEntity::ScriptSetModel
+  - name: ScriptBinding_CBaseModelEntity_SetModel
+    alias:
+    - CS_Script_SetModel
+  - name: CBaseModelEntity_ScriptGetRenderAlpha
+    alias:
+    - CBaseModelEntity::ScriptGetRenderAlpha
+  - name: CBaseModelEntity_ScriptSetRenderAlpha
+    alias:
+    - CBaseModelEntity::ScriptSetRenderAlpha
+  - name: CBaseModelEntity_ScriptSetRenderMode
+    alias:
+    - CBaseModelEntity::ScriptSetRenderMode
+  - name: CBaseModelEntity_ScriptSetRenderColor
+    alias:
+    - CBaseModelEntity::ScriptSetRenderColor
+  - name: CBaseModelEntity_ScriptGetRenderColor
+    alias:
+    - CBaseModelEntity::ScriptGetRenderColor
+  - name: CBaseModelEntity_ScriptSetMaterialGroup
+    alias:
+    - CBaseModelEntity::ScriptSetMaterialGroup
+  - name: CBaseModelEntity_ScriptSetMaterialGroupHash
+    alias:
+    - CBaseModelEntity::ScriptSetMaterialGroupHash
+  - name: CBaseModelEntity_ScriptGetMaterialGroupHash
+    alias:
+    - CBaseModelEntity::ScriptGetMaterialGroupHash
+  - name: CBaseModelEntity_ScriptSetSingleMeshGroup
+    alias:
+    - CBaseModelEntity::ScriptSetSingleMeshGroup
+  - name: CBaseModelEntity_ScriptSetMeshGroupMask
+    alias:
+    - CBaseModelEntity::ScriptSetMeshGroupMask
+  - name: CBaseModelEntity_ScriptGetMeshGroupMask
+    alias:
+    - CBaseModelEntity::ScriptGetMeshGroupMask
+  - name: CBaseModelEntity_ScriptSetBodygroupByName
+    alias:
+    - CBaseModelEntity::ScriptSetBodygroupByName
+  - name: CBaseModelEntity_Script_SetBodygroup
+    alias:
+    - CBaseModelEntity::Script_SetBodygroup
+  - name: CBaseModelEntity_Script_SetSkin
+    alias:
+    - CBaseModelEntity::Script_SetSkin
+  - name: CEntityInstance_NetworkUpdateState_thunk
+    alias:
+    - CEntityInstance::NetworkUpdateState_thunk
+  - name: CBaseEntity_SetGravityScale
+    alias:
+    - CBaseEntity::SetGravityScale
+  - name: CTriggerGravity_GravityTouch
+    alias:
+    - CTriggerGravity::GravityTouch
+  - name: CTriggerGravity_GetTouchFunction
+    alias:
+    - CTriggerGravity::GetTouchFunction
+  - name: CBasePlayerController_HandleCommand_JoinTeam
+    alias:
+    - CBasePlayerController::HandleCommand_JoinTeam
+  - name: CBasePlayerController_SetPlayerName
+    alias:
+    - CBasePlayerController::SetPlayerName
+  - name: CBasePlayerController_ProcessUsercmds
+    alias:
+    - ProcessUsercmds
+  - name: CBasePlayerController_SetPawn
+    alias:
+    - CBasePlayerController::SetPawn
+  - name: CBasePlayerController_GetPawn
+    alias:
+    - CBasePlayerController::GetPawn
+  - name: CBasePlayerController_Connect
+    alias:
+    - CBasePlayerController::Connect
+  - name: CSource2GameClients_ClientDisconnect
+    alias:
+    - CSource2GameClients::ClientDisconnect
+  - name: CSource2GameClients_ClientPutInServer
+    alias:
+    - CSource2GameClients::ClientPutInServer
+  - name: CSource2GameClients_ClientConnect
+    alias:
+    - CSource2GameClients::ClientConnect
+  - name: CSource2GameClients_ClientActive
+    alias:
+    - CSource2GameClients::ClientActive
+  - name: CSource2GameClients_ClientFullyConnect
+    alias:
+    - CSource2GameClients::ClientFullyConnect
+  - name: CSource2GameClients_ClientCommand
+    alias:
+    - CSource2GameClients::ClientCommand
+  - name: CSource2GameClients_ProcessUsercmds
+    alias:
+    - CSource2GameClients::ProcessUsercmds
+  - name: CSource2GameClients_GetBugReportInfo
+    alias:
+    - CSource2GameClients::GetBugReportInfo
+  - name: CSource2GameClients_ClientDiagnostic
+    alias:
+    - CSource2GameClients::ClientDiagnostic
+  - name: CSource2GameClients_SendHLTVStatusMessage
+    alias:
+    - CSource2GameClients::SendHLTVStatusMessage
+  - name: CSource2GameClients_OnClientConnected
+    alias:
+    - CSource2GameClients::OnClientConnected
+  - name: CGameRules_FindPickerEntity
+    alias:
+    - CGameRules::FindPickerEntity
+  - name: CCSGameRules_FindPickerEntity
+    alias:
+    - CCSGameRules::FindPickerEntity
+  - name: CCSGameRules_TerminateRound
+    alias:
+    - CCSGameRules::TerminateRound
+    - CGameRules::TerminateRound
+    - CGameRules_TerminateRound
+  - name: CCSGameRules_GoToIntermission
+    alias:
+    - CCSGameRules::GoToIntermission
+  - name: CEntityInstance_AcceptInput
+    alias:
+    - CEntityInstance::AcceptInput
+    - AcceptInput
+  - name: CEntityIdentity_AcceptInput
+    alias:
+    - CEntityIdentity::AcceptInput
+  - name: CEntityIdentity_AcceptInputInternal
+    alias:
+    - CEntityIdentity::AcceptInputInternal
+  - name: CEntityInstance_ScriptAcceptInput
+    alias:
+    - CEntityInstance::ScriptAcceptInput
+  - name: CEntityIdentity_SetEntityName
+    alias:
+    - CEntityIdentity::SetEntityName
+  - name: CEntitySystem_RemoveEntityFromNameMap
+    alias:
+    - CEntitySystem::RemoveEntityFromNameMap
+  - name: CEntitySystem_AddEntityToNameMap
+    alias:
+    - CEntitySystem::AddEntityToNameMap
+  - name: ScriptBinding_Entity_SetEntityName
+    alias:
+    - Entity::SetEntityName
+  - name: CBtActionCoordinatedBuy_Update
+    alias:
+    - CBtActionCoordinatedBuy::Update
+  - name: CCSPlayer_ItemServices_CanAcquire
+    alias:
+    - CCSPlayer_ItemServices::CanAcquire
+  - name: CCSPlayer_ItemServices_GiveDefaultItems
+    alias:
+    - CCSPlayer_ItemServices::GiveDefaultItems
+  - name: CCSPlayer_ItemServices_GiveNamedItem
+    alias:
+    - CCSPlayer_ItemServices::GiveNamedItem
+  - name: CCSPlayer_ItemServices_GiveNamedItemBool
+    alias:
+    - CCSPlayer_ItemServices::GiveNamedItemBool
+  - name: CCSPlayer_WeaponServices_CanUse
+    alias:
+    - CCSPlayer_WeaponServices::CanUse
+  - name: CCSPlayer_WeaponServices_PickupItem
+    alias:
+    - CCSPlayer_WeaponServices::PickupItem
+  - name: CCSPlayer_WeaponServices_EquipWeapon
+    alias:
+    - CCSPlayer_WeaponServices::EquipWeapon
+  - name: CCSPlayer_WeaponServices_Weapon_GetSlot
+    alias:
+    - CCSPlayer_WeaponServices_Weapon_GetSlot
+  - name: CCSPlayerController_ChangeTeam
+    alias:
+    - CCSPlayerController::ChangeTeam
+  - name: CCSPlayerController_GetThinkFunction
+    alias:
+    - CCSPlayerController::GetThinkFunction
+  - name: CCSPlayerController_PlayerForceTeamThink
+    alias:
+    - PlayerForceTeamThink
+    - CCSPlayerController::PlayerForceTeamThink
+  - name: CCSPlayerController_ResetForceTeamThink
+    alias:
+    - ResetForceTeamThink
+    - CCSPlayerController::ResetForceTeamThink
+  - name: CCSPlayerController_ResourceDataThink
+    alias:
+    - ResourceDataThink
+    - CCSPlayerController::ResourceDataThink
+  - name: CCSPlayerController_InventoryUpdateThink
+    alias:
+    - InventoryUpdateThink
+    - CCSPlayerController::InventoryUpdateThink
+  - name: g_CCSPlayerController_PlayerForceTeamThink
+    alias:
+    - g_CCSPlayerController::PlayerForceTeamThink
+  - name: g_CCSPlayerController_ResetForceTeamThink
+    alias:
+    - g_CCSPlayerController::ResetForceTeamThink
+  - name: g_CCSPlayerController_ResourceDataThink
+    alias:
+    - g_CCSPlayerController::ResourceDataThink
+  - name: g_CCSPlayerController_InventoryUpdateThink
+    alias:
+    - g_CCSPlayerController::InventoryUpdateThink
+  - name: CCSGameRules__sm_mapGcBanInformation
+    alias:
+    - CCSGameRules::sm_mapGcBanInformation
+  - name: CCSGameRules_BeginRound
+    alias:
+    - CCSGameRules::BeginRound
+  - name: CCSGameRules_PlayerSpawn
+    alias:
+    - CCSGameRules::PlayerSpawn
+  - name: CCSPlayerController_Respawn
+    alias:
+    - CCSPlayerController::Respawn
+  - name: CCSPlayerController_Connect
+    alias:
+    - CCSPlayerController::Connect
+  - name: CCSPlayerController_SwitchTeam
+    alias:
+    - CCSPlayerController::SwitchTeam
+  - name: CCSPlayerPawnBase_OnSetDormant
+    alias:
+    - CCSPlayerPawnBase::OnSetDormant
+  - name: CCSPlayerPawnBase_CheckForIdle
+    alias:
+    - CCSPlayerPawnBase::CheckForIdle
+  - name: CCSPlayerPawnBase_CheckForIdleInternal
+    alias:
+    - CCSPlayerPawnBase::CheckForIdleInternal
+  - name: CCSPlayerPawn_PostThink
+    alias:
+    - CCSPlayerPawnBase::PostThink
+    - CCSPlayerPawn::PostThink
+    - CCSPlayerPawnBase_PostThink
+    - CCSPlayerPawn_PostThink
+    - PostThink
+  - name: CCSPlayerPawn_OnSwitchWeapons
+    alias:
+    - CCSPlayerPawn::OnSwitchWeapons
+  - name: CCSPlayerPawn_ProcessSuicideAsKillReward
+    alias:
+    - CCSPlayerPawn::ProcessSuicideAsKillReward
+  - name: CGameRules_ClientSettingsChanged
+    alias:
+    - CGameRules::ClientSettingsChanged
+  - name: CGameRulesGameSystem_OnGameInit
+    alias:
+    - CGameRulesGameSystem::GameInit
+  - name: CGameRulesGameSystem_OnGameShutdown
+    alias:
+    - CGameRulesGameSystem::GameShutdown
+  - name: IGameSystem_OnGameShutdown
+    alias:
+    - IGameSystem::GameShutdown
+  - name: IGameSystem_OnGamePostInit
+    alias:
+    - IGameSystem::GamePostInit
+  - name: IGameSystem_OnGamePreShutdown
+    alias:
+    - IGameSystem::GamePreShutdown
+  - name: CMultiplayRules_ClientDisconnected
+    alias:
+    - CMultiplayRules::ClientDisconnected
+  - name: CSource2Server_Init
+    alias:
+    - CSource2Server::Init
+  - name: CSource2Server_ApplyGameSettings
+    alias:
+    - CSource2Server::ApplyGameSettings
+  - name: CSource2Server_WriteSignonMessages
+    alias:
+    - CSource2Server::WriteSignonMessages
+  - name: CSource2Server_GameCreateNetworkStringTables
+    alias:
+    - CSource2Server::GameCreateNetworkStringTables
+  - name: CSource2Server_GetMatchmakingGameData
+    alias:
+    - CSource2Server::GetMatchmakingGameData
+  - name: CSource2Server_GameServerSteamAPIActivated
+    alias:
+    - CSource2Server::GameServerSteamAPIActivated
+  - name: CSource2Server_GameServerSteamAPIDeactivated
+    alias:
+    - CSource2Server::GameServerSteamAPIDeactivated
+  - name: CSource2Server_OnHostNameChanged
+    alias:
+    - CSource2Server::OnHostNameChanged
+  - name: CSource2Server_GetLevelsFromSaveFile
+    alias:
+    - CSource2Server::GetLevelsFromSaveFile
+  - name: CSource2Server_ServerConVarChanged
+    alias:
+    - CSource2Server::ServerConVarChanged
+  - name: CSource2Server_Save
+    alias:
+    - CSource2Server::Save
+  - name: CSource2Server_Connect
+    alias:
+    - CSource2Server::Connect
+  - name: CSource2Server_PreShutdown
+    alias:
+    - CSource2Server::PreShutdown
+  - name: IAppSystem_Connect
+    alias:
+    - IAppSystem::Connect
+  - name: IAppSystem_PreShutdown
+    alias:
+    - IAppSystem::PreShutdown
+  - name: IVEngineServer2_ServerCommand
+    alias:
+    - IVEngineServer2::ServerCommand
+  - name: IVEngineServer2_IsDedicatedServer
+    alias:
+    - IVEngineServer2::IsDedicatedServer
+  - name: IVEngineServer2_GetServerGlobals
+    alias:
+    - IVEngineServer2::GetServerGlobals
+  - name: IVEngineServer2_IsLogEnabled
+    alias:
+    - IVEngineServer2::IsLogEnabled
+  - name: CSource2Server_Shutdown
+    alias:
+    - CSource2Server::Shutdown
+  - name: CGameEventManager_Shutdown
+    alias:
+    - CGameEventManager::Shutdown
+  - name: CLoopModeRegistry_UnregisterLoopModes
+    alias:
+    - CLoopModeRegistry::UnregisterLoopModes
+  - name: CEngineServiceRegistry_UnregisterEngineServices
+    alias:
+    - CEngineServiceRegistry::UnregisterEngineServices
+  - name: IEngineServiceMgr_UnregisterLoopMode
+    alias:
+    - IEngineServiceMgr::UnregisterLoopMode
+  - name: IEngineServiceMgr_UnregisterEngineService
+    alias:
+    - IEngineServiceMgr::UnregisterEngineService
+  - name: CSource2Server_GameFrame
+    alias:
+    - CSource2Server::GameFrame
+  - name: CGameEventManager_Init
+    alias:
+    - CGameEventManager::Init
+  - name: CTakeDamageInfo_HitGroupInfo
+    alias:
+    - CTakeDamageInfo::HitGroupInfo
+    - CTakeDamageInfo::HitGroup
+    - CTakeDamageInfo_HitGroup
+  - name: CEntitySystem_RegisterEntityClass
+    alias:
+    - CEntitySystem::RegisterEntityClass
+  - name: CEntitySystem_CreateEntityByName
+    alias:
+    - CEntitySystem::CreateEntityByName
+  - name: CEntitySystem_CreateEntity
+    alias:
+    - CEntitySystem::CreateEntity
+  - name: CEntitySystem_AddEntityToEntityDataBase
+    alias:
+    - CEntitySystem::AddEntityToEntityDataBase
+  - name: CEntitySystem_OnAddEntity
+    alias:
+    - CEntitySystem::OnAddEntity
+  - name: CEntitySystem_OnEntityParentChanged
+    alias:
+    - CEntitySystem::OnEntityParentChanged
+  - name: CEntitySystem_PrecacheEntity
+    alias:
+    - CEntitySystem::PrecacheEntity
+  - name: CEntitySystem_InvokePrecacheCallback
+    alias:
+    - CEntitySystem::InvokePrecacheCallback
+  - name: CEntitySystem_DestroyEntity
+    alias:
+    - CEntitySystem::DestroyEntity
+  - name: CConcreteEntityList_AllocEntity
+    alias:
+    - CConcreteEntityList::AllocEntity
+  - name: CEntitySystem_ConstructEntity
+    alias:
+    - CEntitySystem::ConstructEntity
+  - name: CEntitySystem_DoConstructEntity
+    alias:
+    - CEntitySystem::DoConstructEntity
+  - name: CEntitySystem_GetSpawnGroupWorldId
+    alias:
+    - CEntitySystem::GetSpawnGroupWorldId
+  - name: CEntitySystem_FindClassByDesignName
+    alias:
+    - CEntitySystem::FindClassByDesignName
+  - name: CEntitySystem_m_EntityList
+    alias:
+    - CEntitySystem::m_EntityList
+  - name: CEntitySystem_m_entityNames
+    alias:
+    - CEntitySystem::m_entityNames
+  - name: CEntitySystem_m_entityComponentHelpers
+    alias:
+    - CEntitySystem::m_entityComponentHelpers
+  - name: CEntitySystem_m_DataDescKeyUnserializers
+    alias:
+    - CEntitySystem::m_DataDescKeyUnserializers
+  - name: CEntitySystem_m_EntityPostSpawnCallback
+    alias:
+    - CEntitySystem::m_EntityPostSpawnCallback
+  - name: CEntityIdentity_FreeAttributes
+    alias:
+    - CEntityIdentity::FreeAttributes
+  - name: CConcreteEntityList_FreeEntity
+    alias:
+    - CConcreteEntityList::FreeEntity
+  - name: UTIL_CreateEntityByName
+    alias:
+    - CreateEntityByName
+  - name: CBaseEntity_DispatchSpawn
+    alias:
+    - CBaseEntity::DispatchSpawn
+    - DispatchSpawn
+  - name: CEntitySystem_QueueSpawnEntity
+    alias:
+    - CEntitySystem::QueueSpawnEntity
+  - name: CEntitySystem_HelperExecuteQueuedSpawn
+    alias:
+    - CEntitySystem::HelperExecuteQueuedSpawn
+  - name: CEntitySystem_SortEntities
+    alias:
+    - CEntitySystem::SortEntities
+  - name: CGameEntitySystem_SortEntities
+    alias:
+    - CGameEntitySystem::SortEntities
+  - name: CEntitySystem_InstallCreationWrapperCallbacks
+    alias:
+    - CEntitySystem::InstallCreationWrapperCallbacks
+  - name: CEntitySystem_ExecuteQueuedCreation
+    alias:
+    - CEntitySystem::ExecuteQueuedCreation
+  - name: CEntitySystem_ExecuteQueuedActivates
+    alias:
+    - CEntitySystem::ExecuteQueuedActivates
+  - name: CEntitySystem_ExecuteQueuedPostDataUpdateAndActivates
+    alias:
+    - CEntitySystem::ExecuteQueuedPostDataUpdateAndActivates
+  - name: CEntitySystem_Activate
+    alias:
+    - CEntitySystem::Activate
+  - name: CEntitySystem_PostDataUpdate
+    alias:
+    - CEntitySystem::PostDataUpdate
+  - name: CBaseEntity_NetworkStateChangedLog
+    alias:
+    - CBaseEntity::NetworkStateChangedLog
+  - name: CBaseEntity_NetworkStateChanged
+    alias:
+    - CBaseEntity::NetworkStateChanged
+  - name: CBaseEntity_FullEdictChanged
+    alias:
+    - CBaseEntity::FullEdictChanged
+  - name: CBaseEntity_m_NetworkTransmitComponent
+    alias:
+    - CBaseEntity::m_NetworkTransmitComponent
+  - name: CNetworkTransmitComponent_StateChanged
+    alias:
+    - CNetworkTransmitComponent::StateChanged
+  - name: CNetworkTransmitComponent_m_nStateFlags
+    alias:
+    - CNetworkTransmitComponent::m_nStateFlags
+  - name: CInferno_InfernoThink
+    alias:
+    - CInferno::InfernoThink
+  - name: CPhysExplosion_Activate
+    alias:
+    - CPhysExplosion::Activate
+  - name: CPhysExplosion_Explode
+    alias:
+    - CPhysExplosion::Explode
+  - name: UTIL_SayTextFilter2
+    alias:
+    - UTIL_SayText2Filter
+  - name: CCSWeaponBase_ItemPostFrame_ProcessReloadAction
+    alias:
+    - CCSWeaponBase::ItemPostFrame::ProcessReloadAction
+  - name: CCSPlayer_WeaponServices_HandleDropWeapon
+    alias:
+    - CCSPlayer_WeaponServices::HandleDropWeapon
+  - name: CCSPlayer_UseServices_BumpWeapon
+    alias:
+    - CCSPlayer_UseServices::BumpWeapon
+  - name: CCSPlayerPawn_HandleDropWeapon
+    alias:
+    - CCSPlayerPawn::HandleDropWeapon
+  - name: CCSPlayerPawn_ClientCommand
+    alias:
+    - CCSPlayerPawn::ClientCommand
+  - name: CCSPlayerPawn_SprayPaint
+    alias:
+    - CCSPlayerPawn::SprayPaint
+  - name: CEntitySpawner_CPlayerSprayDecal_Spawn
+    alias:
+    - CEntitySpawner<CPlayerSprayDecal>::Spawn
+  - name: CEntityKeyValuesAllocator_GetTempBuffer
+    alias:
+    - CEntityKeyValuesAllocator::GetTempBuffer
+  - name: CEntityKeyValues_LoadFromContext
+    alias:
+    - CEntityKeyValues::LoadFromContext
+  - name: CEntityKeyValues_Initialized
+    alias:
+    - CEntityKeyValues::Initialized
+  - name: CEntitySystem_m_nEntityKeyValuesAllocatorRefCount
+    alias:
+    - CEntitySystem::m_nEntityKeyValuesAllocatorRefCount
+  - name: CEntitySystem_AddRefKeyValues
+    alias:
+    - CEntitySystem::AddRefKeyValues
+  - name: CEntitySystem_ReleaseKeyValues
+    alias:
+    - CEntitySystem::ReleaseKeyValues
+  - name: CCSPlayerController_HandleCommandDrop
+    alias:
+    - CCSPlayerController::HandleCommandDrop
+  - name: IGameSystem_InitAllSystems
+    alias:
+    - IGameSystem::InitAllSystems
+  - name: IGameSystem_LoopInitAllSystems
+    alias:
+    - IGameSystem::LoopInitAllSystems
+  - name: IGameSystem_LoopPostInitAllSystems
+    alias:
+    - IGameSystem::LoopPostInitAllSystems
+  - name: IGameSystem_PostInit
+    alias:
+    - IGameSystem::PostInit
+  - name: IGameSystemFactory_PostInit
+    alias:
+    - IGameSystemFactory::PostInit
+  - name: IGameSystemFactory_GetStaticGameSystem
+    alias:
+    - IGameSystemFactory::GetStaticGameSystem
+  - name: IGameSystem_InitAllSystems_pFirst
+    alias:
+    - IGameSystem::InitAllSystems::pFirst
+    - IGameSystem::InitAllSystems->pFirst
+  - name: IGameSystem_LoopPostInitAllSystems_pEventDispatcher
+    alias:
+    - IGameSystem::LoopPostInitAllSystems::pEventDispatcher
+    - IGameSystem::LoopPostInitAllSystems->pEventDispatcher
+  - name: IGameSystem_LoopDestroyAllSystems_s_GameSystems
+    alias:
+    - IGameSystem::LoopDestroyAllSystems::s_GameSystems
+    - IGameSystem::LoopDestroyAllSystems->s_GameSystems
+  - name: CSource2GameEntities_CheckTransmit
+    alias:
+    - CSource2GameEntities::CheckTransmit
+    - ISource2GameEntities::CheckTransmit
+    - ISource2GameEntities_CheckTransmit
+    - CheckTransmit
+  - name: CBaseEntity_EmitSoundFilter
+    alias:
+    - CBaseEntity::EmitSoundFilter
+  - name: CBaseEntity_ScriptInputKill
+    alias:
+    - CBaseEntity::ScriptInputKill
+  - name: CBaseEntity_ScriptGetForward
+    alias:
+    - CBaseEntity::ScriptGetForward
+  - name: CBaseEntity_ScriptGetRight
+    alias:
+    - CBaseEntity::ScriptGetRight
+  - name: CBaseEntity_ScriptGetLeft
+    alias:
+    - CBaseEntity::ScriptGetLeft
+  - name: CBaseEntity_ScriptGetUp
+    alias:
+    - CBaseEntity::ScriptGetUp
+  - name: CBaseEntity_ScriptGetModelName
+    alias:
+    - CBaseEntity::ScriptGetModelName
+  - name: CBaseEntity_ScriptGetMoveParent
+    alias:
+    - CBaseEntity::ScriptGetMoveParent
+  - name: CBaseEntity_ScriptGetRootMoveParent
+    alias:
+    - CBaseEntity::ScriptGetRootMoveParent
+  - name: CBaseEntity_ScriptFirstMoveChild
+    alias:
+    - CBaseEntity::ScriptFirstMoveChild
+  - name: CBaseEntity_ScriptNextMovePeer
+    alias:
+    - CBaseEntity::ScriptNextMovePeer
+  - name: CBaseEntity_ScriptGetOwnerEntity
+    alias:
+    - CBaseEntity::ScriptGetOwnerEntity
+  - name: CBaseEntity_Script_GetChildren
+    alias:
+    - CBaseEntity::Script_GetChildren
+  - name: CBaseEntity_ScriptSetParent
+    alias:
+    - CBaseEntity::ScriptSetParent
+  - name: CBaseEntity_ScriptEyePosition
+    alias:
+    - CBaseEntity::ScriptEyePosition
+  - name: CBaseEntity_ScriptSetAngles
+    alias:
+    - CBaseEntity::ScriptSetAngles
+  - name: CBaseEntity_ScriptSetAbsAngles
+    alias:
+    - CBaseEntity::ScriptSetAbsAngles
+  - name: CBaseEntity_ScriptGetAngles
+    alias:
+    - CBaseEntity::ScriptGetAngles
+  - name: CBaseEntity_ScriptEyeAngles
+    alias:
+    - CBaseEntity::ScriptEyeAngles
+  - name: CBaseEntity_ScriptSetOrigin
+    alias:
+    - CBaseEntity::ScriptSetOrigin
+  - name: CBaseEntity_ScriptSetLocalAngles
+    alias:
+    - CBaseEntity::ScriptSetLocalAngles
+  - name: CBaseEntity_ScriptGetLocalAngles
+    alias:
+    - CBaseEntity::ScriptGetLocalAngles
+  - name: CBaseEntity_ScriptSetLocalOrigin
+    alias:
+    - CBaseEntity::ScriptSetLocalOrigin
+  - name: CBaseEntity_ScriptGetLocalOrigin
+    alias:
+    - CBaseEntity::ScriptGetLocalOrigin
+  - name: CBaseEntity_ScriptTransformPointEntityToWorld
+    alias:
+    - CBaseEntity::ScriptTransformPointEntityToWorld
+  - name: CBaseEntity_ScriptTransformPointWorldToEntity
+    alias:
+    - CBaseEntity::ScriptTransformPointWorldToEntity
+  - name: CBaseEntity_ScriptSetForward
+    alias:
+    - CBaseEntity::ScriptSetForward
+  - name: CBaseEntity_ScriptGetBoundingMins
+    alias:
+    - CBaseEntity::ScriptGetBoundingMins
+  - name: CBaseEntity_ScriptGetBoundingMaxs
+    alias:
+    - CBaseEntity::ScriptGetBoundingMaxs
+  - name: CBaseEntity_ScriptGetBounds
+    alias:
+    - CBaseEntity::ScriptGetBounds
+  - name: CBaseEntity_ScriptGetLocalAngularVelocity_OBSOLETE
+    alias:
+    - CBaseEntity::ScriptGetLocalAngularVelocity_OBSOLETE
+  - name: CBaseEntity_ScriptSetLocalAngularVelocity_OBSOLETE
+    alias:
+    - CBaseEntity::ScriptSetLocalAngularVelocity_OBSOLETE
+  - name: CBaseEntity_ScriptAddEffects
+    alias:
+    - CBaseEntity::ScriptAddEffects
+  - name: CBaseEntity_ScriptRemoveEffects
+    alias:
+    - CBaseEntity::ScriptRemoveEffects
+  - name: CBaseEntity_ScriptSetAttributeFloatValue
+    alias:
+    - CBaseEntity::ScriptSetAttributeFloatValue
+  - name: CBaseEntity_ScriptGetAttributeFloatValue
+    alias:
+    - CBaseEntity::ScriptGetAttributeFloatValue
+  - name: CBaseEntity_ScriptSetAttributeIntValue
+    alias:
+    - CBaseEntity::ScriptSetAttributeIntValue
+  - name: CBaseEntity_ScriptGetAttributeIntValue
+    alias:
+    - CBaseEntity::ScriptGetAttributeIntValue
+  - name: CBaseEntity_ScriptHasAttribute
+    alias:
+    - CBaseEntity::ScriptHasAttribute
+  - name: CBaseEntity_ScriptDeleteAttribute
+    alias:
+    - CBaseEntity::ScriptDeleteAttribute
+  - name: CBaseEntity_GetScriptOwnerEntity
+    alias:
+    - CBaseEntity::GetScriptOwnerEntity
+  - name: CBaseEntity_SetScriptOwnerEntity
+    alias:
+    - CBaseEntity::SetScriptOwnerEntity
+  - name: CBaseEntity_ScriptSetEntityName
+    alias:
+    - CBaseEntity::ScriptSetEntityName
+  - name: CBaseEntity_ScriptGetMass
+    alias:
+    - CBaseEntity::ScriptGetMass
+  - name: CBaseEntity_ScriptSetMass
+    alias:
+    - CBaseEntity::ScriptSetMass
+  - name: CBaseEntity_ScriptGetSpawnGroupHandle
+    alias:
+    - CBaseEntity::ScriptGetSpawnGroupHandle
+  - name: CBaseEntity_GetAbsAngles
+    alias:
+    - CBaseEntity::GetAbsAngles
+  - name: CBaseEntity_Script_GetTeamNumber
+    alias:
+    - CBaseEntity::Script_GetTeamNumber
+  - name: CBaseEntity_Script_FollowEntity
+    alias:
+    - CBaseEntity::Script_FollowEntity
+  - name: CBaseEntity_Script_FollowEntityMerge
+    alias:
+    - CBaseEntity::Script_FollowEntityMerge
+  - name: CBaseEntity_Script_Trigger
+    alias:
+    - CBaseEntity::Script_Trigger
+  - name: CBaseEntity_Script_SetContextThink
+    alias:
+    - CBaseEntity::Script_SetContextThink
+  - name: CBaseEntity_AddContextForScript
+    alias:
+    - CBaseEntity::AddContextForScript
+  - name: CBaseEntity_AddContextForScriptNumeric
+    alias:
+    - CBaseEntity::AddContextForScriptNumeric
+  - name: CBaseEntity_GetContextForScript
+    alias:
+    - CBaseEntity::GetContextForScript
+  - name: CBaseEntity_ScriptGatherCriteria
+    alias:
+    - CBaseEntity::ScriptGatherCriteria
+  - name: CBaseEntity_Script_TakeDamage
+    alias:
+    - CBaseEntity::Script_TakeDamage
+  - name: CBaseEntity_SetAbsVelocity
+    alias:
+    - CBaseEntity::SetAbsVelocity
+  - name: CBaseEntity_GetAbsVelocity
+    alias:
+    - CBaseEntity::GetAbsVelocity
+  - name: CBaseEntity_Script_ApplyLocalAngularVelocityImpulse
+    alias:
+    - CBaseEntity::Script_ApplyLocalAngularVelocityImpulse
+  - name: CBaseEntity_GetLocalAngularVelocity_OBSOLETE
+    alias:
+    - CBaseEntity::GetLocalAngularVelocity_OBSOLETE
+  - name: CBaseEntity_ScriptEmitSoundParams
+    alias:
+    - CBaseEntity::ScriptEmitSoundParams
+    - CBaseEntity::EmitSoundParams
+    - CBaseEntity_EmitSoundParams
+  - name: CBaseEntity_ScriptStopSound
+    alias:
+    - CBaseEntity::ScriptStopSound
+  - name: CBaseEntity_ScriptSoundDuration
+    alias:
+    - CBaseEntity::ScriptSoundDuration
+  - name: CBaseEntity_ScriptGetAbsOrigin
+    alias:
+    - CBaseEntity::ScriptGetAbsOrigin
+  - name: CBaseEntity_Precache
+    alias:
+    - CBaseEntity::Precache
+    - Precache
+  - name: CEnvEntityIgniter_Precache
+    alias:
+    - CEnvEntityIgniter::Precache
+  - name: CEnvShake_Spawn
+    alias:
+    - CEnvShake::Spawn
+  - name: CBaseEntity_SetMoveType
+    alias:
+    - CBaseEntity::SetMoveType
+  - name: CBasePlayerPawn_CommitSuicide
+    alias:
+    - CBasePlayerPawn::CommitSuicide
+    - CommitSuicide
+  - name: CBaseCombatCharacter_OnKilled
+    alias:
+    - CBaseCombatCharacter::OnKilled
+  - name: CCSPlayerPawn_Event_KilledOther
+    alias:
+    - CCSPlayerPawn::Event_KilledOther
+  - name: CCSPlayerPawn_Event_Killed
+    alias:
+    - CCSPlayerPawn::Event_Killed
+  - name: CBasePlayerPawn_Event_Killed
+    alias:
+    - CBasePlayerPawn::Event_Killed
+  - name: ScriptBinding_CSPlayerPawn_DestroyWeapon
+    alias:
+    - CSPlayerPawn::DestroyWeapon
+  - name: CBasePlayerPawn_RemovePlayerItem
+    alias:
+    - CBasePlayerPawn::RemovePlayerItem
+  - name: CBasePlayerPawn_DropActivePlayerWeapon
+    alias:
+    - CBasePlayerPawn::DropActivePlayerWeapon
+  - name: CBasePlayerPawn_GetEyePosition
+    alias:
+    - CBasePlayerPawn::GetEyePosition
+  - name: CBaseEntity_GetEyePosition
+    alias:
+    - CBaseEntity::GetEyePosition
+  - name: CCSBotManager_BotPlaceCommand
+    alias:
+    - CCSBotManager::BotPlace
+  - name: CBasePlayerPawn_EyeVectors
+    alias:
+    - CBasePlayerPawn::EyeVectors
+  - name: CBasePlayerPawn_GetEyeAngles
+    alias:
+    - CBasePlayerPawn::GetEyeAngles
+  - name: CBaseEntity_GetEyeAngles
+    alias:
+    - CBaseEntity::GetEyeAngles
+  - name: CCSBot_Upkeep
+    alias:
+    - CCSBot::Upkeep
+  - name: CCSBot_SetState
+    alias:
+    - CCSBot::SetState
+  - name: CCSBot_UpdatePathMovement
+    alias:
+    - CCSBot::UpdatePathMovement
+  - name: CCSBot_PrintIfWatched
+    alias:
+    - CCSBot::PrintIfWatched
+  - name: CHostage_Follow
+    alias:
+    - CHostage::Follow
+  - name: CHostage_DropHostage
+    alias:
+    - CHostage::DropHostage
+  - name: HideState_OnUpdate
+    alias:
+    - HideState::OnUpdate
+  - name: CCSBot_Attack
+    alias:
+    - CCSBot::Attack
+  - name: CCSBot_MoveTo
+    alias:
+    - CCSBot::MoveTo
+  - name: CCSBot_InhibitLookAround
+    alias:
+    - CCSBot::InhibitLookAround
+  - name: CCSBot_SetDisposition
+    alias:
+    - CCSBot::SetDisposition
+  - name: CCSBot_Idle
+    alias:
+    - CCSBot::Idle
+  - name: CCSBot_ComputePath
+    alias:
+    - CCSBot::ComputePath
+  - name: CBaseEntity_IsAlive
+    alias:
+    - CBaseEntity::IsAlive
+  - name: CBaseEntity_SetOwner
+    alias:
+    - CBaseEntity::SetOwner
+  - name: CBaseEntity_CollisionRulesChanged
+    alias:
+    - CBaseEntity::CollisionRulesChanged
+    - CollisionRulesChanged
+  - name: CBaseEntity_Use
+    alias:
+    - CBaseEntity::Use
+  - name: CGameSceneNode_PostSpawnKeyValues
+    alias:
+    - CGameSceneNode::PostSpawnKeyValues
+  - name: CBaseEntity_Spawn
+    alias:
+    - CBaseEntity::Spawn
+    - Spawn
+  - name: CBaseEntity_SpawnRadius
+    alias:
+    - CBaseEntity::SpawnRadius
+  - name: CCSPlayer_ItemServices_DropActivePlayerWeapon
+    alias:
+    - CCSPlayer_ItemServices::DropActivePlayerWeapon
+  - name: CCSPlayer_WeaponServices_DropWeapon
+    alias:
+    - CCSPlayer_WeaponServices::DropWeapon
+  - name: CBasePlayerWeapon_Shoot_Secondary
+    alias:
+    - CBasePlayerWeapon::Shoot_Secondary
+  - name: CCSPlayer_ItemServices_RemoveWeapons
+    alias:
+    - CCSPlayer_ItemServices::RemoveWeapons
+  - name: CCSPlayer_WeaponServices_SelectItem
+    alias:
+    - CCSPlayer_WeaponServices::SelectItem
+  - name: CEntFireOutputAutoCompletionFunctor_FireOutput
+    alias:
+    - CEntFireOutputAutoCompletionFunctor::FireOutput
+  - name: CEntityInstance_FindOutputsByName
+    alias:
+    - CEntityInstance::FindOutputsByName
+  - name: CEntityInstance_ScriptEntityIO
+    alias:
+    - CEntityInstance::ScriptEntityIO
+  - name: CEntityIOOutput_FireOutputInternal
+    alias:
+    - CEntityIOOutput::FireOutputInternal
+  - name: CEntitySystem_AddEntityIOEvent
+    alias:
+    - CEntitySystem::AddEntityIOEvent
+  - name: CEntitySystem_AddEntityIOEvent2
+    alias:
+    - CEntitySystem::AddEntityIOEvent2
+  - name: CEntitySystem_AddEntityIOEventBuildStruct
+    alias:
+    - CEntitySystem::AddEntityIOEventBuildStruct
+  - name: CEntitySystem_AddEntityIOEventToQueue
+    alias:
+    - CEntitySystem::AddEntityIOEventToQueue
+  - name: CEntitySystem_m_EventQueue
+    alias:
+    - CEntitySystem::m_EventQueue
+  - name: CGameEntitySystem_FindEntityByClassName
+    alias:
+    - CGameEntitySystem::FindEntityByClassName
+  - name: CGameEntitySystem_FindEntityByName
+    alias:
+    - CGameEntitySystem::FindEntityByName
+  - name: CGameEntitySystem_OnAddEntity
+    alias:
+    - CGameEntitySystem::OnAddEntity
+  - name: CGameEntitySystem_BuildResourceManifest_ManifestNameOrGroupName
+    alias:
+    - CGameEntitySystem::BuildResourceManifest_ManifestNameOrGroupName
+  - name: CGameEntitySystem_BuildResourceManifest_KeyValuesVectors
+    alias:
+    - CGameEntitySystem::BuildResourceManifest_KeyValuesVectors
+  - name: CGameEntitySystem_FindEntityProcedural
+    alias:
+    - CGameEntitySystem::FindEntityProcedural
+  - name: CGameEntitySystem_Spawn
+    alias:
+    - CGameEntitySystem::Spawn
+  - name: CEntitySystem_Spawn
+    alias:
+    - CEntitySystem::Spawn
+  - name: CBodyGameSystem_SpawnDependencyIsland
+    alias:
+    - CBodyGameSystem::SpawnDependencyIsland
+  - name: CGameEntitySystem_CheckGlobalState
+    alias:
+    - CGameEntitySystem::CheckGlobalState
+  - name: IGameSystem_OnBuildGameSessionManifest
+    alias:
+    - IGameSystem::BuildGameSessionManifest
+  - name: IGameSystem_OnServerPreEntityThink
+    alias:
+    - IGameSystem::OnServerPreEntityThink
+  - name: IGameSystem_OnServerPostEntityThink
+    alias:
+    - IGameSystem::OnServerPostEntityThink
+  - name: IGameSystem_OnServerPreClientUpdate
+    alias:
+    - IGameSystem::ServerPreClientUpdate
+  - name: IGameSystem_OnServerAdvanceTick
+    alias:
+    - IGameSystem::ServerAdvanceTick
+  - name: IGameSystem_OnServerGamePostSimulate
+    alias:
+    - IGameSystem::ServerGamePostSimulate
+  - name: IGameSystem_OnServerPostAdvanceTick
+    alias:
+    - IGameSystem::ServerPostAdvanceTick
+  - name: IGameSystem_OnServerPreBeginAsyncPostTickWork
+    alias:
+    - IGameSystem::OnServerPreBeginAsyncPostTickWork
+  - name: IGameSystem_OnServerBeginAsyncPostTickWork
+    alias:
+    - IGameSystem::OnServerBeginAsyncPostTickWork
+  - name: IGameSystem_OnServerPreEndAsyncPostTickWork
+    alias:
+    - IGameSystem::OnServerPreEndAsyncPostTickWork
+  - name: IGameSystem_OnServerPostEndAsyncPostTickWork
+    alias:
+    - IGameSystem::OnServerPostEndAsyncPostTickWork
+  - name: IGameSystem_OnSaveGame
+    alias:
+    - IGameSystem::OnSaveGame
+  - name: IGameSystem_OnRestoreGame
+    alias:
+    - IGameSystem::OnRestoreGame
+  - name: IGameSystem_OnOutOfGameFrameBoundary
+    alias:
+    - IGameSystem::OnOutOfGameFrameBoundary
+  - name: CSource2GameClients_StartHLTVServer
+    alias:
+    - CSource2GameClients::StartHLTVServer
+  - name: LegacyGameEventListener
+    alias:
+    - GetLegacyGameEventListener
+  - name: CPhysicsGameSystem_ProcessContactEvents
+    alias:
+    - CPhysicsGameSystem::ProcessContactEvents
+  - name: CBaseEntity_VPhysicsStartTouch
+    alias:
+    - CBaseEntity::VPhysicsStartTouch
+  - name: CBaseEntity_PhysicsTouch
+    alias:
+    - CBaseEntity::PhysicsTouch
+  - name: CBaseEntity_VPhysicsEndTouch
+    alias:
+    - CBaseEntity::VPhysicsEndTouch
+  - name: CBaseEntity_StartTouch
+    alias:
+    - CBaseEntity::StartTouch
+    - StartTouch
+  - name: CBaseEntity_Touch
+    alias:
+    - CBaseEntity::Touch
+    - Touch
+  - name: CBaseEntity_EndTouch
+    alias:
+    - CBaseEntity::EndTouch
+    - EndTouch
+  - name: IVPhys2World_GetTouchingList
+    alias:
+    - IVPhys2World::GetTouchingList
+    - CVPhys2World::GetTouchingList
+  - name: CTriggerPush_Touch
+    alias:
+    - CTriggerPush::Touch
+    - TriggerPush_Touch
+  - name: CPhysBox_Use
+    alias:
+    - CPhysBox::Use
+  - name: CBaseEntity_SetGroundEntity
+    alias:
+    - SetGroundEntity
+  - name: CBaseEntity_GetHammerUniqueId
+    alias:
+    - CBaseEntity::GetHammerUniqueId
+    - GetHammerUniqueId
+  - name: CBaseEntity_IsPlayerPawn
+    alias:
+    - CBaseEntity::IsPlayerPawn
+    - IsEntityPawn
+    - IsPlayerPawn
+  - name: CBaseEntity_IsPlayerController
+    alias:
+    - CBaseEntity::IsPlayerController
+    - IsEntityController
+    - IsPlayerController
+  - name: CBaseTrigger_StartTouch
+    alias:
+    - CBaseTrigger::StartTouch
+  - name: CBaseTrigger_EndTouch
+    alias:
+    - CBaseTrigger::EndTouch
+  - name: CBaseTrigger_PassesTriggerFilters
+    alias:
+    - CBaseTrigger::PassesTriggerFilters
+    - PassesTriggerFilters
+  - name: CBaseAnimGraph_GetAnimationController
+    alias:
+    - CBaseAnimGraph::GetAnimationController
+  - name: CBaseAnimGraph_m_skeletonInstance
+    alias:
+    - CBaseAnimGraph::m_skeletonInstance
+  - name: CGameSceneNode_PreInstanceSpawn
+    alias:
+    - CGameSceneNode::PreInstanceSpawn
+  - name: CGameSceneNode_GetSkeletonInstance
+    alias:
+    - CGameSceneNode::GetSkeletonInstance
+  - name: CSkeletonInstance_m_animationController
+    alias:
+    - CSkeletonInstance::m_animationController
+  - name: CSkeletonInstance_PostDataUpdate
+    alias:
+    - CSkeletonInstance::PostDataUpdate
+  - name: CGameSceneNode_PostDataUpdate
+    alias:
+    - CGameSceneNode::PostDataUpdate
+  - name: CGameSceneNode_UpdateEntityForHierarchyChange
+    alias:
+    - CGameSceneNode::UpdateEntityForHierarchyChange
+  - name: CPointTeleportAPI_TeleportEntityInternal
+    alias:
+    - CPointTeleportAPI::TeleportEntityInternal
+  - name: CBaseEntity_Teleport
+    alias:
+    - CBaseEntity::Teleport
+  - name: CPointTeleport_Activate
+    alias:
+    - CPointTeleport::Activate
+  - name: CBaseEntity_Activate
+    alias:
+    - CBaseEntity::Activate
+    - Activate
+  - name: CBaseEntity_DrawDebugTextOverlays
+    alias:
+    - CBaseEntity::DrawDebugTextOverlays
+  - name: CRagdollProp_DrawEntityDebugOverlays
+    alias:
+    - CRagdollProp::DrawEntityDebugOverlays
+  - name: CBaseEntity_ReloadPrivateScripts
+    alias:
+    - CBaseEntity::ReloadPrivateScripts
+  - name: CCheckTransmitInfo_m_nPlayerSlot
+    alias:
+    - CCheckTransmitInfo::m_nPlayerSlot
+    - CheckTransmitPlayerSlot
+  - name: CDedicatedServerWorkshopManager_SwitchToWorkshopMapGroup
+    alias:
+    - CDedicatedServerWorkshopManager::SwitchToWorkshopMapGroup
+  - name: IGameTypes_CreateWorkshopMapGroup
+    alias:
+    - IGameTypes::CreateWorkshopMapGroup
+  - name: CEngineServer_UnloadSpawnGroup
+    alias:
+    - CEngineServer::UnloadSpawnGroup
+  - name: IVEngineServer2_MakeSpawnGroupActive
+    alias:
+    - IVEngineServer2::MakeSpawnGroupActive
+  - name: CSpawnGroupMgrGameSystem_GetSpawnGroups
+    alias:
+    - CSpawnGroupMgrGameSystem::GetSpawnGroups
+    - GetSpawnGroups
+  - name: CSpawnGroupMgrGameSystem_DumpSpawnGroups
+    alias:
+    - CSpawnGroupMgrGameSystem::DumpSpawnGroups
+    - DumpSpawnGroups
+  - name: CSpawnGroupMgrGameSystem_SpawnGroupSpawnEntitiesInternal
+    alias:
+    - CSpawnGroupMgrGameSystem::SpawnGroupSpawnEntitiesInternal
+    - SpawnGroupSpawnEntitiesInternal
+  - name: IGameSystem_OnPreSpawnGroupLoad
+    alias:
+    - IGameSystem::OnPreSpawnGroupLoad
+  - name: IGameSystem_OnPostSpawnGroupLoad
+    alias:
+    - IGameSystem::OnPostSpawnGroupLoad
+  - name: CSpawnGroupMgrGameSystem_SpawnGroupShutdown
+    alias:
+    - CSpawnGroupMgrGameSystem::SpawnGroupShutdown
+    - SpawnGroupShutdown
+  - name: CSpawnGroupMgrGameSystem_SpawnGroupActuallyShutdown
+    alias:
+    - CSpawnGroupMgrGameSystem::SpawnGroupActuallyShutdown
+    - SpawnGroupActuallyShutdown
+  - name: IGameSystem_OnPreSpawnGroupUnload
+    alias:
+    - IGameSystem::OnPreSpawnGroupUnload
+  - name: IGameSystem_OnPostSpawnGroupUnload
+    alias:
+    - IGameSystem::OnPostSpawnGroupUnload
+  - name: CLoadingSpawnGroup_CreateEntityToSpawn
+    alias:
+    - CLoadingSpawnGroup::CreateEntityToSpawn
+  - name: CSpawnGroupMgrGameSystem_OnSpawnGroupPrecache
+    alias:
+    - CSpawnGroupMgrGameSystem::OnSpawnGroupPrecache
+    - SpawnGroupPrecache
+  - name: CSpawnGroupMgrGameSystem_AllocateSpawnGroup
+    alias:
+    - CSpawnGroupMgrGameSystem::AllocateSpawnGroup
+  - name: CSpawnGroupMgrGameSystem_ReleaseSpawnGroup
+    alias:
+    - CSpawnGroupMgrGameSystem::ReleaseSpawnGroup
+  - name: CSpawnGroupMgrGameSystem_SpawnGroupInit
+    alias:
+    - CSpawnGroupMgrGameSystem::SpawnGroupInit
+  - name: CSpawnGroupMgrGameSystem_CreateLoadingSpawnGroup
+    alias:
+    - CSpawnGroupMgrGameSystem::CreateLoadingSpawnGroup
+  - name: CSpawnGroupMgrGameSystem_CreateLoadingSpawnGroupForSaveFile
+    alias:
+    - CSpawnGroupMgrGameSystem::CreateLoadingSpawnGroupForSaveFile
+  - name: CSpawnGroupMgrGameSystem_SpawnGroupSpawnEntities
+    alias:
+    - CSpawnGroupMgrGameSystem::SpawnGroupSpawnEntities
+  - name: CSpawnGroupMgrGameSystem_SetActiveSpawnGroup
+    alias:
+    - CSpawnGroupMgrGameSystem::SetActiveSpawnGroup
+  - name: CSpawnGroupMgrGameSystem_UnloadSpawnGroup
+    alias:
+    - CSpawnGroupMgrGameSystem::UnloadSpawnGroup
+  - name: CSpawnGroupMgrGameSystem_SaveGame_Start
+    alias:
+    - CSpawnGroupMgrGameSystem::SaveGame_Start
+  - name: IGameSystem_OnSpawnGroupPrecache
+    alias:
+    - IGameSystem::OnSpawnGroupPrecache
+  - name: IGameSystem_OnSpawnGroupUncache
+    alias:
+    - IGameSystem::OnSpawnGroupUncache
+  - name: CBaseFilter_InputTestActivator
+    alias:
+    - CBaseFilter::InputTestActivator
+  - name: CGamePlayerEquip_InputTriggerForAllPlayers
+    alias:
+    - CGamePlayerEquip::InputTriggerForAllPlayers
+  - name: CGamePlayerEquip_InputTriggerForActivatedPlayer
+    alias:
+    - CGamePlayerEquip::InputTriggerForActivatedPlayer
+  - name: CNavMesh_GetNearestNavArea
+    alias:
+    - CNavMesh::GetNearestNavArea
+  - name: CCSBotManager_AddBot
+    alias:
+    - CCSBotManager::AddBot
+  - name: BotAdd_CommandHandler
+    alias:
+    - CCSBotManager::BotAddCommand
+  - name: BotKill_CommandHandler
+    alias:
+    - CCSBotManager::BotKillCommand
+  - name: EntInfo_CommandHandler
+    alias:
+    - CC_Ent_Info
+  - name: CEntitySystem_DestroyEntityImmediate
+    alias:
+    - CEntitySystem::DestroyEntityImmediate
+  - name: CEntitySystem_OnRemoveEntityFromDatabase
+    alias:
+    - CEntitySystem::OnRemoveEntityFromDatabase
+  - name: CEntitySystem_DoDestructEntity
+    alias:
+    - CEntitySystem::DoDestructEntity
+  - name: CEntitySystem_UpdateOnRemove
+    alias:
+    - CEntitySystem::UpdateOnRemove
+  - name: ClientPrintToController
+    alias:
+    - ClientPrint
+  - name: CCSBotManager_AddBot_BotNavIgnore
+    alias:
+    - BotNavIgnore
+  - name: CEnvHudHint_API_ShowHudHint
+    alias:
+    - CEnvHudHint_API::ShowHudHint
+  - name: UTIL_GetPlayerControllerForEntity
+    alias:
+    - UTIL_GetPlayerControllerForEntity
+  - name: CEntitySystem_ctor
+    alias:
+    - CEntitySystem::CEntitySystem
+  - name: CGameEntitySystem_ctor
+    alias:
+    - CGameEntitySystem::CGameEntitySystem
+  - name: CEntitySystem_RegisterAccessor
+    alias:
+    - CEntitySystem::RegisterAccessor
+  - name: CEntitySystem_Init
+    alias:
+    - CEntitySystem::Init
+  - name: CEntitySystem_ProcessEntityRegistration
+    alias:
+    - CEntitySystem::ProcessEntityRegistration
+  - name: CEntitySystem_PostCreateEntitySystem
+    alias:
+    - CEntitySystem::PostCreateEntitySystem
+  - name: CSource2EntitySystem_StaticInit
+    alias:
+    - CSource2EntitySystem::StaticInit
+  - name: CSpawnGroupEntityFilterRegistrar_RegisterSpawnGroupEntityFilters
+    alias:
+    - CSpawnGroupEntityFilterRegistrar::RegisterSpawnGroupEntityFilters
+  - name: CGameEntitySystem_m_spawnGroupEntityFilters
+    alias:
+    - CGameEntitySystem::m_spawnGroupEntityFilters
+  - name: CGameEntitySystem_m_pEntity2Networkables
+    alias:
+    - CGameEntitySystem::m_pEntity2Networkables
+  - name: CEntity2NetworkClasses_ServerClass_InitEntity2NetworkClasses
+    alias:
+    - CEntity2NetworkClasses<ServerClass>::InitEntity2NetworkClasses
+  - name: CEntitySystem_m_Symbols
+    alias:
+    - CEntitySystem::m_Symbols
+  - name: CEntitySystem_m_pNetworkFieldChangedEventQueue
+    alias:
+    - CEntitySystem::m_pNetworkFieldChangedEventQueue
+  - name: CEntitySystem_m_pNetworkFieldScratchData
+    alias:
+    - CEntitySystem::m_pNetworkFieldScratchData
+  - name: CEntitySystem_m_pFieldChangeLimitSpew
+    alias:
+    - CEntitySystem::m_pFieldChangeLimitSpew
+  - name: CEntitySystem_m_ComponentUnserializerInfoAllocator
+    alias:
+    - CEntitySystem::m_ComponentUnserializerInfoAllocator
+  - name: CEntitySystem_m_EntityMaterialAttributes
+    alias:
+    - CEntitySystem::m_EntityMaterialAttributes
+  - name: CEntitySystem_m_flChangeCallbackSpewThreshold
+    alias:
+    - CEntitySystem::m_flChangeCallbackSpewThreshold
+  - name: CEntitySystem_ClearEntityDatabase
+    alias:
+    - CEntitySystem::ClearEntityDatabase
+  - name: INetworkMessages_SetNetworkSerializationContextData
+    alias:
+    - INetworkMessages::SetNetworkSerializationContextData
+  - name: CFlattenedSerializers_CreateFieldChangedEventQueue
+    alias:
+    - CFlattenedSerializers::CreateFieldChangedEventQueue
+  - name: INetworkMessages_RegisterSchemaTypeOverride
+    alias:
+    - INetworkMessages::RegisterSchemaTypeOverride
+  - name: CSceneEntity_GetScriptDesc
+    alias:
+    - CSceneEntity::GetScriptDesc
+  - name: CEntityInstance_GetScriptDesc
+    alias:
+    - CEntityInstance::GetScriptDesc
+  - name: CEntityInstance_Spawn
+    alias:
+    - CEntityInstance::Spawn
+  - name: CEntityInstance_Activate
+    alias:
+    - CEntityInstance::Activate
+  - name: CEntityInstance_Precache
+    alias:
+    - CEntityInstance::Precache
+  - name: CEntityInstance_GetDataDescMap
+    alias:
+    - CEntityInstance::GetDataDescMap
+  - name: CEntityInstance_ReloadPrivateScripts
+    alias:
+    - CEntityInstance::ReloadPrivateScripts
+  - name: CEntityInstance_ValidatePrivateScriptScope
+    alias:
+    - CEntityInstance::ValidatePrivateScriptScope
+  - name: CEntityInstance_NetworkStateChanged
+    alias:
+    - CEntityInstance::NetworkStateChanged
+  - name: CEntityInstance_FullEdictChanged
+    alias:
+    - CEntityInstance::FullEdictChanged
+  - name: CEntityInstance_NetworkUpdateState
+    alias:
+    - CEntityInstance::NetworkUpdateState
+  - name: CEntityInstance_NetworkStateChangedLog
+    alias:
+    - CEntityInstance::NetworkStateChangedLog
+  - name: CEntityInstance_DrawDebugTextOverlays
+    alias:
+    - CEntityInstance::DrawDebugTextOverlays
+  - name: CEntityInstance_DrawEntityDebugOverlays
+    alias:
+    - CEntityInstance::DrawEntityDebugOverlays
+  - name: CEntityInstance_PostDataUpdateDelta
+    alias:
+    - CEntityInstance::PostDataUpdateDelta
+  - name: CEntityInstance_PreDataUpdate
+    alias:
+    - CEntityInstance::PreDataUpdate
+  - name: CEntityInstance_PostDataUpdate
+    alias:
+    - CEntityInstance::PostDataUpdate
+  - name: CEntityInstance_PostDataUpdatePreserve
+    alias:
+    - CEntityInstance::PostDataUpdatePreserve
+  - name: CEntityInstance_Connect
+    alias:
+    - CEntityInstance::Connect
+  - name: CEntityInstance_UpdateOnRemove
+    alias:
+    - CEntityInstance::UpdateOnRemove
+  - name: CEntityInstance_Disconnect
+    alias:
+    - CEntityInstance::Disconnect
+  - name: CEntityInstance_AddedToEntityDatabase
+    alias:
+    - CEntityInstance::AddedToEntityDatabase
+  - name: CEntityInstance_OnSetDormant
+    alias:
+    - CEntityInstance::OnSetDormant
+  - name: CEntityInstance_Schema_DynamicBinding
+    alias:
+    - CEntityInstance::Schema_DynamicBinding
+  - name: CEntitySystem_OnRemoveEntity
+    alias:
+    - CEntitySystem::OnRemoveEntity
+  - name: CEntityComponentHelperT_Free
+    alias:
+    - CEntityComponentHelperT::Free
+  - name: CScriptedSequence_SynchronizeSequence
+    alias:
+    - CScriptedSequence::SynchronizeSequence
+  - name: CNetworkUtlVectorEmbedded_NetworkStateChanged_m_vecRenderAttributes
+    alias:
+    - CNetworkUtlVectorEmbedded<CRenderAttribute>::NetworkStateChanged_m_vecRenderAttributes
+  - name: CNetworkUtlVectorEmbedded_NetworkStateChanged_m_perRoundStats
+    alias:
+    - CNetworkUtlVectorEmbedded<CSPerRoundStats_t>::NetworkStateChanged_m_perRoundStats
+  - name: CUtlVectorEmbeddedNetworkVar_CSPerRoundStats_t_NetworkVar_m_perRoundStats_SetCount
+    alias:
+    - CUtlVectorEmbeddedNetworkVar<CSPerRoundStats_t, NetworkVar>::SetCount
+  - name: CNetworkUtlVectorEmbedded_TryLateResolve_m_vecRenderAttributes
+    alias:
+    - CNetworkUtlVectorEmbedded<CRenderAttribute>::TryLateResolve
+  - name: INetworkMessages_GetLoggingChannel
+    alias:
+    - INetworkMessages::GetLoggingChannel
+  - name: CPhysicsEntitySolver_PhysEnableEntityCollisions
+    alias:
+    - CPhysicsEntitySolver::PhysEnableEntityCollisions
+  - name: CLoopModeGame_StaticInit
+    alias:
+    - CLoopModeGame::StaticInit
+  - name: CLoopModeFactory_CLoopModeGame_Init
+    alias:
+    - CLoopModeFactory<CLoopModeGame>::Init
+  - name: CLoopModeFactory_CLoopModeGame_Shutdown
+    alias:
+    - CLoopModeFactory<CLoopModeGame>::Shutdown
+  - name: CLoopModeGame_OnLoopActivate
+    alias:
+    - CLoopModeGame::OnLoopActivate
+  - name: ILoopMode_OnLoopActivate
+    alias:
+    - ILoopMode::OnLoopActivate
+  - name: CLoopModeGame_AddViewsToSceneSystem
+    alias:
+    - CLoopModeGame::AddViewsToSceneSystem
+  - name: ILoopMode_AddViewsToSceneSystem
+    alias:
+    - ILoopMode::AddViewsToSceneSystem
+  - name: CLoopModeGame_LoopInitInternal
+    alias:
+    - CLoopModeGame::LoopInitInternal
+  - name: CLoopModeGame_LoopInit
+    alias:
+    - CLoopModeGame::LoopInit
+  - name: ILoopMode_LoopInit
+    alias:
+    - ILoopMode::LoopInit
+  - name: ILoopMode_LoopShutdown
+    alias:
+    - ILoopMode::LoopShutdown
+  - name: CLoopModeGame_RegisterEventMapInternal
+    alias:
+    - CLoopModeGame::RegisterEventMapInternal
+  - name: CLoopModeGame_OnServerAdvanceTick
+    alias:
+    - CLoopModeGame::OnServerAdvanceTick
+  - name: CLoopModeGame_OnServerBeginSimulate
+    alias:
+    - CLoopModeGame::OnServerBeginSimulate
+  - name: CLoopModeGame_OnServerPostSimulate
+    alias:
+    - CLoopModeGame::OnServerPostSimulate
+  - name: CLoopModeGame_OnServerPostAdvanceTick
+    alias:
+    - CLoopModeGame::OnServerPostAdvanceTick
+  - name: CLoopModeGame_OnServerBeginAsyncPostTickWork
+    alias:
+    - CLoopModeGame::OnServerBeginAsyncPostTickWork
+  - name: CLoopModeGame_OnServerEndAsyncPostTickWork
+    alias:
+    - CLoopModeGame::OnServerEndAsyncPostTickWork
+  - name: CLoopModeGame_OnFrameBoundary
+    alias:
+    - CLoopModeGame::OnFrameBoundary
+  - name: CLoopModeGame_ReceivedServerInfo
+    alias:
+    - CLoopModeGame::ReceivedServerInfo
+  - name: CLoopModeGame_SetWorldSession
+    alias:
+    - CLoopModeGame::SetWorldSession
+  - name: CLoopModeGame_SetGameSystemState
+    alias:
+    - CLoopModeGame::SetGameSystemState
+  - name: IGameSystem_DestroyAllGameSystems
+    alias:
+    - IGameSystem::DestroyAllGameSystems
+  - name: IGameSystem_ShutdownAllSystems
+    alias:
+    - IGameSystem::ShutdownAllSystems
+  - name: IGameSystem_LoopDestroyAllSystems
+    alias:
+    - IGameSystem::LoopDestroyAllSystems
+  - name: IGameSystem_LoopPreShutdownAllSystems
+    alias:
+    - IGameSystem::LoopPreShutdownAllSystems
+  - name: CLoopModeGame_Shutdown
+    alias:
+    - CLoopModeGame::Shutdown
+  - name: CLoopModeGame_LoopShutdown
+    alias:
+    - CLoopModeGame::LoopShutdown
+  - name: CLoopModeGame_ShutdownServer
+    alias:
+    - CLoopModeGame::ShutdownServer
+  - name: CLoopModeGame_OnLoopDeactivate
+    alias:
+    - CLoopModeGame::OnLoopDeactivate
+  - name: ILoopMode_OnLoopDeactivate
+    alias:
+    - ILoopMode::OnLoopDeactivate
+  - name: CPlayerCommandQueue_ctor
+    alias:
+    - CPlayerCommandQueue::CPlayerCommandQueue
+  - name: IGameResourceService_SetEntityResourceManifestHandler
+    alias:
+    - IGameResourceService::SetEntityResourceManifestHandler
+  - name: CNetworkSerializerBindingBuildFilter_GetFieldPriority
+    alias:
+    - CNetworkSerializerBindingBuildFilter::GetFieldPriority
+  - name: CEntitySystem_FindComponentTypeByName
+    alias:
+    - CEntitySystem::FindComponentTypeByName
+- name: networksystem
+  symbols:
+  - name: INetworkMessages_GetFieldChangeCallbackOrderCount
+    alias:
+    - INetworkMessages::GetFieldChangeCallbackOrderCount
+  - name: INetworkMessages_GetFieldChangeCallbackPriorities
+    alias:
+    - INetworkMessages::GetFieldChangeCallbackPriorities

--- a/gamesymbols/14173.metadata.yaml
+++ b/gamesymbols/14173.metadata.yaml
@@ -1,0 +1,3526 @@
+modules:
+- name: scenesystem
+  symbols:
+  - name: ISceneSystem_GetWorldsInfo
+    alias:
+    - ISceneSystem::GetWorldsInfo
+  - name: ISceneWorld_GetObjectsInfo
+    alias:
+    - ISceneWorld::GetObjectsInfo
+  - name: ISceneWorld_GetWorldName
+    alias:
+    - ISceneWorld::GetWorldName
+  - name: ISceneSystem_GetObjectBounds
+    alias:
+    - ISceneSystem::GetObjectBounds
+  - name: ISceneSystem_GetObjectClassName
+    alias:
+    - ISceneSystem::GetObjectClassName
+  - name: CSceneObject_pDesc
+    alias:
+    - CSceneObject::pDesc
+  - name: CSceneObject_nFlags
+    alias:
+    - CSceneObject::nFlags
+  - name: CSceneObject_fOriginX
+    alias:
+    - CSceneObject::fOriginX
+  - name: CSceneObject_fOriginY
+    alias:
+    - CSceneObject::fOriginY
+  - name: CSceneObject_fOriginZ
+    alias:
+    - CSceneObject::fOriginZ
+  - name: CSceneObject_nClassIndex
+    alias:
+    - CSceneObject::nClassIndex
+- name: networksystem
+  symbols:
+  - name: CNetworkMessages_RegisterNetworkCategory
+    alias:
+    - CNetworkMessages::RegisterNetworkCategory
+  - name: CNetworkMessages_AssociateNetMessageWithChannelCategoryAbstract
+    alias:
+    - CNetworkMessages::AssociateNetMessageWithChannelCategoryAbstract
+  - name: CNetworkMessages_FindOrCreateNetMessage
+    alias:
+    - CNetworkMessages::FindOrCreateNetMessage
+  - name: CNetworkMessages_SerializeInternal
+    alias:
+    - CNetworkMessages::SerializeInternal
+  - name: CNetworkMessages_UnserializeMessageInternal
+    alias:
+    - CNetworkMessages::UnserializeMessageInternal
+  - name: CNetworkMessages_SerializeMessageInternal
+    alias:
+    - CNetworkMessages::SerializeMessageInternal
+  - name: CNetworkMessages_UnserializeFromStream
+    alias:
+    - CNetworkMessages::UnserializeFromStream
+  - name: CNetworkMessages_AllocateAndCopyConstructNetMessageAbstract
+    alias:
+    - CNetworkMessages::AllocateAndCopyConstructNetMessageAbstract
+  - name: CNetworkMessages_DeallocateNetMessageAbstract
+    alias:
+    - CNetworkMessages::DeallocateNetMessageAbstract
+  - name: CNetworkMessages_RegisterNetworkFieldSerializer
+    alias:
+    - CNetworkMessages::RegisterNetworkFieldSerializer
+  - name: CNetworkMessages_RegisterNetworkArrayFieldSerializer
+    alias:
+    - CNetworkMessages::RegisterNetworkArrayFieldSerializer
+  - name: CNetworkMessages_AssociateNetMessageGroupIdWithChannelCategory
+    alias:
+    - CNetworkMessages::AssociateNetMessageGroupIdWithChannelCategory
+  - name: CNetworkMessages_RegisterNetworkFieldChangeCallbackInternal
+    alias:
+    - CNetworkMessages::RegisterNetworkFieldChangeCallbackInternal
+  - name: CNetworkMessages_AllowAdditionalMessageRegistration
+    alias:
+    - CNetworkMessages::AllowAdditionalMessageRegistration
+  - name: CNetworkMessages_IsAdditionalMessageRegistrationAllowed
+    alias:
+    - CNetworkMessages::IsAdditionalMessageRegistrationAllowed
+  - name: CNetworkMessages_RegisterFieldChangeCallbackPriority
+    alias:
+    - CNetworkMessages::RegisterFieldChangeCallbackPriority
+  - name: CNetworkMessages_ComputeOrderForPriority
+    alias:
+    - CNetworkMessages::ComputeOrderForPriority
+  - name: CNetworkMessages_dtor
+    alias:
+    - CNetworkMessages::~CNetworkMessages
+  - name: CNetworkMessages_GetIsForServer
+    alias:
+    - CNetworkMessages::GetIsForServer
+  - name: CNetworkMessages_GetNetworkSerializationContextData
+    alias:
+    - CNetworkMessages::GetNetworkSerializationContextData
+  - name: CNetChan_ParseMessagesDemoInternal
+    alias:
+    - CNetChan::ParseMessagesDemoInternal
+  - name: CNetChan_ParseNetMessageShowFilter
+    alias:
+    - CNetChan::ParseNetMessageShowFilter
+  - name: CNetworkMessages_FindNetworkMessagePartial
+    alias:
+    - CNetworkMessages::FindNetworkMessagePartial
+  - name: CNetworkMessages_FindNetworkMessage
+    alias:
+    - CNetworkMessages::FindNetworkMessage
+  - name: CNetworkMessages_FindNetworkGroup
+    alias:
+    - CNetworkMessages::FindNetworkGroup
+  - name: CNetworkSystem_SendNetworkStats
+    alias:
+    - CNetworkSystem::SendNetworkStats
+  - name: CNetworkMessages_GetNetworkGroupCount
+    alias:
+    - CNetworkMessages::GetNetworkGroupCount
+  - name: CNetworkMessages_GetNetworkGroupName
+    alias:
+    - CNetworkMessages::GetNetworkGroupName
+  - name: CNetworkMessages_GetNetworkGroupColor
+    alias:
+    - CNetworkMessages::GetNetworkGroupColor
+  - name: CNetworkMessages_ConfirmAllMessageHandlersInstalled
+    alias:
+    - CNetworkMessages::ConfirmAllMessageHandlersInstalled
+- name: engine
+  symbols:
+  - name: CServerSideClient_IsHearingClient
+    alias:
+    - IsHearingClient
+  - name: CServerSideClient_ExecuteStringCommand
+    alias:
+    - CServerSideClient::ExecuteStringCommand
+  - name: CServerSideClient_ActivatePlayer
+    alias:
+    - CServerSideClient::ActivatePlayer
+  - name: ISource2GameClients_ClientSettingsChanged
+    alias:
+    - ISource2GameClients::ClientSettingsChanged
+  - name: CGameResourceService_BuildResourceManifest
+    alias:
+    - CGameResourceService::BuildResourceManifest
+    - BuildResourceManifest
+  - name: CGameResourceService_m_pEntitySystem
+    alias:
+    - GameEntitySystem
+  - name: CGameResourceService_LoadGameResourceManifestNamed
+    alias:
+    - CGameResourceService::LoadGameResourceManifestNamed
+  - name: CGameResourceService_LoadGameResourceManifestGroup
+    alias:
+    - CGameResourceService::LoadGameResourceManifestGroup
+  - name: CGameResourceService_GetResourceManifestDebugName
+    alias:
+    - CGameResourceService::GetResourceManifestDebugName
+  - name: CGameResourceService_PrecacheEntitiesAndConfirmResourcesAreLoaded
+    alias:
+    - CGameResourceService::PrecacheEntitiesAndConfirmResourcesAreLoaded
+  - name: CGameResourceService_LoadGameResourceManifest_IEntityResourceManifest
+    alias:
+    - CGameResourceService::LoadGameResourceManifest
+  - name: CGameResourceService_DescribeContents
+    alias:
+    - CGameResourceService::DescribeContents
+  - name: CGameResourceService_AppendToGameResourceManifest
+    alias:
+    - CGameResourceService::AppendToGameResourceManifest
+  - name: CGameResourceService_RegisterEventMap
+    alias:
+    - CGameResourceService::RegisterEventMap
+  - name: IEntityResourceManifestBuilder_BuildResourceManifest_ManifestNameOrGroupName
+    alias:
+    - IEntityResourceManifestBuilder::BuildResourceManifest
+  - name: CServerSideClientBase_ClientPrintf
+    alias:
+    - CServerSideClientBase::ClientPrintf
+    - ClientPrintf
+  - name: CNetworkGameServer_ClientList
+    alias:
+    - CNetworkGameServer::ClientList
+  - name: CNetworkGameServerBase_SendPeerList
+    alias:
+    - CNetworkGameServerBase::SendPeerList
+  - name: CNetworkGameServerBase_ConnectClient
+    alias:
+    - CNetworkGameServerBase::ConnectClient
+  - name: CNetworkGameServerBase_ServerSimulateInternal
+    alias:
+    - CNetworkGameServerBase::ServerSimulateInternal
+  - name: CNetworkGameServerBase_ServerSimulate
+    alias:
+    - CNetworkGameServerBase::ServerSimulate
+  - name: CNetworkGameServerBase_ServerPollNetworking
+    alias:
+    - CNetworkGameServerBase::ServerPollNetworking
+  - name: CNetworkGameServerBase_BroadcastMessage
+    alias:
+    - CNetworkGameServerBase::BroadcastMessage
+  - name: CNetworkGameServerBase_BroadcastPrintf
+    alias:
+    - CNetworkGameServerBase::BroadcastPrintf
+  - name: CNetworkGameServerBase_WriteDeltaEntities
+    alias:
+    - CNetworkGameServerBase::WriteDeltaEntities
+  - name: CNetworkGameServerBase_ReserveServerForQueuedGame
+    alias:
+    - CNetworkGameServerBase::ReserveServerForQueuedGame
+  - name: CNetworkGameServerBase_FinishChangeLevel
+    alias:
+    - CNetworkGameServerBase::FinishChangeLevel
+  - name: CNetworkGameServerBase_StartChangeLevel
+    alias:
+    - CNetworkGameServerBase::StartChangeLevel
+  - name: CNetworkGameServerBase_SetServerState
+    alias:
+    - CNetworkGameServerBase::SetServerState
+  - name: CNetworkGameServer_GetFreeClient
+    alias:
+    - CNetworkGameServer::GetFreeClient
+    - GetFreeClient
+  - name: CNetworkGameServerBase_CreateFakeClient
+    alias:
+    - CNetworkGameServerBase::CreateFakeClient
+  - name: CNetworkGameServerBase_UserInfoChanged
+    alias:
+    - CNetworkGameServerBase::UserInfoChanged
+  - name: CNetworkGameServerBase_GetPlayerNetworkIDString
+    alias:
+    - CNetworkGameServerBase::GetPlayerNetworkIDString
+  - name: CNetworkGameServerBase_StartHLTVMaster
+    alias:
+    - CNetworkGameServerBase::StartHLTVMaster
+  - name: CNetworkGameServerBase_RegisterLoadingSpawnGroups
+    alias:
+    - CNetworkGameServerBase::RegisterLoadingSpawnGroups
+  - name: CNetworkServerSpawnGroupCreatePrerequisites_Init
+    alias:
+    - CNetworkServerSpawnGroupCreatePrerequisites::Init
+  - name: CNetworkGameServerBase_LoadSpawnGroup
+    alias:
+    - CNetworkGameServerBase::LoadSpawnGroup
+  - name: CNetworkGameServerBase_SpawnGroupThink
+    alias:
+    - CNetworkGameServerBase::SpawnGroupThink
+  - name: CNetworkGameServerBase_PrintSpawnGroupStatus
+    alias:
+    - CNetworkGameServerBase::PrintSpawnGroupStatus
+  - name: CNetworkGameServerBase_AsyncUnloadSpawnGroup
+    alias:
+    - CNetworkGameServerBase::AsyncUnloadSpawnGroup
+  - name: CNetworkGameServerBase_AsyncUnloadSpawnGroupInternal
+    alias:
+    - CNetworkGameServerBase::AsyncUnloadSpawnGroupInternal
+  - name: CNetworkGameServer_PrepareForAssetLoad
+    alias:
+    - CNetworkGameServer::PrepareForAssetLoad
+  - name: CNetworkGameServerBase_IsSaveRestoreAllowed
+    alias:
+    - CNetworkGameServerBase::IsSaveRestoreAllowed
+  - name: CNetworkGameServerBase_Init
+    alias:
+    - CNetworkGameServerBase::Init
+  - name: CNetworkGameServerBase_Shutdown
+    alias:
+    - CNetworkGameServerBase::Shutdown
+  - name: CNetworkGameServerBase_ShutdownInternal
+    alias:
+    - CNetworkGameServerBase::ShutdownInternal
+  - name: CNetworkGameServer_ActivateServer
+    alias:
+    - CNetworkGameServer::ActivateServer
+  - name: CNetworkGameServer_DirectUpdate
+    alias:
+    - CNetworkGameServer::DirectUpdate
+  - name: CNetworkGameServer_Init
+    alias:
+    - CNetworkGameServer::Init
+  - name: CNetworkGameServer_Shutdown
+    alias:
+    - CNetworkGameServer::Shutdown
+  - name: CNetworkGameServer_SpawnServer
+    alias:
+    - CNetworkGameServer::SpawnServer
+  - name: CNetworkGameServerBase_GetMaxClients
+    alias:
+    - CNetworkGameServerBase::GetMaxClients
+  - name: CNetworkGameServerBase_SetMaxClients
+    alias:
+    - CNetworkGameServerBase::SetMaxClients
+  - name: CNetworkGameServerBase_CheckTimeouts
+    alias:
+    - CNetworkGameServerBase::CheckTimeouts
+  - name: CNetworkGameServerBase_OnKickById
+    alias:
+    - CNetworkGameServerBase::OnKickById
+  - name: CNetworkGameServerBase_OnKickByName
+    alias:
+    - CNetworkGameServerBase::OnKickByName
+  - name: CNetworkGameClient_SendMovePacket
+    alias:
+    - CNetworkGameClient::SendMovePacket
+    - SendMovePacket
+  - name: CNetworkGameClient_SendMove
+    alias:
+    - CNetworkGameClient::SendMove
+    - SendMove
+  - name: INetworkMessages_Serialize
+    alias:
+    - INetworkMessages::Serialize
+  - name: CDemoPlayer_SkipToTick
+    alias:
+    - CDemoPlayer::SkipToTick
+  - name: CDemoPlayer_PlayDemo
+    alias:
+    - CDemoPlayer::PlayDemo
+  - name: CDemoPlayer_StopPlayback
+    alias:
+    - CDemoPlayer::StopPlayback
+  - name: CDemoPlayer_StartPlayback
+    alias:
+    - CDemoPlayer::StartPlayback
+  - name: CDemoPlayer_SetIgnorePacketsForResourceLoading
+    alias:
+    - CDemoPlayer::SetIgnorePacketsForResourceLoading
+  - name: CDemoPlayer_InternalReadPacket
+    alias:
+    - CDemoPlayer::InternalReadPacket
+  - name: CDemoPlayer_Pause
+    alias:
+    - CDemoPlayer::Pause
+  - name: CDemoPlayer_m_bIsPlaying
+    alias:
+    - CDemoPlayer::m_bIsPlaying
+  - name: CDemoPlayer_m_bIsPaused
+    alias:
+    - CDemoPlayer::m_bIsPaused
+  - name: CDemoRecorder_ParseMessage
+    alias:
+    - CDemoRecorder::ParseMessage
+  - name: CDemoRecorder_WriteSpawnGroups
+    alias:
+    - CDemoRecorder::WriteSpawnGroups
+  - name: CHLTVDemoRecorder_WriteFrameImmediate
+    alias:
+    - CHLTVDemoRecorder::WriteFrameImmediate
+  - name: INetworkMessages_SerializeAbstract
+    alias:
+    - INetworkMessages::SerializeAbstract
+  - name: INetworkMessages_GetNetMessageInfo
+    alias:
+    - INetworkMessages::GetNetMessageInfo
+  - name: INetworkMessages_FindNetworkMessageById
+    alias:
+    - INetworkMessages::FindNetworkMessageById
+  - name: CNetChan_ProcessMessages
+    alias:
+    - CNetChan::ProcessMessages
+  - name: CNetChan_ParseMessagesDemo
+    alias:
+    - CNetChan::ParseMessagesDemo
+  - name: CNetworkGameClient_ProcessPacketEntitiesInternal
+    alias:
+    - CNetworkGameClient::ProcessPacketEntitiesInternal
+  - name: CNetworkGameClient_ProcessPacketEntities
+    alias:
+    - CNetworkGameClient::ProcessPacketEntities
+    - ProcessPacketEntities
+  - name: CNetworkGameClient_RecordEntityBandwidth
+    alias:
+    - CNetworkGameClient::RecordEntityBandwidth
+    - RecordEntityBandwidth
+  - name: CNetworkGameClient_PrintNetStats
+    alias:
+    - CNetworkGameClient::PrintNetStats
+  - name: CMsgSource2NetworkFlowQuality_PrintStats
+    alias:
+    - CMsgSource2NetworkFlowQuality::PrintStats
+  - name: CNetworkGameClient_CreateMove
+    alias:
+    - CNetworkGameClient::CreateMove
+  - name: ISource2Client_CreateMove
+    alias:
+    - ISource2Client::CreateMove
+  - name: CNetworkGameClient_SetSignonState
+    alias:
+    - CNetworkGameClient::SetSignonState
+  - name: CNetworkGameClient_ProcessReadPacketEntitiesWorkItems
+    alias:
+    - CNetworkGameClient::ProcessReadPacketEntitiesWorkItems
+  - name: CNetworkGameClient_OnPreserveEntity
+    alias:
+    - CNetworkGameClient::OnPreserveEntity
+  - name: CNetworkGameClient_GetClientNetworkable
+    alias:
+    - CNetworkGameClient::GetClientNetworkable
+  - name: CNetworkGameClient_CopyNewEntity
+    alias:
+    - CNetworkGameClient::CopyNewEntity
+  - name: CNetworkGameClient_CopyExistingEntity
+    alias:
+    - CNetworkGameClient::CopyExistingEntity
+  - name: CNetworkGameClient_OnReceivedUncompressedPacket
+    alias:
+    - CNetworkGameClient::OnReceivedUncompressedPacket
+  - name: CNetworkGameClient_Clear
+    alias:
+    - CNetworkGameClient::Clear
+  - name: CNetworkGameClient_DisconnectGame
+    alias:
+    - CNetworkGameClient::DisconnectGame
+  - name: INetworkMessages_FindNetworkGroup
+    alias:
+    - INetworkMessages::FindNetworkGroup
+  - name: INetworkClientService_IsActive
+    alias:
+    - INetworkClientService::IsActive
+  - name: INetworkClientService_IsConnected
+    alias:
+    - INetworkClientService::IsConnected
+  - name: INetworkClientService_IsPutInServer
+    alias:
+    - INetworkClientService::IsPutInServer
+  - name: INetworkClientService_IsConnecting
+    alias:
+    - INetworkClientService::IsConnecting
+  - name: CInputService_ProcessConVar
+    alias:
+    - CInputService::ProcessConVar
+  - name: CInputService_ProcessCommand
+    alias:
+    - CInputService::ProcessCommand
+  - name: CInputService_IsClientOnlyCommandAllowed
+    alias:
+    - CInputService::IsClientOnlyCommandAllowed
+  - name: CNetworkClientService_RegisterEventMapInternal
+    alias:
+    - CNetworkClientService::RegisterEventMapInternal
+  - name: CNetworkClientService_RegisterEventMap
+    alias:
+    - CNetworkClientService::RegisterEventMap
+  - name: CNetworkClientService_OnClientAdvanceTick
+    alias:
+    - CNetworkClientService::OnClientAdvanceTick
+  - name: CNetworkClientService_OnClientProcessGameInput
+    alias:
+    - CNetworkClientService::OnClientProcessGameInput
+  - name: ISource2Client_ProcessGameInput
+    alias:
+    - ISource2Client::ProcessGameInput
+  - name: CNetworkClientService_OnClientPollNetworking
+    alias:
+    - CNetworkClientService::OnClientPollNetworking
+  - name: CNetworkClientService_OnClientProcessNetworking
+    alias:
+    - CNetworkClientService::OnClientProcessNetworking
+  - name: CNetworkClientService_OnClientSimulate
+    alias:
+    - CNetworkClientService::OnClientSimulate
+  - name: CNetworkClientService_OnClientPauseSimulate
+    alias:
+    - CNetworkClientService::OnClientPauseSimulate
+  - name: CNetworkClientService_OnClientFrameSimulate
+    alias:
+    - CNetworkClientService::OnClientFrameSimulate
+  - name: CNetworkClientService_OnSimpleLoopFrameUpdate
+    alias:
+    - CNetworkClientService::OnSimpleLoopFrameUpdate
+  - name: CNetworkClientService_OnFrameBoundary
+    alias:
+    - CNetworkClientService::OnFrameBoundary
+  - name: CNetworkClientService_OnServerPostSimulate
+    alias:
+    - CNetworkClientService::OnServerPostSimulate
+  - name: CNetworkClientService_OnServerBeginAsyncPostTickWork
+    alias:
+    - CNetworkClientService::OnServerBeginAsyncPostTickWork
+  - name: CNetworkClientService_ReceivedServerInfo
+    alias:
+    - CNetworkClientService::ReceivedServerInfo
+  - name: CNetworkClientService_SplitScreenConnect
+    alias:
+    - CNetworkClientService::SplitScreenConnect
+  - name: CNetworkClientService_SendNetMessage
+    alias:
+    - CNetworkClientService::SendNetMessage
+  - name: CNetworkClientService_SendStringCmd
+    alias:
+    - CNetworkClientService::SendStringCmd
+  - name: CNetworkClientService_StartChangeLevel
+    alias:
+    - CNetworkClientService::StartChangeLevel
+  - name: CNetworkClientService_FinishChangeLevel
+    alias:
+    - CNetworkClientService::FinishChangeLevel
+  - name: CNetworkClientService_PrintConnectionStatus
+    alias:
+    - CNetworkClientService::PrintConnectionStatus
+  - name: CNetworkClientService_OnStatus
+    alias:
+    - CNetworkClientService::OnStatus
+  - name: CNetworkClientService_ServerCmd
+    alias:
+    - CNetworkClientService::ServerCmd
+  - name: CNetworkClientService_GetDisconnectReason
+    alias:
+    - CNetworkClientService::GetDisconnectReason
+  - name: CNetworkClientService_PrintSpawnGroupStatus
+    alias:
+    - CNetworkClientService::PrintSpawnGroupStatus
+  - name: CNetworkClientService_IsActive
+    alias:
+    - CNetworkClientService::IsActive
+  - name: CNetworkClientService_IsConnected
+    alias:
+    - CNetworkClientService::IsConnected
+  - name: CNetworkClientService_IsPutInServer
+    alias:
+    - CNetworkClientService::IsPutInServer
+  - name: CNetworkClientService_IsConnecting
+    alias:
+    - CNetworkClientService::IsConnecting
+  - name: CEngineSoundServices_ShouldSuppressNonUISounds
+    alias:
+    - CEngineSoundServices::ShouldSuppressNonUISounds
+  - name: CNetworkClientService_ClockDriftAdjustFrameTime
+    alias:
+    - CNetworkClientService::ClockDriftAdjustFrameTime
+  - name: CNetworkClientService_Init
+    alias:
+    - CNetworkClientService::Init
+  - name: CNetworkClientService_Shutdown
+    alias:
+    - CNetworkClientService::Shutdown
+  - name: CNetworkClientService_DisconnectGameNow
+    alias:
+    - CNetworkClientService::DisconnectGameNow
+  - name: CGameClientConnectPrerequisite_ctor
+    alias:
+    - CGameClientConnectPrerequisite::CGameClientConnectPrerequisite
+  - name: CNetworkClientService_AddClientPrerequisites
+    alias:
+    - CNetworkClientService::AddClientPrerequisites
+  - name: CNetworkClientService_AllocateRemoteConnectionClient
+    alias:
+    - CNetworkClientService::AllocateRemoteConnectionClient
+  - name: CNetworkServerService_Init
+    alias:
+    - CNetworkServerService::Init
+  - name: CNetworkServerService_StartupServer
+    alias:
+    - CNetworkServerService::StartupServer
+  - name: CNetworkServerService_RegisterEventMapInternal
+    alias:
+    - CNetworkServerService::RegisterEventMapInternal
+  - name: CNetworkServerService_OnServerAdvanceTick
+    alias:
+    - CNetworkServerService::OnServerAdvanceTick
+  - name: CNetworkServerService_OnServerPollNetworking
+    alias:
+    - CNetworkServerService::OnServerPollNetworking
+  - name: CNetworkServerService_OnServerProcessNetworking
+    alias:
+    - CNetworkServerService::OnServerProcessNetworking
+  - name: CNetworkServerService_OnServerBeginSimulate
+    alias:
+    - CNetworkServerService::OnServerBeginSimulate
+  - name: CNetworkServerService_OnServerEndSimulate
+    alias:
+    - CNetworkServerService::OnServerEndSimulate
+  - name: CNetworkServerService_OnServerPostSimulate
+    alias:
+    - CNetworkServerService::OnServerPostSimulate
+  - name: CNetworkServerService_OnServerPostAdvanceTick
+    alias:
+    - CNetworkServerService::OnServerPostAdvanceTick
+  - name: CNetworkServerService_OnFrameBoundary
+    alias:
+    - CNetworkServerService::OnFrameBoundary
+  - name: CNetworkServerService_OnClientPollNetworking
+    alias:
+    - CNetworkServerService::OnClientPollNetworking
+  - name: CNetworkServerService_OnSimpleLoopFrameUpdate
+    alias:
+    - CNetworkServerService::OnSimpleLoopFrameUpdate
+  - name: CNetworkServerService_OnKickByIdHLTV
+    alias:
+    - CNetworkServerService::OnKickByIdHLTV
+  - name: CNetworkServerService_DisconnectGameNow
+    alias:
+    - CNetworkServerService::DisconnectGameNow
+  - name: INetworkGameServer_GetMaxClients
+    alias:
+    - INetworkGameServer::GetMaxClients
+  - name: INetworkGameServer_PreWorldUpdate
+    alias:
+    - INetworkGameServer::PreWorldUpdate
+  - name: CNetworkGameServer_PreWorldUpdate
+    alias:
+    - CNetworkGameServer::PreWorldUpdate
+  - name: INetworkGameServer_ServerEndSimulate
+    alias:
+    - INetworkGameServer::ServerEndSimulate
+  - name: CNetworkGameServerBase_ServerEndSimulate
+    alias:
+    - CNetworkGameServerBase::ServerEndSimulate
+  - name: INetworkGameServer_ServerPostSimulate
+    alias:
+    - INetworkGameServer::ServerPostSimulate
+  - name: CNetworkGameServerBase_ServerPostSimulate
+    alias:
+    - CNetworkGameServerBase::ServerPostSimulate
+  - name: INetworkGameServer_ServerAdvanceTick
+    alias:
+    - INetworkGameServer::ServerAdvanceTick
+  - name: CNetworkGameServerBase_ServerAdvanceTick
+    alias:
+    - CNetworkGameServerBase::ServerAdvanceTick
+  - name: INetworkGameServer_ServerProcessNetworking
+    alias:
+    - INetworkGameServer::ServerProcessNetworking
+  - name: CNetworkGameServerBase_ServerProcessNetworking
+    alias:
+    - CNetworkGameServerBase::ServerProcessNetworking
+  - name: INetworkGameServer_GetTimescale
+    alias:
+    - INetworkGameServer::GetTimescale
+  - name: CNetworkGameServerBase_GetTimescale
+    alias:
+    - CNetworkGameServerBase::GetTimescale
+  - name: ISource2Server_PreWorldUpdate
+    alias:
+    - ISource2Server::PreWorldUpdate
+  - name: ISource2Server_OutOfGameFrameBoundary
+    alias:
+    - ISource2Server::OutOfGameFrameBoundary
+  - name: INetworkMessages_SetIsForServer
+    alias:
+    - INetworkMessages::SetIsForServer
+  - name: CRenderingWorldSession_FindOrCreateWorldSession
+    alias:
+    - CRenderingWorldSession::FindOrCreateWorldSession
+  - name: CRenderingWorldSession_GetEntityLumpForTemplate
+    alias:
+    - CRenderingWorldSession::GetEntityLumpForTemplate
+  - name: CEngineClient_GetEntityLumpForTemplate
+    alias:
+    - CEngineClient::GetEntityLumpForTemplate
+  - name: CEngineClient_FindOrCreateWorldSession
+    alias:
+    - CEngineClient::FindOrCreateWorldSession
+  - name: CEngineClient_GetStatsAppID
+    alias:
+    - CEngineClient::GetStatsAppID
+  - name: CEngineClient_DumpNetStats
+    alias:
+    - CEngineClient::DumpNetStats
+  - name: CEngineClient_ExecuteClientCmd
+    alias:
+    - CEngineClient::ExecuteClientCmd
+  - name: CEngineClient_IsPlayingDemo
+    alias:
+    - CEngineClient::IsPlayingDemo
+  - name: CInputService_ProcessCommandBuffer
+    alias:
+    - CInputService::ProcessCommandBuffer
+  - name: CInputService_ProcessCommandBuffers
+    alias:
+    - CInputService::ProcessCommandBuffers
+  - name: CInputService_HandleAnalogValueChange
+    alias:
+    - CInputService::HandleAnalogValueChange
+  - name: CInputService_HandleInputEvent
+    alias:
+    - CInputService::HandleInputEvent
+  - name: CEngineClient_ClientCmd_Unrestricted
+    alias:
+    - CEngineClient::ClientCmd_Unrestricted
+  - name: INetworkGameClient_SendStringCmd
+    alias:
+    - INetworkGameClient::SendStringCmd
+  - name: CEngineServer_DumpNetStats
+    alias:
+    - CEngineServer::DumpNetStats
+  - name: CEngineServer_ClientPrintf
+    alias:
+    - CEngineServer::ClientPrintf
+  - name: CEngineServer_GetFrameTimeAmnesty
+    alias:
+    - CEngineServer::GetFrameTimeAmnesty
+  - name: CEngineServer_ShowFrameTimeReport
+    alias:
+    - CEngineServer::ShowFrameTimeReport
+  - name: CEngineServer_SetFrameTimeAmnesty
+    alias:
+    - CEngineServer::SetFrameTimeAmnesty
+  - name: CEngineServer_GetSteamUniverse
+    alias:
+    - CEngineServer::GetSteamUniverse
+  - name: CEngineServer_ChangeLevel
+    alias:
+    - CEngineServer::ChangeLevel
+  - name: CMapListService_IsMapValid
+    alias:
+    - CMapListService::IsMapValid
+    - IMapListService::IsMapValid
+  - name: CEngineServer_IsMapValid
+    alias:
+    - CEngineServer::IsMapValid
+  - name: CEngineServer_PrecacheGeneric
+    alias:
+    - CEngineServer::PrecacheGeneric
+  - name: CEngineServer_ClientCommand
+    alias:
+    - CEngineServer::ClientCommand
+  - name: CEngineServer_GetClientConVarValue
+    alias:
+    - CEngineServer::GetClientConVarValue
+  - name: CEngineServer_SetFakeClientConVarValue
+    alias:
+    - CEngineServer::SetFakeClientConVarValue
+  - name: CEngineServer_CreateFakeClient
+    alias:
+    - CEngineServer::CreateFakeClient
+  - name: CEngineServer_GetPlayerInfo
+    alias:
+    - CEngineServer::GetPlayerInfo
+  - name: CEngineServer_ClientCommandKeyValues
+    alias:
+    - CEngineServer::ClientCommandKeyValues
+  - name: CLog_Print
+    alias:
+    - CLog::Print
+  - name: CEngineServer_LogPrint
+    alias:
+    - CEngineServer::LogPrint
+  - name: CEngineServer_KickClient
+    alias:
+    - CEngineServer::KickClient
+  - name: CEngineServer_IsDedicatedServer
+    alias:
+    - CEngineServer::IsDedicatedServer
+  - name: CEngineServer_GetServerGlobals
+    alias:
+    - CEngineServer::GetServerGlobals
+  - name: CEngineServer_GetAchievementMgr
+    alias:
+    - CEngineServer::GetAchievementMgr
+  - name: CEngineServer_IsLogEnabled
+    alias:
+    - CEngineServer::IsLogEnabled
+  - name: CEngineServer_ServerCommand
+    alias:
+    - CEngineServer::ServerCommand
+  - name: CLoopTypeClientSimple_ActivateEngineServices
+    alias:
+    - CLoopTypeClientServer::ActivateEngineServices
+  - name: CLoopTypeClientServer_LoopTypeInit
+    alias:
+    - CLoopTypeClientServer::LoopTypeInit
+  - name: CLoopTypeClientServer_AdvanceTime
+    alias:
+    - CLoopTypeClientServer::AdvanceTime
+  - name: CLoopTypeClientServer_Update
+    alias:
+    - CLoopTypeClientServer::Update
+  - name: CLoopTypeClientServer_ActivateLoop
+    alias:
+    - CLoopTypeClientServer::ActivateLoop
+  - name: CLoopTypeClientServer_AllocateLoopMode
+    alias:
+    - CLoopTypeClientServer::AllocateLoopMode
+  - name: CLoopTypeClientServer_WritePerfStats
+    alias:
+    - CLoopTypeClientServer::WritePerfStats
+  - name: CLoopTypeClientServer_DeactivateLoop
+    alias:
+    - CLoopTypeClientServer::DeactivateLoop
+  - name: CLoopTypeClientServer_OutputListeners
+    alias:
+    - CLoopTypeClientServer::OutputListeners
+  - name: CLoopTypeSimple_FrameUpdate
+    alias:
+    - CLoopTypeSimple::FrameUpdate
+  - name: CLoopTypeClientServerService_OnLoopActivate
+    alias:
+    - CLoopTypeClientServerService::OnLoopActivate
+  - name: CLoopTypeSimpleService_OnLoopActivate
+    alias:
+    - CLoopTypeSimpleService::OnLoopActivate
+  - name: CLoopTypeClientServerService_HandleInputEvent
+    alias:
+    - CLoopTypeClientServerService::HandleInputEvent
+  - name: ILoopMode_HandleInputEvent
+    alias:
+    - ILoopMode::HandleInputEvent
+  - name: ILoopType_AddEngineService
+    alias:
+    - ILoopType::AddEngineService
+  - name: CLoopTypeBase_DeallocateLoopMode
+    alias:
+    - CLoopTypeBase::DeallocateLoopMode
+  - name: CLoopTypeBase_EngineLoop
+    alias:
+    - CLoopTypeBase::EngineLoop
+  - name: CLoopTypeBase_FrameUpdate
+    alias:
+    - CLoopTypeBase::FrameUpdate
+  - name: CLoopTypeBase_ActivateLoop
+    alias:
+    - CLoopTypeBase::ActivateLoop
+  - name: CLoopTypeBase_AllocateLoopMode
+    alias:
+    - CLoopTypeBase::AllocateLoopMode
+  - name: CLoopTypeBase_DeactivateLoop
+    alias:
+    - CLoopTypeBase::DeactivateLoop
+  - name: CLoopTypeBase_LoopTypeInit
+    alias:
+    - CLoopTypeBase::LoopTypeInit
+  - name: CLoopTypeBase_LoopTypeShutdown
+    alias:
+    - CLoopTypeBase::LoopTypeShutdown
+  - name: CLoopTypeBase_GetClientServerMode
+    alias:
+    - CLoopTypeBase::GetClientServerMode
+  - name: CLoopTypeBase_GetImplType
+    alias:
+    - CLoopTypeBase::GetImplType
+  - name: CLoopTypeBase_AddDependentServices
+    alias:
+    - CLoopTypeBase::AddDependentServices
+  - name: CLoopTypeBase_GenerateServiceDependencies
+    alias:
+    - CLoopTypeBase::GenerateServiceDependencies
+  - name: CLoopTypeBase_GenerateSecondaryDependencies
+    alias:
+    - CLoopTypeBase::GenerateSecondaryDependencies
+  - name: CLoopTypeBase_LoadDependentServices
+    alias:
+    - CLoopTypeBase::LoadDependentServices
+  - name: IEngineService_GetServiceDependencies
+    alias:
+    - IEngineService::GetServiceDependencies
+  - name: IEngineService_GetName
+    alias:
+    - IEngineService::GetName
+  - name: ILoopModeFactory_GetLoopModeType
+    alias:
+    - ILoopModeFactory::GetLoopModeType
+  - name: ILoopModeFactory_Shutdown
+    alias:
+    - ILoopModeFactory::Shutdown
+  - name: CEngineServiceMgr_RegisterEngineService
+    alias:
+    - CEngineServiceMgr::RegisterEngineService
+  - name: CEngineServiceMgr_RegisterLoopMode
+    alias:
+    - CEngineServiceMgr::RegisterLoopMode
+  - name: CEngineServiceMgr_UnregisterLoopMode
+    alias:
+    - CEngineServiceMgr::UnregisterLoopMode
+  - name: CEngineServiceMgr_UnregisterEngineService
+    alias:
+    - CEngineServiceMgr::UnregisterEngineService
+  - name: CEngineServiceMgr_SwitchToLoop
+    alias:
+    - CEngineServiceMgr::SwitchToLoop
+  - name: CEngineServiceMgr_PrintStatus
+    alias:
+    - CEngineServiceMgr::PrintStatus
+  - name: CEngineServiceMgr__MainLoop
+    alias:
+    - CEngineServiceMgr::_MainLoop
+  - name: CEngineServiceMgr_DeactivateLoop
+    alias:
+    - CEngineServiceMgr::DeactivateLoop
+  - name: CEngineServiceMgr_Shutdown
+    alias:
+    - CEngineServiceMgr::Shutdown
+  - name: CEngineServiceMgr_GetActiveLoopClientServerMode
+    alias:
+    - CEngineServiceMgr::GetActiveLoopClientServerMode
+  - name: CEngineServiceMgr_GetEventDispatcher
+    alias:
+    - CEngineServiceMgr::GetEventDispatcher
+  - name: CEngineGameUI_Shutdown
+    alias:
+    - CEngineGameUI::Shutdown
+  - name: IAppSystem_Shutdown
+    alias:
+    - IAppSystem::Shutdown
+  - name: CSplitScreenService_AddSplitScreenUser
+    alias:
+    - CSplitScreenService::AddSplitScreenUser
+  - name: CSplitScreenService_LoadUserConfiguration
+    alias:
+    - CSplitScreenService::LoadUserConfiguration
+  - name: CHLTVClient_ProcessSetConVar
+    alias:
+    - CHLTVClient::ProcessSetConVar
+  - name: CHLTVBroadcast_RecordSnapshot
+    alias:
+    - CHLTVBroadcast::RecordSnapshot
+  - name: CServerSideClientBase_ProcessTick
+    alias:
+    - CServerSideClientBase::ProcessTick
+  - name: CServerSideClientBase_ProcessStringCmd
+    alias:
+    - CServerSideClientBase::ProcessStringCmd
+  - name: CServerSideClientBase_MarkSpawnGroupLoadCompleted
+    alias:
+    - CServerSideClientBase::MarkSpawnGroupLoadCompleted
+  - name: CServerSideClientBase_ProcessSpawnGroup_LoadCompleted
+    alias:
+    - CServerSideClientBase::ProcessSpawnGroup_LoadCompleted
+  - name: CServerSideClientBase_ProcessClientInfo
+    alias:
+    - CServerSideClientBase::ProcessClientInfo
+  - name: CServerSideClientBase_ProcessBaselineAck
+    alias:
+    - CServerSideClientBase::ProcessBaselineAck
+  - name: CServerSideClientBase_ProcessSplitPlayerConnectInternal
+    alias:
+    - CServerSideClientBase::ProcessSplitPlayerConnectInternal
+  - name: CServerSideClientBase_ProcessSplitPlayerConnect
+    alias:
+    - CServerSideClientBase::ProcessSplitPlayerConnect
+  - name: CServerSideClientBase_GetUserIDString
+    alias:
+    - CServerSideClientBase::GetUserIDString
+  - name: CServerSideClientBase_GetNetworkIDString
+    alias:
+    - CServerSideClientBase::GetNetworkIDString
+  - name: CServerSideClientBase_Connect
+    alias:
+    - CServerSideClientBase::Connect
+  - name: CServerSideClientBase_GetPlayerInfo
+    alias:
+    - CServerSideClientBase::GetPlayerInfo
+  - name: CNetworkGameServer_GetPlayerNetworkIDString
+    alias:
+    - CNetworkGameServer::GetPlayerNetworkIDString
+  - name: CNetworkGameServerBase_RemoveClientFromGame
+    alias:
+    - CNetworkGameServerBase::RemoveClientFromGame
+  - name: CEngineServer_GetPlayerNetworkIDString
+    alias:
+    - CEngineServer::GetPlayerNetworkIDString
+  - name: CNetworkGameClientBase_ServerCmd
+    alias:
+    - CNetworkGameClientBase::ServerCmd
+  - name: CNetworkGameClientBase_ProcessSetConVar
+    alias:
+    - CNetworkGameClientBase::ProcessSetConVar
+  - name: CNetworkGameClientBase_SendStringCmd
+    alias:
+    - CNetworkGameClientBase::SendStringCmd
+  - name: CNetworkGameClientBase_StartChangeLevel
+    alias:
+    - CNetworkGameClientBase::StartChangeLevel
+  - name: CNetworkGameClientBase_FinishChangeLevel
+    alias:
+    - CNetworkGameClientBase::FinishChangeLevel
+  - name: CNetworkGameClientBase_DeferActivate
+    alias:
+    - CNetworkGameClientBase::DeferActivate
+  - name: CNetworkGameClientBase_ClockDrift_AdjustFrameTime
+    alias:
+    - CNetworkGameClientBase::ClockDrift_AdjustFrameTime
+  - name: CNetworkGameClientBase_Connect
+    alias:
+    - CNetworkGameClientBase::Connect
+  - name: CNetworkGameClientBase_DisconnectGame
+    alias:
+    - CNetworkGameClientBase::DisconnectGame
+  - name: CNetSupportImpl_Connect
+    alias:
+    - CNetSupportImpl::Connect
+- name: client
+  symbols:
+  - name: CLoopModeGame_RegisterEventMapInternal
+    alias:
+    - CLoopModeGame::RegisterEventMapInternal
+  - name: CLoopModeGame_OnClientPollNetworking
+    alias:
+    - CLoopModeGame::OnClientPollNetworking
+  - name: CLoopModeGame_OnClientAdvanceTick
+    alias:
+    - CLoopModeGame::OnClientAdvanceTick
+  - name: CLoopModeGame_OnClientPostAdvanceTick
+    alias:
+    - CLoopModeGame::OnClientPostAdvanceTick
+  - name: CLoopModeGame_OnClientPreSimulate
+    alias:
+    - CLoopModeGame::OnClientPreSimulate
+  - name: CLoopModeGame_OnClientPreOutput
+    alias:
+    - CLoopModeGame::OnClientPreOutput
+  - name: CLoopModeGame_OnClientPreOutputParallelWithServer
+    alias:
+    - CLoopModeGame::OnClientPreOutputParallelWithServer
+  - name: CLoopModeGame_OnClientPostOutput
+    alias:
+    - CLoopModeGame::OnClientPostOutput
+  - name: CLoopModeGame_OnClientFrameSimulate
+    alias:
+    - CLoopModeGame::OnClientFrameSimulate
+  - name: CLoopModeGame_OnClientAdvanceNonRenderedFrame
+    alias:
+    - CLoopModeGame::OnClientAdvanceNonRenderedFrame
+  - name: CLoopModeGame_OnClientPostSimulate
+    alias:
+    - CLoopModeGame::OnClientPostSimulate
+  - name: CLoopModeGame_OnClientPauseSimulate
+    alias:
+    - CLoopModeGame::OnClientPauseSimulate
+  - name: CLoopModeGame_OnClientSimulate
+    alias:
+    - CLoopModeGame::OnClientSimulate
+  - name: CLoopModeGame_OnPostDataUpdate
+    alias:
+    - CLoopModeGame::OnPostDataUpdate
+  - name: CLoopModeGame_OnPreDataUpdate
+    alias:
+    - CLoopModeGame::OnPreDataUpdate
+  - name: CLoopModeGame_OnFrameBoundary
+    alias:
+    - CLoopModeGame::OnFrameBoundary
+  - name: CLoopModeGame_StaticInit
+    alias:
+    - CLoopModeGame::StaticInit
+  - name: CLoopModeFactory_CLoopModeGame_Init
+    alias:
+    - CLoopModeFactory<CLoopModeGame>::Init
+  - name: CLoopModeFactory_CLoopModeGame_Shutdown
+    alias:
+    - CLoopModeFactory<CLoopModeGame>::Shutdown
+  - name: CLoopModeGame_OnLoopActivate
+    alias:
+    - CLoopModeGame::OnLoopActivate
+  - name: ILoopMode_OnLoopActivate
+    alias:
+    - ILoopMode::OnLoopActivate
+  - name: CLoopModeGame_AddViewsToSceneSystem
+    alias:
+    - CLoopModeGame::AddViewsToSceneSystem
+  - name: ILoopMode_AddViewsToSceneSystem
+    alias:
+    - ILoopMode::AddViewsToSceneSystem
+  - name: CLoopModeGame_LoopInitInternal
+    alias:
+    - CLoopModeGame::LoopInitInternal
+  - name: CLoopModeGame_LoopInit
+    alias:
+    - CLoopModeGame::LoopInit
+  - name: ILoopMode_LoopInit
+    alias:
+    - ILoopMode::LoopInit
+  - name: ILoopMode_LoopShutdown
+    alias:
+    - ILoopMode::LoopShutdown
+  - name: CLoopModeGame_ReceivedServerInfo
+    alias:
+    - CLoopModeGame::ReceivedServerInfo
+  - name: CLoopModeGame_RegisterEventMap
+    alias:
+    - CLoopModeGame::RegisterEventMap
+  - name: ILoopMode_RegisterEventMap
+    alias:
+    - ILoopMode::RegisterEventMap
+  - name: CLoopModeGame_SetWorldSession
+    alias:
+    - CLoopModeGame::SetWorldSession
+  - name: CLoopModeGame_SetGameSystemState
+    alias:
+    - CLoopModeGame::SetGameSystemState
+  - name: CLoopModeGame_LoopShutdown
+    alias:
+    - CLoopModeGame::LoopShutdown
+  - name: IGameSystem_AddByName
+    alias:
+    - IGameSystem::AddByName
+  - name: IGameSystem_Add
+    alias:
+    - IGameSystem::Add
+  - name: IGameSystem_PostInit
+    alias:
+    - IGameSystem::PostInit
+  - name: IGameSystem_InitAllSystems
+    alias:
+    - IGameSystem::InitAllSystems
+  - name: IGameSystem_LoopInitAllSystems
+    alias:
+    - IGameSystem::LoopInitAllSystems
+  - name: IGameSystemFactory_PostInit
+    alias:
+    - IGameSystemFactory::PostInit
+  - name: IGameSystemFactory_GetStaticGameSystem
+    alias:
+    - IGameSystemFactory::GetStaticGameSystem
+  - name: IGameSystemFactory_ShouldAutoAdd
+    alias:
+    - IGameSystemFactory::ShouldAutoAdd
+  - name: IGameSystemFactory_CreateGameSystem
+    alias:
+    - IGameSystemFactory::CreateGameSystem
+  - name: IGameSystemFactory_IsReallocating
+    alias:
+    - IGameSystemFactory::IsReallocating
+  - name: IGameSystem_SetName
+    alias:
+    - IGameSystem::SetName
+  - name: CSpawnGroupMgrGameSystem_DoesGameSystemReallocate
+    alias:
+    - IGameSystem::DoesGameSystemReallocate
+  - name: IGameSystem_DestroyAllGameSystems
+    alias:
+    - IGameSystem::DestroyAllGameSystems
+  - name: IGameSystem_ShutdownAllSystems
+    alias:
+    - IGameSystem::ShutdownAllSystems
+  - name: IGameSystem_LoopDestroyAllSystems
+    alias:
+    - IGameSystem::LoopDestroyAllSystems
+  - name: IGameSystem_LoopPreShutdownAllSystems
+    alias:
+    - IGameSystem::LoopPreShutdownAllSystems
+  - name: IGameSystem_OnClientPollNetworking
+    alias:
+    - IGameSystem::OnClientPollNetworking
+  - name: IGameSystem_OnClientGamePostSimulate
+    alias:
+    - IGameSystem::ClientGamePostSimulate
+  - name: IGameSystem_OnClientPauseSimulate
+    alias:
+    - IGameSystem::OnClientPauseSimulate
+  - name: IGameSystem_OnClientPreUpdate
+    alias:
+    - IGameSystem::OnClientPreUpdate
+  - name: IGameSystem_OnClientPostUpdate
+    alias:
+    - IGameSystem::OnClientPostUpdate
+  - name: IGameSystem_OnClientPostDataUpdate
+    alias:
+    - IGameSystem::OnClientPostDataUpdate
+  - name: IGameSystem_OnGameFrameBoundary
+    alias:
+    - IGameSystem::OnGameFrameBoundary
+  - name: IGameSystem_OnClientAdvanceNonRenderedFrame
+    alias:
+    - IGameSystem::OnClientAdvanceNonRenderedFrame
+  - name: IGameSystem_OnClientFrameSimulate
+    alias:
+    - IGameSystem::OnClientFrameSimulate
+  - name: IGameSystem_OnClientAdvanceTick
+    alias:
+    - IGameSystem::ClientAdvanceTick
+  - name: IGameSystem_OnClientPostAdvanceTick
+    alias:
+    - IGameSystem::ClientPostAdvanceTick
+  - name: IGameSystem_OnClientPostRender
+    alias:
+    - IGameSystem::OnClientPostRender
+  - name: IGameSystem_OnClientPreRender
+    alias:
+    - IGameSystem::OnClientPreRender
+  - name: IGameSystem_OnClientPreRenderAlt
+    alias:
+    - IGameSystem::OnClientPreRenderAlt
+  - name: CSource2Client_CreateMove
+    alias:
+    - CSource2Client::CreateMove
+  - name: CClientInput_CreateMove
+    alias:
+    - CClientInput::CreateMove
+  - name: CClientInput_m_viewangles
+    alias:
+    - CClientInput::m_viewangles
+  - name: CSource2Client_ProcessGameInput
+    alias:
+    - CSource2Client::ProcessGameInput
+  - name: ISource2Client_FrameStageNotify
+    alias:
+    - ISource2Client::FrameStageNotify
+  - name: CSource2Client_FrameStageNotify
+    alias:
+    - CSource2Client::FrameStageNotify
+  - name: IViewRender_OnRenderStart
+    alias:
+    - IViewRender::OnRenderStart
+  - name: CViewRender_OnRenderStart
+    alias:
+    - CViewRender::OnRenderStart
+  - name: CViewRender_Render
+    alias:
+    - CViewRender::Render
+  - name: C_BaseEntity_SetInterpolationPhase
+    alias:
+    - C_BaseEntity::SetInterpolationPhase
+  - name: CSource2Client_SetGlobals
+    alias:
+    - CSource2Client::SetGlobals
+  - name: CSource2Client_Connect
+    alias:
+    - CSource2Client::Connect
+  - name: CBasePlayerController_CheckForLocalPlayer
+    alias:
+    - CBasePlayerController::CheckForLocalPlayer
+  - name: CSource2Client_OnDisconnect
+    alias:
+    - CSource2Client::OnDisconnect
+  - name: IGameSystem_OnClientDisconnect
+    alias:
+    - IGameSystem::OnClientDisconnect
+  - name: IGameSystem_OnClientPreEntityThink
+    alias:
+    - IGameSystem::OnClientPreEntityThink
+  - name: CNetworkGameClient_OnSource1Source1LegacyGameEvent
+    alias:
+    - CNetworkGameClient::OnSource1Source1LegacyGameEvent
+  - name: CMapAnNodeManager_FireGameEvent
+    alias:
+    - CMapAnNodeManager::FireGameEvent
+  - name: C_ServerVoiceHandler_OnServerVoiceData
+    alias:
+    - C_ServerVoiceHandler::OnServerVoiceData
+  - name: IVEngineClient2_IsPlayingDemo
+    alias:
+    - IVEngineClient2::IsPlayingDemo
+  - name: IVEngineClient2_ExecuteClientCmd
+    alias:
+    - IVEngineClient2::ExecuteClientCmd
+  - name: IGameEventManager2_UnserializeEvent
+    alias:
+    - IGameEventManager2::UnserializeEvent
+  - name: IGameEventManager2_FireEventClientSide
+    alias:
+    - IGameEventManager2::FireEventClientSide
+  - name: CGameEventManager_FireEventClientSide
+    alias:
+    - CGameEventManager::FireEventClientSide
+  - name: CGameEventManager_UnserializeEvent
+    alias:
+    - CGameEventManager::UnserializeEvent
+  - name: CSteamworksGameStats_OnReceivedSessionID
+    alias:
+    - CSteamworksGameStats::OnReceivedSessionID
+  - name: IGameSystem_GetName
+    alias:
+    - IGameSystem::GetName
+  - name: IGameSystemFactory_DestroyGameSystem
+    alias:
+    - IGameSystemFactory::DestroyGameSystem
+  - name: IGameSystemFactory_Init
+    alias:
+    - IGameSystemFactory::Init
+  - name: IGameSystemFactory_GetPriority
+    alias:
+    - IGameSystemFactory::GetPriority
+  - name: IGameSystemFactory_Shutdown
+    alias:
+    - IGameSystemFactory::Shutdown
+  - name: IGameSystemFactory_SetGlobalPtr
+    alias:
+    - IGameSystemFactory::SetGlobalPtr
+  - name: CPrediction_PostNetworkDataReceived
+    alias:
+    - CPrediction::PostNetworkDataReceived
+  - name: IEngineServiceMgr_GetActiveLoopClientServerMode
+    alias:
+    - IEngineServiceMgr::GetActiveLoopClientServerMode
+  - name: IEngineServiceMgr_GetEventDispatcher
+    alias:
+    - IEngineServiceMgr::GetEventDispatcher
+  - name: ClientModeCSNormal_Update
+    alias:
+    - ClientModeCSNormal::Update
+  - name: CEntitySystem_ctor
+    alias:
+    - CEntitySystem::CEntitySystem
+  - name: CGameEntitySystem_ctor
+    alias:
+    - CGameEntitySystem::CGameEntitySystem
+  - name: CEntitySystem_Init
+    alias:
+    - CEntitySystem::Init
+  - name: CEntitySystem_PostCreateEntitySystem
+    alias:
+    - CEntitySystem::PostCreateEntitySystem
+  - name: CSource2EntitySystem_StaticInit
+    alias:
+    - CSource2EntitySystem::StaticInit
+  - name: CGameSystemReallocatingFactory_CSource2EntitySystem_Init
+    alias:
+    - CGameSystemReallocatingFactory<CSource2EntitySystem>::Init
+  - name: CGameSystemReallocatingFactory_CSource2EntitySystem_CreateGameSystem
+    alias:
+    - CGameSystemReallocatingFactory<CSource2EntitySystem>::CreateGameSystem
+  - name: CSkeletonInstance_PostDataUpdate
+    alias:
+    - CSkeletonInstance::PostDataUpdate
+  - name: CSkeletonInstance_m_modelState_m_simulationState
+    alias:
+    - CSkeletonInstance::m_modelState.m_simulationState
+  - name: CSkeletonInstance_m_modelState_m_hModel
+    alias:
+    - CSkeletonInstance::m_modelState.m_hModel
+  - name: CSimulationState_SetupJointState
+    alias:
+    - CSimulationState::SetupJointState
+  - name: CSimulationState_m_nTotalTransformCount
+    alias:
+    - CSimulationState::m_nTotalTransformCount
+  - name: CSimulationState_m_nBoneCount
+    alias:
+    - CSimulationState::m_nBoneCount
+  - name: CSimulationState_m_nAttachmentCount
+    alias:
+    - CSimulationState::m_nAttachmentCount
+  - name: IVEngineClient2_GetNetworkClient
+    alias:
+    - IVEngineClient2::GetNetworkClient
+  - name: INetworkClient_GetLocalAddress
+    alias:
+    - INetworkClient::GetLocalAddress
+  - name: INetworkClientService_IsConnected
+    alias:
+    - INetworkClientService::IsConnected
+  - name: INetworkClientService_SendNetMessage
+    alias:
+    - INetworkClientService::SendNetMessage
+  - name: C_GameRules_ctor
+    alias:
+    - C_GameRules::C_GameRules
+  - name: IGameResourceService_SetEntityResourceManifestHandler
+    alias:
+    - IGameResourceService::SetEntityResourceManifestHandler
+  - name: CNetworkSerializerBindingBuildFilter_GetFieldPriority
+    alias:
+    - CNetworkSerializerBindingBuildFilter::GetFieldPriority
+  - name: GameStateAPI_RegisterAPIs
+    alias:
+    - GameStateAPI::RegisterAPIs
+  - name: GameStateAPI_IsLatched
+    alias:
+    - GameStateAPI::IsLatched
+  - name: GameStateAPI_GetPlayerSlot
+    alias:
+    - GameStateAPI::GetPlayerSlot
+  - name: GameStateAPI_GetPlayerName
+    alias:
+    - GameStateAPI::GetPlayerName
+  - name: GameStateAPI_GetPlayerXuidStringFromPlayerSlot
+    alias:
+    - GameStateAPI::GetPlayerXuidStringFromPlayerSlot
+  - name: GameStateAPI_GetLocalPlayerXuid
+    alias:
+    - GameStateAPI::GetLocalPlayerXuid
+  - name: GameStateAPI_GetLocalOrInEyePlayerXuid
+    alias:
+    - GameStateAPI::GetLocalOrInEyePlayerXuid
+  - name: GameStateAPI_GetHudPlayerXuid
+    alias:
+    - GameStateAPI::GetHudPlayerXuid
+  - name: GameStateAPI_GetPlayerTeamName
+    alias:
+    - GameStateAPI::GetPlayerTeamName
+  - name: GameStateAPI_GetPlayerTeamNumber
+    alias:
+    - GameStateAPI::GetPlayerTeamNumber
+  - name: GameStateAPI_GetCoachingTeamNumber
+    alias:
+    - GameStateAPI::GetCoachingTeamNumber
+  - name: GameStateAPI_GetAssociatedTeamNumber
+    alias:
+    - GameStateAPI::GetAssociatedTeamNumber
+  - name: GameStateAPI_IsPlayerConnected
+    alias:
+    - GameStateAPI::IsPlayerConnected
+  - name: GameStateAPI_IsPlayerAlive
+    alias:
+    - GameStateAPI::IsPlayerAlive
+  - name: GameStateAPI_GetPlayerPing
+    alias:
+    - GameStateAPI::GetPlayerPing
+  - name: GameStateAPI_GetPlayerKills
+    alias:
+    - GameStateAPI::GetPlayerKills
+  - name: GameStateAPI_GetPlayerRoundKills
+    alias:
+    - GameStateAPI::GetPlayerRoundKills
+  - name: GameStateAPI_GetPlayerAssists
+    alias:
+    - GameStateAPI::GetPlayerAssists
+  - name: GameStateAPI_GetPlayerDeaths
+    alias:
+    - GameStateAPI::GetPlayerDeaths
+  - name: GameStateAPI_GetPlayerMVPs
+    alias:
+    - GameStateAPI::GetPlayerMVPs
+  - name: GameStateAPI_GetPlayerMoney
+    alias:
+    - GameStateAPI::GetPlayerMoney
+  - name: GameStateAPI_GetPlayerScore
+    alias:
+    - GameStateAPI::GetPlayerScore
+  - name: GameStateAPI_GetPlayerClanTag
+    alias:
+    - GameStateAPI::GetPlayerClanTag
+  - name: GameStateAPI_GetPlayerActiveCoinRank
+    alias:
+    - GameStateAPI::GetPlayerActiveCoinRank
+  - name: GameStateAPI_GetPlayerCompetitiveRankType
+    alias:
+    - GameStateAPI::GetPlayerCompetitiveRankType
+  - name: GameStateAPI_GetPlayerCompetitiveRanking
+    alias:
+    - GameStateAPI::GetPlayerCompetitiveRanking
+  - name: GameStateAPI_GetPlayerCompetitiveWins
+    alias:
+    - GameStateAPI::GetPlayerCompetitiveWins
+  - name: GameStateAPI_GetPlayerPremierRankStatsObject
+    alias:
+    - GameStateAPI::GetPlayerPremierRankStatsObject
+  - name: GameStateAPI_GetPlayerDisplayFlairItem
+    alias:
+    - GameStateAPI::GetPlayerDisplayFlairItem
+  - name: GameStateAPI_GetPlayerStatus
+    alias:
+    - GameStateAPI::GetPlayerStatus
+  - name: GameStateAPI_IsFakePlayer
+    alias:
+    - GameStateAPI::IsFakePlayer
+  - name: GameStateAPI_GetPlayerActiveWeaponItemId
+    alias:
+    - GameStateAPI::GetPlayerActiveWeaponItemId
+  - name: GameStateAPI_IsXuidValid
+    alias:
+    - GameStateAPI::IsXuidValid
+  - name: GameStateAPI_GetPlayerVoiceVolume
+    alias:
+    - GameStateAPI::GetPlayerVoiceVolume
+  - name: GameStateAPI_SetPlayerVoiceVolume
+    alias:
+    - GameStateAPI::SetPlayerVoiceVolume
+  - name: GameStateAPI_GetMapsInMapGroup
+    alias:
+    - GameStateAPI::GetMapsInMapGroup
+  - name: GameStateAPI_GetMapDisplayNameToken
+    alias:
+    - GameStateAPI::GetMapDisplayNameToken
+  - name: GameStateAPI_GetMapsInCurrentMapGroup
+    alias:
+    - GameStateAPI::GetMapsInCurrentMapGroup
+  - name: GameStateAPI_GetPlayerLifetime
+    alias:
+    - GameStateAPI::GetPlayerLifetime
+  - name: GameStateAPI_GetPlayerColor
+    alias:
+    - GameStateAPI::GetPlayerColor
+  - name: GameStateAPI_GetPlayerXpLevel
+    alias:
+    - GameStateAPI::GetPlayerXpLevel
+  - name: GameStateAPI_GetPlayerXpTrailLevel
+    alias:
+    - GameStateAPI::GetPlayerXpTrailLevel
+  - name: GameStateAPI_GetPlayerCommendsLeader
+    alias:
+    - GameStateAPI::GetPlayerCommendsLeader
+  - name: GameStateAPI_GetPlayerCommendsTeacher
+    alias:
+    - GameStateAPI::GetPlayerCommendsTeacher
+  - name: GameStateAPI_GetPlayerCommendsFriendly
+    alias:
+    - GameStateAPI::GetPlayerCommendsFriendly
+  - name: GameStateAPI_HasCommunicationAbuseMute
+    alias:
+    - GameStateAPI::HasCommunicationAbuseMute
+  - name: GameStateAPI_HasCommunicationBan
+    alias:
+    - GameStateAPI::HasCommunicationBan
+  - name: GameStateAPI_ShouldShowHudElements
+    alias:
+    - GameStateAPI::ShouldShowHudElements
+  - name: GameStateAPI_IsQueuedMatchmaking
+    alias:
+    - GameStateAPI::IsQueuedMatchmaking
+  - name: GameStateAPI_GetKickTargets
+    alias:
+    - GameStateAPI::GetKickTargets
+  - name: GameStateAPI_GetPlayerCharacterItemID
+    alias:
+    - GameStateAPI::GetPlayerCharacterItemID
+  - name: GameStateAPI_GetCharacterDefaultCheerByXuid
+    alias:
+    - GameStateAPI::GetCharacterDefaultCheerByXuid
+  - name: GameStateAPI_GetCharacterDefaultDefeatByXuid
+    alias:
+    - GameStateAPI::GetCharacterDefaultDefeatByXuid
+  - name: GameStateAPI_ArePlayersEnemies
+    alias:
+    - GameStateAPI::ArePlayersEnemies
+  - name: GameStateAPI_GetCSGOGameUIStateName
+    alias:
+    - GameStateAPI::GetCSGOGameUIStateName
+  - name: GameStateAPI_IsLocalPlayerPlayingMatch
+    alias:
+    - GameStateAPI::IsLocalPlayerPlayingMatch
+  - name: GameStateAPI_IsConnectedOrConnectingToServer
+    alias:
+    - GameStateAPI::IsConnectedOrConnectingToServer
+  - name: GameStateAPI_AreTeamsPlayingSwitchedSides
+    alias:
+    - GameStateAPI::AreTeamsPlayingSwitchedSides
+  - name: GameStateAPI_AreTeamsPlayingSwitchedSidesInRound
+    alias:
+    - GameStateAPI::AreTeamsPlayingSwitchedSidesInRound
+  - name: GameStateAPI_IsReportCategoryEnabledForSelectedPlayer
+    alias:
+    - GameStateAPI::IsReportCategoryEnabledForSelectedPlayer
+  - name: GameStateAPI_SubmitPlayerReport
+    alias:
+    - GameStateAPI::SubmitPlayerReport
+  - name: GameStateAPI_SubmitServerReport
+    alias:
+    - GameStateAPI::SubmitServerReport
+  - name: GameStateAPI_QueryServersForCommendation
+    alias:
+    - GameStateAPI::QueryServersForCommendation
+  - name: GameStateAPI_GetCommendationTokensAvailable
+    alias:
+    - GameStateAPI::GetCommendationTokensAvailable
+  - name: GameStateAPI_GetMyCommendationsJSOForUser
+    alias:
+    - GameStateAPI::GetMyCommendationsJSOForUser
+  - name: GameStateAPI_SubmitCommendation
+    alias:
+    - GameStateAPI::SubmitCommendation
+  - name: GameStateAPI_IsSelectedPlayerMuted
+    alias:
+    - GameStateAPI::IsSelectedPlayerMuted
+  - name: GameStateAPI_ToggleMute
+    alias:
+    - GameStateAPI::ToggleMute
+  - name: GameStateAPI_GetCrosshairCode
+    alias:
+    - GameStateAPI::GetCrosshairCode
+  - name: GameStateAPI_IsDemoOrHltv
+    alias:
+    - GameStateAPI::IsDemoOrHltv
+  - name: GameStateAPI_IsOverwatch
+    alias:
+    - GameStateAPI::IsOverwatch
+  - name: GameStateAPI_IsLocalPlayerWatchingOwnDemo
+    alias:
+    - GameStateAPI::IsLocalPlayerWatchingOwnDemo
+  - name: GameStateAPI_IsLocalPlayerHLTV
+    alias:
+    - GameStateAPI::IsLocalPlayerHLTV
+  - name: GameStateAPI_IsHLTVAutodirectorOn
+    alias:
+    - GameStateAPI::IsHLTVAutodirectorOn
+  - name: GameStateAPI_SetCasterIsCameraman
+    alias:
+    - GameStateAPI::SetCasterIsCameraman
+  - name: GameStateAPI_SetCasterIsHeard
+    alias:
+    - GameStateAPI::SetCasterIsHeard
+  - name: GameStateAPI_SetCasterControlsXray
+    alias:
+    - GameStateAPI::SetCasterControlsXray
+  - name: GameStateAPI_SetCasterControlsUI
+    alias:
+    - GameStateAPI::SetCasterControlsUI
+  - name: GameStateAPI_GetServerName
+    alias:
+    - GameStateAPI::GetServerName
+  - name: GameStateAPI_GetMapName
+    alias:
+    - GameStateAPI::GetMapName
+  - name: GameStateAPI_GetTournamentEventStage
+    alias:
+    - GameStateAPI::GetTournamentEventStage
+  - name: GameStateAPI_GetGameModeInternalName
+    alias:
+    - GameStateAPI::GetGameModeInternalName
+  - name: GameStateAPI_GetGameModeImagePath
+    alias:
+    - GameStateAPI::GetGameModeImagePath
+  - name: GameStateAPI_GetGameModeName
+    alias:
+    - GameStateAPI::GetGameModeName
+  - name: GameStateAPI_GetViewerCount
+    alias:
+    - GameStateAPI::GetViewerCount
+  - name: GameStateAPI_GetMapBSPName
+    alias:
+    - GameStateAPI::GetMapBSPName
+  - name: GameStateAPI_IsQueuedMatchmakingMode_Team
+    alias:
+    - GameStateAPI::IsQueuedMatchmakingMode_Team
+  - name: GameStateAPI_HasHalfTime
+    alias:
+    - GameStateAPI::HasHalfTime
+  - name: GameStateAPI_GetPlayerModel
+    alias:
+    - GameStateAPI::GetPlayerModel
+  - name: GameStateAPI_GetAllPlayersMatchDataJSO
+    alias:
+    - GameStateAPI::GetAllPlayersMatchDataJSO
+  - name: GameStateAPI_GetPlayerDataJSO
+    alias:
+    - GameStateAPI::GetPlayerDataJSO
+  - name: GameStateAPI_GetTimeDataJSO
+    alias:
+    - GameStateAPI::GetTimeDataJSO
+  - name: GameStateAPI_GetScoreDataJSO
+    alias:
+    - GameStateAPI::GetScoreDataJSO
+  - name: GameStateAPI_GetPlayerStatsJSO
+    alias:
+    - GameStateAPI::GetPlayerStatsJSO
+  - name: GameStateAPI_GetMatchInfoJSO
+    alias:
+    - GameStateAPI::GetMatchInfoJSO
+  - name: GameStateAPI_GetMatchEndWinDataJSO
+    alias:
+    - GameStateAPI::GetMatchEndWinDataJSO
+  - name: GameStateAPI_GetAccoladeLocalizationString
+    alias:
+    - GameStateAPI::GetAccoladeLocalizationString
+  - name: GameStateAPI_GetTeamClanName
+    alias:
+    - GameStateAPI::GetTeamClanName
+  - name: GameStateAPI_GetTeamLogoImagePath
+    alias:
+    - GameStateAPI::GetTeamLogoImagePath
+  - name: GameStateAPI_GetTeamFlagImagePath
+    alias:
+    - GameStateAPI::GetTeamFlagImagePath
+  - name: GameStateAPI_GetTeamTotalPlayerCount
+    alias:
+    - GameStateAPI::GetTeamTotalPlayerCount
+  - name: GameStateAPI_GetTeamLivingPlayerCount
+    alias:
+    - GameStateAPI::GetTeamLivingPlayerCount
+  - name: GameStateAPI_GetTeamNextRoundLossBonus
+    alias:
+    - GameStateAPI::GetTeamNextRoundLossBonus
+  - name: GameStateAPI_GetActiveQuestID
+    alias:
+    - GameStateAPI::GetActiveQuestID
+  - name: GameStateAPI_GetAnnotationsViewingLevel
+    alias:
+    - GameStateAPI::GetAnnotationsViewingLevel
+  - name: GameStateAPI_BIsLocalServerHost
+    alias:
+    - GameStateAPI::BIsLocalServerHost
+- name: server
+  symbols:
+  - name: CSource2Server_OnStreamEntitiesFromFileCompleted
+    alias:
+    - CSource2Server::OnStreamEntitiesFromFileCompleted
+  - name: CSource2Server_PreWorldUpdate
+    alias:
+    - CSource2Server::PreWorldUpdate
+  - name: CSource2Server_OutOfGameFrameBoundary
+    alias:
+    - CSource2Server::OutOfGameFrameBoundary
+  - name: CGameSystemReallocatingFactory_CSource2EntitySystem_Init
+    alias:
+    - CGameSystemReallocatingFactory<CSource2EntitySystem>::Init
+  - name: CGameSystemReallocatingFactory_CSource2EntitySystem_CreateGameSystem
+    alias:
+    - CGameSystemReallocatingFactory<CSource2EntitySystem>::CreateGameSystem
+  - name: IGameSystemFactory_Init
+    alias:
+    - IGameSystemFactory::Init
+  - name: IGameSystemFactory_Shutdown
+    alias:
+    - IGameSystemFactory::Shutdown
+  - name: IGameSystemFactory_SetGlobalPtr
+    alias:
+    - IGameSystemFactory::SetGlobalPtr
+  - name: CGameSystemReallocatingFactory_CSpawnGroupMgrGameSystem_DestroyGameSystem
+    alias:
+    - CGameSystemReallocatingFactory<CSpawnGroupMgrGameSystem>::Deallocate
+  - name: IGameSystem_SetGameSystemGlobalPtrs
+    alias:
+    - IGameSystem::SetGameSystemGlobalPtrs
+  - name: IGameSystem_vdtor
+    alias:
+    - IGameSystem::~IGameSystem
+  - name: IGameSystem_OnGameInit
+    alias:
+    - IGameSystem::GameInit
+  - name: CMultiplayRules_ctor
+    alias:
+    - CMultiplayRules::CMultiplayRules
+  - name: CGameMoney_OnMoneySpent
+    alias:
+    - CGameMoney::OnMoneySpent
+  - name: CGameMoney_m_DataMap
+    alias:
+    - CGameMoney::m_DataMap
+  - name: CGameMoney_GetDataDescMap
+    alias:
+    - CGameMoney::GetDataDescMap
+  - name: CCSPlayer_UseServices_OnUseImpl
+    alias:
+    - CCSPlayer_UseServices::OnUseImpl
+  - name: CCSPlayer_UseServices_OnUse
+    alias:
+    - CCSPlayer_UseServices::OnUse
+  - name: CCSPlayer_MovementServices_ProcessMovement
+    alias:
+    - CCSPlayer_MovementServices::ProcessMovement
+    - ProcessMovement
+  - name: CCSPlayer_MovementServices_CheckMovingGround
+    alias:
+    - CCSPlayer_MovementServices::CheckMovingGround
+    - CheckMovingGround
+  - name: CCSPlayer_MovementServices_WalkMove
+    alias:
+    - CCSPlayer_MovementServices::WalkMove
+    - WalkMove
+  - name: CCSPlayer_MovementServices_FullWalkMove
+    alias:
+    - CCSPlayer_MovementServices::FullWalkMove
+    - FullWalkMove
+  - name: CCSPlayer_MovementServices_CheckVelocity
+    alias:
+    - CCSPlayer_MovementServices::CheckVelocity
+    - CheckVelocity
+  - name: CCSPlayer_MovementServices_WaterMove
+    alias:
+    - CCSPlayer_MovementServices::WaterMove
+    - WaterMove
+  - name: CCSPlayer_MovementServices_FullWalkMove_SpeedClamp
+    alias:
+    - ServerMovementUnlock
+  - name: CCSPlayer_MovementServices_CheckJumpButton
+    alias:
+    - CCSPlayer_MovementServices::CheckJumpButton
+  - name: CCSPlayer_MovementServices_CheckJumpButton_WaterPatch
+    alias:
+    - CheckJumpButtonWater
+    - FixWaterFloorJump
+  - name: CPlayer_MovementServices_PlayWaterStepSound
+    alias:
+    - CPlayer_MovementServices::PlayWaterStepSound
+  - name: CPlayer_MovementServices_ForceButtons
+    alias:
+    - CPlayer_MovementServices::ForceButtons
+  - name: CPlayer_MovementServices_ForceButtonState
+    alias:
+    - CPlayer_MovementServices::ForceButtonState
+  - name: CPlayer_MovementServices_s_pRunCommandPawn
+    alias:
+    - CPlayer_MovementServices::s_pRunCommandPawn
+  - name: CEntityInstance_m_pEntity
+    alias:
+    - CEntityInstance::m_pEntity
+  - name: CEntityInstance_m_hPrivateScope
+    alias:
+    - CEntityInstance::m_hPrivateScope
+  - name: CEntityInstance_m_CScriptComponent
+    alias:
+    - CEntityInstance::m_CScriptComponent
+  - name: CEntityInstance_m_pKeyValues
+    alias:
+    - CEntityInstance::m_pKeyValues
+  - name: CEntityInstance_m_iszPrivateVScripts
+    alias:
+    - CEntityInstance::m_iszPrivateVScripts
+  - name: CBaseEntity_OnRestore
+    alias:
+    - CBaseEntity::OnRestore
+  - name: CEntityInstance_OnRestore
+    alias:
+    - CEntityInstance::OnRestore
+  - name: CBaseEntity_ctor
+    alias:
+    - CBaseEntity::CBaseEntity
+  - name: CBaseEntity_dtor
+    alias:
+    - CBaseEntity::~CBaseEntity
+  - name: CBaseEntity_vdtor
+    alias:
+    - CBaseEntity::~CBaseEntity (virtual)
+  - name: CEntityInstance_vdtor
+    alias:
+    - CEntityInstance::~CEntityInstance (virtual)
+  - name: CEntitySaveRestoreBlockHandler_PreSave
+    alias:
+    - CEntitySaveRestoreBlockHandler::PreSave
+  - name: CEntitySaveRestoreBlockHandler_SaveInternal
+    alias:
+    - CEntitySaveRestoreBlockHandler::SaveInternal
+  - name: CEntitySaveRestoreBlockHandler_Save
+    alias:
+    - CEntitySaveRestoreBlockHandler::Save
+  - name: CEntitySaveRestoreBlockHandler_Restore
+    alias:
+    - CEntitySaveRestoreBlockHandler::Restore
+  - name: CEntitySaveRestoreBlockHandler_DoRestoreEntity
+    alias:
+    - CEntitySaveRestoreBlockHandler::DoRestoreEntity
+  - name: CEntitySaveRestoreBlockHandler_RestoreEntity
+    alias:
+    - CEntitySaveRestoreBlockHandler::RestoreEntity
+  - name: CreateEntityTransitionList
+    alias:
+    - CreateEntityTransitionList
+  - name: CEntitySaveRestoreBlockHandler_WriteSaveHeaders
+    alias:
+    - CEntitySaveRestoreBlockHandler::WriteSaveHeaders
+  - name: CEntitySaveRestoreBlockHandler_ReadRestoreHeaders
+    alias:
+    - CEntitySaveRestoreBlockHandler::ReadRestoreHeaders
+  - name: CEntity2SaveRestore_StreamEntitiesFromFile
+    alias:
+    - CEntity2SaveRestore::StreamEntitiesFromFile
+  - name: CSaveRestoreBlockSet_PreRestore
+    alias:
+    - CSaveRestoreBlockSet::PreRestore
+  - name: CSaveRestoreBlockSet_PostRestore
+    alias:
+    - CSaveRestoreBlockSet::PostRestore
+  - name: CEntitySaveRestoreBlockHandler_PreRestore
+    alias:
+    - CEntitySaveRestoreBlockHandler::PreRestore
+  - name: CEntitySaveRestoreBlockHandler_PostRestore
+    alias:
+    - CEntitySaveRestoreBlockHandler::PostRestore
+  - name: CEntitySystem_ForceSetInPVSCallsIntoQueue
+    alias:
+    - CEntitySystem::ForceSetInPVSCallsIntoQueue
+  - name: CEntitySystem_ExecuteQueuedSetInPVS
+    alias:
+    - CEntitySystem::ExecuteQueuedSetInPVS
+  - name: CEntitySystem_m_nSuppressDormancyChangeCount
+    alias:
+    - CEntitySystem::m_nSuppressDormancyChangeCount
+  - name: CEntitySystem_m_nExecuteQueuedCreationDepth
+    alias:
+    - CEntitySystem::m_nExecuteQueuedCreationDepth
+  - name: CEntitySystem_m_queuedDormancyChanges
+    alias:
+    - CEntitySystem::m_queuedDormancyChanges
+  - name: CEntitySystem_SetInPVS
+    alias:
+    - CEntitySystem::SetInPVS
+  - name: CEntitySystem_OnSetDormant
+    alias:
+    - CEntitySystem::OnSetDormant
+  - name: CEntitySystem_BuildResourceManifestForEntity
+    alias:
+    - CEntitySystem::BuildResourceManifestForEntity
+  - name: CEntityInstance_ObjectCaps
+    alias:
+    - CEntityInstance::ObjectCaps
+  - name: CEntityInstance_Save
+    alias:
+    - CEntityInstance::Save
+  - name: CEntityInstance_Restore
+    alias:
+    - CEntityInstance::Restore
+  - name: CEntitySaveRestoreBlockHandler_SaveInitEntities
+    alias:
+    - CEntitySaveRestoreBlockHandler::SaveInitEntities
+  - name: CEntityInstance_OnSave
+    alias:
+    - CEntityInstance::OnSave
+  - name: CEntityInstance_RequiredEdictIndex
+    alias:
+    - CEntityInstance::RequiredEdictIndex
+  - name: PolymorphicHelper_t__SetPolymorphicPointer
+    alias:
+    - PolymorphicHelper_t::SetPolymorphicPointer
+  - name: CEntityInstance_AddChangeAccessorPathPolymorphic
+    alias:
+    - CEntityInstance::AddChangeAccessorPathPolymorphic
+  - name: CEntityInstance_AssignChangeAccessorPathIdsPolymorphic
+    alias:
+    - CEntityInstance::AssignChangeAccessorPathIdsPolymorphic
+  - name: CEntityInstance_AddChangeAccessorPath
+    alias:
+    - CEntityInstance::AddChangeAccessorPath
+  - name: CEntityInstance_AssignChangeAccessorPathIds
+    alias:
+    - CEntityInstance::AssignChangeAccessorPathIds
+  - name: CEntityInstance_GetChangeAccessorPathInfo_2
+    alias:
+    - CEntityInstance::GetChangeAccessorPathInfo_2
+  - name: CBaseEntity_GetChangeAccessorPathInfo_2
+    alias:
+    - CBaseEntity::GetChangeAccessorPathInfo_2
+  - name: CBaseEntity_GetChangeAccessorPathInfo_1
+    alias:
+    - CBaseEntity::GetChangeAccessorPathInfo_1
+  - name: CMomentaryRotButton_Use
+    alias:
+    - CMomentaryRotButton::Use
+  - name: CBaseEntity_TakeDamageOld
+    alias:
+    - CBaseEntity::TakeDamageOld
+  - name: CBaseEntity_OnTakeDamage
+    alias:
+    - CBasePlayerPawn::OnTakeDamage
+  - name: CBasePlayerPawn_OnTakeDamage_Alive
+    alias:
+    - CBasePlayerPawn::OnTakeDamage_Alive
+  - name: CBasePlayerPawn_OnTakeDamage_Dying
+    alias:
+    - CBasePlayerPawn::OnTakeDamage_Dying
+  - name: CBasePlayerPawn_OnTakeDamage_Dead
+    alias:
+    - CBasePlayerPawn::OnTakeDamage_Dead
+  - name: CBasePlayerPawn_OnTakeDamage
+    alias:
+    - CBasePlayerPawn::OnTakeDamage
+  - name: CCSPlayerPawn_OnTakeDamage_Alive
+    alias:
+    - CCSPlayerPawn::OnTakeDamage_Alive
+  - name: CCSPlayerPawn_OnTakeDamage_Dying
+    alias:
+    - CCSPlayerPawn::OnTakeDamage_Dying
+  - name: CCSPlayerPawn_OnTakeDamage_Dead
+    alias:
+    - CCSPlayerPawn::OnTakeDamage_Dead
+  - name: CFlashbangProjectile_Spawn
+    alias:
+    - CFlashbangProjectile::Spawn
+  - name: CSmokeGrenadeProjectile_Create
+    alias:
+    - CSmokeGrenadeProjectile::Create
+  - name: CEntitySystem_QueueDestroyEntity
+    alias:
+    - CEntitySystem::QueueDestroyEntity
+  - name: CEntitySystem_ExecuteQueuedDeletion
+    alias:
+    - CEntitySystem::ExecuteQueuedDeletion
+  - name: CEntitySystem_m_nExecuteQueuedDeletionDepth
+    alias:
+    - CEntitySystem::m_nExecuteQueuedDeletionDepth
+  - name: CBaseModelEntity_SetModel
+    alias:
+    - CBaseModelEntity::SetModel
+  - name: CBaseModelEntity_SetRenderAttribute
+    alias:
+    - CBaseModelEntity::SetRenderAttribute
+  - name: CBaseEntity_GetScriptDescInternal
+    alias:
+    - CBaseEntity::GetScriptDescInternal
+  - name: CBaseModelEntity_GetScriptDescInternal
+    alias:
+    - CBaseModelEntity::GetScriptDescInternal
+  - name: CBaseModelEntity_GetModelScale
+    alias:
+    - CBaseModelEntity::GetModelScale
+  - name: CBaseModelEntity_Script_SetModelScale
+    alias:
+    - CBaseModelEntity::Script_SetModelScale
+  - name: CBaseModelEntity_ScriptLookupAttachment
+    alias:
+    - CBaseModelEntity::ScriptLookupAttachment
+  - name: CBaseModelEntity_ScriptGetAttachmentOrigin
+    alias:
+    - CBaseModelEntity::ScriptGetAttachmentOrigin
+  - name: CBaseModelEntity_ScriptGetAttachmentAngles
+    alias:
+    - CBaseModelEntity::ScriptGetAttachmentAngles
+  - name: CBaseModelEntity_ScriptGetAttachmentForward
+    alias:
+    - CBaseModelEntity::ScriptGetAttachmentForward
+  - name: CBaseModelEntity_ScriptSetSize
+    alias:
+    - CBaseModelEntity::ScriptSetSize
+  - name: CBaseModelEntity_ScriptSetModel
+    alias:
+    - CBaseModelEntity::ScriptSetModel
+  - name: ScriptBinding_CBaseModelEntity_SetModel
+    alias:
+    - CS_Script_SetModel
+  - name: CBaseModelEntity_ScriptGetRenderAlpha
+    alias:
+    - CBaseModelEntity::ScriptGetRenderAlpha
+  - name: CBaseModelEntity_ScriptSetRenderAlpha
+    alias:
+    - CBaseModelEntity::ScriptSetRenderAlpha
+  - name: CBaseModelEntity_ScriptSetRenderMode
+    alias:
+    - CBaseModelEntity::ScriptSetRenderMode
+  - name: CBaseModelEntity_ScriptSetRenderColor
+    alias:
+    - CBaseModelEntity::ScriptSetRenderColor
+  - name: CBaseModelEntity_ScriptGetRenderColor
+    alias:
+    - CBaseModelEntity::ScriptGetRenderColor
+  - name: CBaseModelEntity_ScriptSetMaterialGroup
+    alias:
+    - CBaseModelEntity::ScriptSetMaterialGroup
+  - name: CBaseModelEntity_ScriptSetMaterialGroupHash
+    alias:
+    - CBaseModelEntity::ScriptSetMaterialGroupHash
+  - name: CBaseModelEntity_ScriptGetMaterialGroupHash
+    alias:
+    - CBaseModelEntity::ScriptGetMaterialGroupHash
+  - name: CBaseModelEntity_ScriptSetSingleMeshGroup
+    alias:
+    - CBaseModelEntity::ScriptSetSingleMeshGroup
+  - name: CBaseModelEntity_ScriptSetMeshGroupMask
+    alias:
+    - CBaseModelEntity::ScriptSetMeshGroupMask
+  - name: CBaseModelEntity_ScriptGetMeshGroupMask
+    alias:
+    - CBaseModelEntity::ScriptGetMeshGroupMask
+  - name: CBaseModelEntity_ScriptSetBodygroupByName
+    alias:
+    - CBaseModelEntity::ScriptSetBodygroupByName
+  - name: CBaseModelEntity_Script_SetBodygroup
+    alias:
+    - CBaseModelEntity::Script_SetBodygroup
+  - name: CBaseModelEntity_Script_SetSkin
+    alias:
+    - CBaseModelEntity::Script_SetSkin
+  - name: CEntityInstance_NetworkUpdateState_thunk
+    alias:
+    - CEntityInstance::NetworkUpdateState_thunk
+  - name: CBaseEntity_SetGravityScale
+    alias:
+    - CBaseEntity::SetGravityScale
+  - name: CTriggerGravity_GravityTouch
+    alias:
+    - CTriggerGravity::GravityTouch
+  - name: CTriggerGravity_GetTouchFunction
+    alias:
+    - CTriggerGravity::GetTouchFunction
+  - name: CBasePlayerController_HandleCommand_JoinTeam
+    alias:
+    - CBasePlayerController::HandleCommand_JoinTeam
+  - name: CBasePlayerController_SetPlayerName
+    alias:
+    - CBasePlayerController::SetPlayerName
+  - name: CBasePlayerController_ProcessUsercmds
+    alias:
+    - ProcessUsercmds
+  - name: CBasePlayerController_SetPawn
+    alias:
+    - CBasePlayerController::SetPawn
+  - name: CBasePlayerController_GetPawn
+    alias:
+    - CBasePlayerController::GetPawn
+  - name: CBasePlayerController_Connect
+    alias:
+    - CBasePlayerController::Connect
+  - name: CBasePlayerController_SetConnectedState
+    alias:
+    - CBasePlayerController::SetConnectedState
+  - name: CSource2GameClients_ClientSettingsChanged
+    alias:
+    - CSource2GameClients::ClientSettingsChanged
+  - name: CSource2GameClients_ClientSetupVisibility
+    alias:
+    - CSource2GameClients::ClientSetupVisibility
+  - name: CSource2GameClients_ClientDisconnect
+    alias:
+    - CSource2GameClients::ClientDisconnect
+  - name: CSource2GameClients_ClientPutInServer
+    alias:
+    - CSource2GameClients::ClientPutInServer
+  - name: CSource2GameClients_ClientConnect
+    alias:
+    - CSource2GameClients::ClientConnect
+  - name: CSource2GameClients_ClientActive
+    alias:
+    - CSource2GameClients::ClientActive
+  - name: CSource2GameClients_ClientFullyConnect
+    alias:
+    - CSource2GameClients::ClientFullyConnect
+  - name: CSource2GameClients_ClientCommand
+    alias:
+    - CSource2GameClients::ClientCommand
+  - name: CSource2GameClients_ProcessUsercmds
+    alias:
+    - CSource2GameClients::ProcessUsercmds
+  - name: CSource2GameClients_GetBugReportInfo
+    alias:
+    - CSource2GameClients::GetBugReportInfo
+  - name: CSource2GameClients_ClientDiagnostic
+    alias:
+    - CSource2GameClients::ClientDiagnostic
+  - name: CSource2GameClients_SendHLTVStatusMessage
+    alias:
+    - CSource2GameClients::SendHLTVStatusMessage
+  - name: CSource2GameClients_OnClientConnected
+    alias:
+    - CSource2GameClients::OnClientConnected
+  - name: CGameRules_FindPickerEntity
+    alias:
+    - CGameRules::FindPickerEntity
+  - name: CCSGameRules_FindPickerEntity
+    alias:
+    - CCSGameRules::FindPickerEntity
+  - name: CCSGameRules_TerminateRound
+    alias:
+    - CCSGameRules::TerminateRound
+    - CGameRules::TerminateRound
+    - CGameRules_TerminateRound
+  - name: CCSGameRules_GoToIntermission
+    alias:
+    - CCSGameRules::GoToIntermission
+  - name: CEntityInstance_AcceptInput
+    alias:
+    - CEntityInstance::AcceptInput
+    - AcceptInput
+  - name: CEntityIdentity_AcceptInput
+    alias:
+    - CEntityIdentity::AcceptInput
+  - name: CEntityIdentity_AcceptInputInternal
+    alias:
+    - CEntityIdentity::AcceptInputInternal
+  - name: CEntityInstance_ScriptAcceptInput
+    alias:
+    - CEntityInstance::ScriptAcceptInput
+  - name: CEntityIdentity_SetEntityName
+    alias:
+    - CEntityIdentity::SetEntityName
+  - name: CEntitySystem_RemoveEntityFromNameMap
+    alias:
+    - CEntitySystem::RemoveEntityFromNameMap
+  - name: CEntitySystem_AddEntityToNameMap
+    alias:
+    - CEntitySystem::AddEntityToNameMap
+  - name: ScriptBinding_Entity_SetEntityName
+    alias:
+    - Entity::SetEntityName
+  - name: CBtActionCoordinatedBuy_Update
+    alias:
+    - CBtActionCoordinatedBuy::Update
+  - name: CCSPlayer_ItemServices_CanAcquire
+    alias:
+    - CCSPlayer_ItemServices::CanAcquire
+  - name: CCSPlayer_ItemServices_GiveDefaultItems
+    alias:
+    - CCSPlayer_ItemServices::GiveDefaultItems
+  - name: CCSPlayer_ItemServices_GiveNamedItem
+    alias:
+    - CCSPlayer_ItemServices::GiveNamedItem
+  - name: CCSPlayer_ItemServices_GiveNamedItemBool
+    alias:
+    - CCSPlayer_ItemServices::GiveNamedItemBool
+  - name: CCSPlayer_WeaponServices_CanUse
+    alias:
+    - CCSPlayer_WeaponServices::CanUse
+  - name: CCSPlayer_WeaponServices_PickupItem
+    alias:
+    - CCSPlayer_WeaponServices::PickupItem
+  - name: CCSPlayer_WeaponServices_EquipWeapon
+    alias:
+    - CCSPlayer_WeaponServices::EquipWeapon
+  - name: CCSPlayer_WeaponServices_Weapon_GetSlot
+    alias:
+    - CCSPlayer_WeaponServices_Weapon_GetSlot
+  - name: CCSPlayerController_ChangeTeam
+    alias:
+    - CCSPlayerController::ChangeTeam
+  - name: CCSPlayerController_GetThinkFunction
+    alias:
+    - CCSPlayerController::GetThinkFunction
+  - name: CCSPlayerController_PlayerForceTeamThink
+    alias:
+    - PlayerForceTeamThink
+    - CCSPlayerController::PlayerForceTeamThink
+  - name: CCSPlayerController_ResetForceTeamThink
+    alias:
+    - ResetForceTeamThink
+    - CCSPlayerController::ResetForceTeamThink
+  - name: CCSPlayerController_ResourceDataThink
+    alias:
+    - ResourceDataThink
+    - CCSPlayerController::ResourceDataThink
+  - name: CCSPlayerController_InventoryUpdateThink
+    alias:
+    - InventoryUpdateThink
+    - CCSPlayerController::InventoryUpdateThink
+  - name: g_CCSPlayerController_PlayerForceTeamThink
+    alias:
+    - g_CCSPlayerController::PlayerForceTeamThink
+  - name: g_CCSPlayerController_ResetForceTeamThink
+    alias:
+    - g_CCSPlayerController::ResetForceTeamThink
+  - name: g_CCSPlayerController_ResourceDataThink
+    alias:
+    - g_CCSPlayerController::ResourceDataThink
+  - name: g_CCSPlayerController_InventoryUpdateThink
+    alias:
+    - g_CCSPlayerController::InventoryUpdateThink
+  - name: CCSGameRules__sm_mapGcBanInformation
+    alias:
+    - CCSGameRules::sm_mapGcBanInformation
+  - name: CCSGameRules_BeginRound
+    alias:
+    - CCSGameRules::BeginRound
+  - name: CCSGameRules_PlayerSpawn
+    alias:
+    - CCSGameRules::PlayerSpawn
+  - name: CCSPlayerController_Respawn
+    alias:
+    - CCSPlayerController::Respawn
+  - name: CCSPlayerController_Connect
+    alias:
+    - CCSPlayerController::Connect
+  - name: CCSPlayerController_SwitchTeam
+    alias:
+    - CCSPlayerController::SwitchTeam
+  - name: CCSPlayerPawnBase_OnSetDormant
+    alias:
+    - CCSPlayerPawnBase::OnSetDormant
+  - name: CCSPlayerPawnBase_CheckForIdle
+    alias:
+    - CCSPlayerPawnBase::CheckForIdle
+  - name: CCSPlayerPawnBase_CheckForIdleInternal
+    alias:
+    - CCSPlayerPawnBase::CheckForIdleInternal
+  - name: CCSPlayerPawn_PostThink
+    alias:
+    - CCSPlayerPawnBase::PostThink
+    - CCSPlayerPawn::PostThink
+    - CCSPlayerPawnBase_PostThink
+    - CCSPlayerPawn_PostThink
+    - PostThink
+  - name: CCSPlayerPawn_OnSwitchWeapons
+    alias:
+    - CCSPlayerPawn::OnSwitchWeapons
+  - name: CCSPlayerPawn_ProcessSuicideAsKillReward
+    alias:
+    - CCSPlayerPawn::ProcessSuicideAsKillReward
+  - name: CGameRules_ClientSettingsChanged
+    alias:
+    - CGameRules::ClientSettingsChanged
+  - name: CGameRulesGameSystem_OnGameInit
+    alias:
+    - CGameRulesGameSystem::GameInit
+  - name: CGameRulesGameSystem_OnGameShutdown
+    alias:
+    - CGameRulesGameSystem::GameShutdown
+  - name: IGameSystem_OnGameShutdown
+    alias:
+    - IGameSystem::GameShutdown
+  - name: IGameSystem_OnGamePostInit
+    alias:
+    - IGameSystem::GamePostInit
+  - name: IGameSystem_OnGamePreShutdown
+    alias:
+    - IGameSystem::GamePreShutdown
+  - name: CMultiplayRules_ClientDisconnected
+    alias:
+    - CMultiplayRules::ClientDisconnected
+  - name: CSource2Server_Init
+    alias:
+    - CSource2Server::Init
+  - name: CSource2Server_ApplyGameSettings
+    alias:
+    - CSource2Server::ApplyGameSettings
+  - name: CSource2Server_WriteSignonMessages
+    alias:
+    - CSource2Server::WriteSignonMessages
+  - name: CSource2Server_GameCreateNetworkStringTables
+    alias:
+    - CSource2Server::GameCreateNetworkStringTables
+  - name: CSource2Server_GetMatchmakingGameData
+    alias:
+    - CSource2Server::GetMatchmakingGameData
+  - name: CSource2Server_GameServerSteamAPIActivated
+    alias:
+    - CSource2Server::GameServerSteamAPIActivated
+  - name: CSource2Server_GameServerSteamAPIDeactivated
+    alias:
+    - CSource2Server::GameServerSteamAPIDeactivated
+  - name: CSource2Server_OnHostNameChanged
+    alias:
+    - CSource2Server::OnHostNameChanged
+  - name: CSource2Server_GetLevelsFromSaveFile
+    alias:
+    - CSource2Server::GetLevelsFromSaveFile
+  - name: CSource2Server_ServerConVarChanged
+    alias:
+    - CSource2Server::ServerConVarChanged
+  - name: CSource2Server_Save
+    alias:
+    - CSource2Server::Save
+  - name: CSource2Server_Connect
+    alias:
+    - CSource2Server::Connect
+  - name: CSource2Server_PreShutdown
+    alias:
+    - CSource2Server::PreShutdown
+  - name: IAppSystem_Connect
+    alias:
+    - IAppSystem::Connect
+  - name: IAppSystem_PreShutdown
+    alias:
+    - IAppSystem::PreShutdown
+  - name: IVEngineServer2_ServerCommand
+    alias:
+    - IVEngineServer2::ServerCommand
+  - name: IVEngineServer2_IsDedicatedServer
+    alias:
+    - IVEngineServer2::IsDedicatedServer
+  - name: IVEngineServer2_GetServerGlobals
+    alias:
+    - IVEngineServer2::GetServerGlobals
+  - name: IVEngineServer2_GetAchievementMgr
+    alias:
+    - IVEngineServer2::GetAchievementMgr
+  - name: IVEngineServer2_IsLogEnabled
+    alias:
+    - IVEngineServer2::IsLogEnabled
+  - name: CSource2Server_Shutdown
+    alias:
+    - CSource2Server::Shutdown
+  - name: CGameEventManager_Shutdown
+    alias:
+    - CGameEventManager::Shutdown
+  - name: CLoopModeRegistry_UnregisterLoopModes
+    alias:
+    - CLoopModeRegistry::UnregisterLoopModes
+  - name: CEngineServiceRegistry_UnregisterEngineServices
+    alias:
+    - CEngineServiceRegistry::UnregisterEngineServices
+  - name: IEngineServiceMgr_UnregisterLoopMode
+    alias:
+    - IEngineServiceMgr::UnregisterLoopMode
+  - name: IEngineServiceMgr_UnregisterEngineService
+    alias:
+    - IEngineServiceMgr::UnregisterEngineService
+  - name: CSource2Server_GameFrame
+    alias:
+    - CSource2Server::GameFrame
+  - name: CGameEventManager_Init
+    alias:
+    - CGameEventManager::Init
+  - name: CTakeDamageInfo_HitGroupInfo
+    alias:
+    - CTakeDamageInfo::HitGroupInfo
+    - CTakeDamageInfo::HitGroup
+    - CTakeDamageInfo_HitGroup
+  - name: CEntitySystem_RegisterEntityClass
+    alias:
+    - CEntitySystem::RegisterEntityClass
+  - name: CEntitySystem_CreateEntityByName
+    alias:
+    - CEntitySystem::CreateEntityByName
+  - name: CEntitySystem_CreateEntity
+    alias:
+    - CEntitySystem::CreateEntity
+  - name: CEntitySystem_AddEntityToEntityDataBase
+    alias:
+    - CEntitySystem::AddEntityToEntityDataBase
+  - name: CEntitySystem_OnAddEntity
+    alias:
+    - CEntitySystem::OnAddEntity
+  - name: CEntitySystem_OnEntityParentChanged
+    alias:
+    - CEntitySystem::OnEntityParentChanged
+  - name: CEntitySystem_PrecacheEntity
+    alias:
+    - CEntitySystem::PrecacheEntity
+  - name: CEntitySystem_InvokePrecacheCallback
+    alias:
+    - CEntitySystem::InvokePrecacheCallback
+  - name: CEntitySystem_DestroyEntity
+    alias:
+    - CEntitySystem::DestroyEntity
+  - name: CConcreteEntityList_AllocEntity
+    alias:
+    - CConcreteEntityList::AllocEntity
+  - name: CEntitySystem_ConstructEntity
+    alias:
+    - CEntitySystem::ConstructEntity
+  - name: CEntitySystem_DoConstructEntity
+    alias:
+    - CEntitySystem::DoConstructEntity
+  - name: CEntitySystem_GetSpawnGroupWorldId
+    alias:
+    - CEntitySystem::GetSpawnGroupWorldId
+  - name: CEntitySystem_FindClassByDesignName
+    alias:
+    - CEntitySystem::FindClassByDesignName
+  - name: CEntitySystem_m_EntityList
+    alias:
+    - CEntitySystem::m_EntityList
+  - name: CEntitySystem_m_entityNames
+    alias:
+    - CEntitySystem::m_entityNames
+  - name: CEntitySystem_m_entityComponentHelpers
+    alias:
+    - CEntitySystem::m_entityComponentHelpers
+  - name: CEntitySystem_m_DataDescKeyUnserializers
+    alias:
+    - CEntitySystem::m_DataDescKeyUnserializers
+  - name: CEntitySystem_m_EntityPostSpawnCallback
+    alias:
+    - CEntitySystem::m_EntityPostSpawnCallback
+  - name: CEntityIdentity_FreeAttributes
+    alias:
+    - CEntityIdentity::FreeAttributes
+  - name: CConcreteEntityList_FreeEntity
+    alias:
+    - CConcreteEntityList::FreeEntity
+  - name: UTIL_CreateEntityByName
+    alias:
+    - CreateEntityByName
+  - name: CBaseEntity_DispatchSpawn
+    alias:
+    - CBaseEntity::DispatchSpawn
+    - DispatchSpawn
+  - name: CEntitySystem_QueueSpawnEntity
+    alias:
+    - CEntitySystem::QueueSpawnEntity
+  - name: CEntitySystem_HelperExecuteQueuedSpawn
+    alias:
+    - CEntitySystem::HelperExecuteQueuedSpawn
+  - name: CEntitySystem_SortEntities
+    alias:
+    - CEntitySystem::SortEntities
+  - name: CGameEntitySystem_SortEntities
+    alias:
+    - CGameEntitySystem::SortEntities
+  - name: CEntitySystem_InstallCreationWrapperCallbacks
+    alias:
+    - CEntitySystem::InstallCreationWrapperCallbacks
+  - name: CEntitySystem_ExecuteQueuedCreation
+    alias:
+    - CEntitySystem::ExecuteQueuedCreation
+  - name: CEntitySystem_ExecuteQueuedActivates
+    alias:
+    - CEntitySystem::ExecuteQueuedActivates
+  - name: CEntitySystem_ExecuteQueuedPostDataUpdateAndActivates
+    alias:
+    - CEntitySystem::ExecuteQueuedPostDataUpdateAndActivates
+  - name: CEntitySystem_Activate
+    alias:
+    - CEntitySystem::Activate
+  - name: CEntitySystem_PostDataUpdate
+    alias:
+    - CEntitySystem::PostDataUpdate
+  - name: CBaseEntity_NetworkStateChangedLog
+    alias:
+    - CBaseEntity::NetworkStateChangedLog
+  - name: CBaseEntity_NetworkStateChanged
+    alias:
+    - CBaseEntity::NetworkStateChanged
+  - name: CBaseEntity_FullEdictChanged
+    alias:
+    - CBaseEntity::FullEdictChanged
+  - name: CBaseEntity_m_NetworkTransmitComponent
+    alias:
+    - CBaseEntity::m_NetworkTransmitComponent
+  - name: CNetworkTransmitComponent_StateChanged
+    alias:
+    - CNetworkTransmitComponent::StateChanged
+  - name: CNetworkTransmitComponent_m_nStateFlags
+    alias:
+    - CNetworkTransmitComponent::m_nStateFlags
+  - name: CInferno_InfernoThink
+    alias:
+    - CInferno::InfernoThink
+  - name: CPhysExplosion_Activate
+    alias:
+    - CPhysExplosion::Activate
+  - name: CPhysExplosion_Explode
+    alias:
+    - CPhysExplosion::Explode
+  - name: UTIL_SayTextFilter2
+    alias:
+    - UTIL_SayText2Filter
+  - name: CCSWeaponBase_ItemPostFrame_ProcessReloadAction
+    alias:
+    - CCSWeaponBase::ItemPostFrame::ProcessReloadAction
+  - name: CCSPlayer_WeaponServices_HandleDropWeapon
+    alias:
+    - CCSPlayer_WeaponServices::HandleDropWeapon
+  - name: CCSPlayer_UseServices_BumpWeapon
+    alias:
+    - CCSPlayer_UseServices::BumpWeapon
+  - name: CCSPlayerPawn_HandleDropWeapon
+    alias:
+    - CCSPlayerPawn::HandleDropWeapon
+  - name: CCSPlayerPawn_ClientCommand
+    alias:
+    - CCSPlayerPawn::ClientCommand
+  - name: CCSPlayerPawn_SprayPaint
+    alias:
+    - CCSPlayerPawn::SprayPaint
+  - name: CEntitySpawner_CPlayerSprayDecal_Spawn
+    alias:
+    - CEntitySpawner<CPlayerSprayDecal>::Spawn
+  - name: CEntityKeyValuesAllocator_GetTempBuffer
+    alias:
+    - CEntityKeyValuesAllocator::GetTempBuffer
+  - name: CEntityKeyValues_LoadFromContext
+    alias:
+    - CEntityKeyValues::LoadFromContext
+  - name: CEntityKeyValues_Initialized
+    alias:
+    - CEntityKeyValues::Initialized
+  - name: CEntitySystem_m_nEntityKeyValuesAllocatorRefCount
+    alias:
+    - CEntitySystem::m_nEntityKeyValuesAllocatorRefCount
+  - name: CEntitySystem_AddRefKeyValues
+    alias:
+    - CEntitySystem::AddRefKeyValues
+  - name: CEntitySystem_ReleaseKeyValues
+    alias:
+    - CEntitySystem::ReleaseKeyValues
+  - name: CCSPlayerController_HandleCommandDrop
+    alias:
+    - CCSPlayerController::HandleCommandDrop
+  - name: IGameSystem_InitAllSystems
+    alias:
+    - IGameSystem::InitAllSystems
+  - name: IGameSystem_LoopInitAllSystems
+    alias:
+    - IGameSystem::LoopInitAllSystems
+  - name: IGameSystem_LoopPostInitAllSystems
+    alias:
+    - IGameSystem::LoopPostInitAllSystems
+  - name: IGameSystem_PostInit
+    alias:
+    - IGameSystem::PostInit
+  - name: IGameSystemFactory_PostInit
+    alias:
+    - IGameSystemFactory::PostInit
+  - name: IGameSystemFactory_GetStaticGameSystem
+    alias:
+    - IGameSystemFactory::GetStaticGameSystem
+  - name: IGameSystem_InitAllSystems_pFirst
+    alias:
+    - IGameSystem::InitAllSystems::pFirst
+    - IGameSystem::InitAllSystems->pFirst
+  - name: IGameSystem_LoopPostInitAllSystems_pEventDispatcher
+    alias:
+    - IGameSystem::LoopPostInitAllSystems::pEventDispatcher
+    - IGameSystem::LoopPostInitAllSystems->pEventDispatcher
+  - name: IGameSystem_LoopDestroyAllSystems_s_GameSystems
+    alias:
+    - IGameSystem::LoopDestroyAllSystems::s_GameSystems
+    - IGameSystem::LoopDestroyAllSystems->s_GameSystems
+  - name: CSource2GameEntities_CheckTransmit
+    alias:
+    - CSource2GameEntities::CheckTransmit
+    - ISource2GameEntities::CheckTransmit
+    - ISource2GameEntities_CheckTransmit
+    - CheckTransmit
+  - name: CSource2GameEntities_ShouldClientReceiveStringTableUserData
+    alias:
+    - CSource2GameEntities::ShouldClientReceiveStringTableUserData
+    - ISource2GameEntities::ShouldClientReceiveStringTableUserData
+    - ISource2GameEntities_ShouldClientReceiveStringTableUserData
+    - ShouldClientReceiveStringTableUserData
+  - name: CBaseEntity_EmitSoundFilter
+    alias:
+    - CBaseEntity::EmitSoundFilter
+  - name: CBaseEntity_ScriptInputKill
+    alias:
+    - CBaseEntity::ScriptInputKill
+  - name: CBaseEntity_ScriptGetForward
+    alias:
+    - CBaseEntity::ScriptGetForward
+  - name: CBaseEntity_ScriptGetRight
+    alias:
+    - CBaseEntity::ScriptGetRight
+  - name: CBaseEntity_ScriptGetLeft
+    alias:
+    - CBaseEntity::ScriptGetLeft
+  - name: CBaseEntity_ScriptGetUp
+    alias:
+    - CBaseEntity::ScriptGetUp
+  - name: CBaseEntity_ScriptGetModelName
+    alias:
+    - CBaseEntity::ScriptGetModelName
+  - name: CBaseEntity_ScriptGetMoveParent
+    alias:
+    - CBaseEntity::ScriptGetMoveParent
+  - name: CBaseEntity_ScriptGetRootMoveParent
+    alias:
+    - CBaseEntity::ScriptGetRootMoveParent
+  - name: CBaseEntity_ScriptFirstMoveChild
+    alias:
+    - CBaseEntity::ScriptFirstMoveChild
+  - name: CBaseEntity_ScriptNextMovePeer
+    alias:
+    - CBaseEntity::ScriptNextMovePeer
+  - name: CBaseEntity_ScriptGetOwnerEntity
+    alias:
+    - CBaseEntity::ScriptGetOwnerEntity
+  - name: CBaseEntity_Script_GetChildren
+    alias:
+    - CBaseEntity::Script_GetChildren
+  - name: CBaseEntity_ScriptSetParent
+    alias:
+    - CBaseEntity::ScriptSetParent
+  - name: CBaseEntity_ScriptEyePosition
+    alias:
+    - CBaseEntity::ScriptEyePosition
+  - name: CBaseEntity_ScriptSetAngles
+    alias:
+    - CBaseEntity::ScriptSetAngles
+  - name: CBaseEntity_ScriptSetAbsAngles
+    alias:
+    - CBaseEntity::ScriptSetAbsAngles
+  - name: CBaseEntity_ScriptGetAngles
+    alias:
+    - CBaseEntity::ScriptGetAngles
+  - name: CBaseEntity_ScriptEyeAngles
+    alias:
+    - CBaseEntity::ScriptEyeAngles
+  - name: CBaseEntity_ScriptSetOrigin
+    alias:
+    - CBaseEntity::ScriptSetOrigin
+  - name: CBaseEntity_ScriptSetLocalAngles
+    alias:
+    - CBaseEntity::ScriptSetLocalAngles
+  - name: CBaseEntity_ScriptGetLocalAngles
+    alias:
+    - CBaseEntity::ScriptGetLocalAngles
+  - name: CBaseEntity_ScriptSetLocalOrigin
+    alias:
+    - CBaseEntity::ScriptSetLocalOrigin
+  - name: CBaseEntity_ScriptGetLocalOrigin
+    alias:
+    - CBaseEntity::ScriptGetLocalOrigin
+  - name: CBaseEntity_ScriptTransformPointEntityToWorld
+    alias:
+    - CBaseEntity::ScriptTransformPointEntityToWorld
+  - name: CBaseEntity_ScriptTransformPointWorldToEntity
+    alias:
+    - CBaseEntity::ScriptTransformPointWorldToEntity
+  - name: CBaseEntity_ScriptSetForward
+    alias:
+    - CBaseEntity::ScriptSetForward
+  - name: CBaseEntity_ScriptGetBoundingMins
+    alias:
+    - CBaseEntity::ScriptGetBoundingMins
+  - name: CBaseEntity_ScriptGetBoundingMaxs
+    alias:
+    - CBaseEntity::ScriptGetBoundingMaxs
+  - name: CBaseEntity_ScriptGetBounds
+    alias:
+    - CBaseEntity::ScriptGetBounds
+  - name: CBaseEntity_ScriptGetLocalAngularVelocity_OBSOLETE
+    alias:
+    - CBaseEntity::ScriptGetLocalAngularVelocity_OBSOLETE
+  - name: CBaseEntity_ScriptSetLocalAngularVelocity_OBSOLETE
+    alias:
+    - CBaseEntity::ScriptSetLocalAngularVelocity_OBSOLETE
+  - name: CBaseEntity_ScriptAddEffects
+    alias:
+    - CBaseEntity::ScriptAddEffects
+  - name: CBaseEntity_ScriptRemoveEffects
+    alias:
+    - CBaseEntity::ScriptRemoveEffects
+  - name: CBaseEntity_ScriptSetAttributeFloatValue
+    alias:
+    - CBaseEntity::ScriptSetAttributeFloatValue
+  - name: CBaseEntity_ScriptGetAttributeFloatValue
+    alias:
+    - CBaseEntity::ScriptGetAttributeFloatValue
+  - name: CBaseEntity_ScriptSetAttributeIntValue
+    alias:
+    - CBaseEntity::ScriptSetAttributeIntValue
+  - name: CBaseEntity_ScriptGetAttributeIntValue
+    alias:
+    - CBaseEntity::ScriptGetAttributeIntValue
+  - name: CBaseEntity_ScriptHasAttribute
+    alias:
+    - CBaseEntity::ScriptHasAttribute
+  - name: CBaseEntity_ScriptDeleteAttribute
+    alias:
+    - CBaseEntity::ScriptDeleteAttribute
+  - name: CBaseEntity_GetScriptOwnerEntity
+    alias:
+    - CBaseEntity::GetScriptOwnerEntity
+  - name: CBaseEntity_SetScriptOwnerEntity
+    alias:
+    - CBaseEntity::SetScriptOwnerEntity
+  - name: CBaseEntity_ScriptSetEntityName
+    alias:
+    - CBaseEntity::ScriptSetEntityName
+  - name: CBaseEntity_ScriptGetMass
+    alias:
+    - CBaseEntity::ScriptGetMass
+  - name: CBaseEntity_ScriptSetMass
+    alias:
+    - CBaseEntity::ScriptSetMass
+  - name: CBaseEntity_ScriptGetSpawnGroupHandle
+    alias:
+    - CBaseEntity::ScriptGetSpawnGroupHandle
+  - name: CBaseEntity_GetAbsAngles
+    alias:
+    - CBaseEntity::GetAbsAngles
+  - name: CBaseEntity_Script_GetTeamNumber
+    alias:
+    - CBaseEntity::Script_GetTeamNumber
+  - name: CBaseEntity_Script_FollowEntity
+    alias:
+    - CBaseEntity::Script_FollowEntity
+  - name: CBaseEntity_Script_FollowEntityMerge
+    alias:
+    - CBaseEntity::Script_FollowEntityMerge
+  - name: CBaseEntity_Script_Trigger
+    alias:
+    - CBaseEntity::Script_Trigger
+  - name: CBaseEntity_Script_SetContextThink
+    alias:
+    - CBaseEntity::Script_SetContextThink
+  - name: CBaseEntity_AddContextForScript
+    alias:
+    - CBaseEntity::AddContextForScript
+  - name: CBaseEntity_AddContextForScriptNumeric
+    alias:
+    - CBaseEntity::AddContextForScriptNumeric
+  - name: CBaseEntity_GetContextForScript
+    alias:
+    - CBaseEntity::GetContextForScript
+  - name: CBaseEntity_ScriptGatherCriteria
+    alias:
+    - CBaseEntity::ScriptGatherCriteria
+  - name: CBaseEntity_Script_TakeDamage
+    alias:
+    - CBaseEntity::Script_TakeDamage
+  - name: CBaseEntity_SetAbsVelocity
+    alias:
+    - CBaseEntity::SetAbsVelocity
+  - name: CBaseEntity_GetAbsVelocity
+    alias:
+    - CBaseEntity::GetAbsVelocity
+  - name: CBaseEntity_Script_ApplyLocalAngularVelocityImpulse
+    alias:
+    - CBaseEntity::Script_ApplyLocalAngularVelocityImpulse
+  - name: CBaseEntity_GetLocalAngularVelocity_OBSOLETE
+    alias:
+    - CBaseEntity::GetLocalAngularVelocity_OBSOLETE
+  - name: CBaseEntity_ScriptEmitSoundParams
+    alias:
+    - CBaseEntity::ScriptEmitSoundParams
+    - CBaseEntity::EmitSoundParams
+    - CBaseEntity_EmitSoundParams
+  - name: CBaseEntity_ScriptStopSound
+    alias:
+    - CBaseEntity::ScriptStopSound
+  - name: CBaseEntity_ScriptSoundDuration
+    alias:
+    - CBaseEntity::ScriptSoundDuration
+  - name: CBaseEntity_ScriptGetAbsOrigin
+    alias:
+    - CBaseEntity::ScriptGetAbsOrigin
+  - name: CBaseEntity_Precache
+    alias:
+    - CBaseEntity::Precache
+    - Precache
+  - name: CEnvEntityIgniter_Precache
+    alias:
+    - CEnvEntityIgniter::Precache
+  - name: CEnvShake_Spawn
+    alias:
+    - CEnvShake::Spawn
+  - name: CBaseEntity_SetMoveType
+    alias:
+    - CBaseEntity::SetMoveType
+  - name: CBasePlayerPawn_CommitSuicide
+    alias:
+    - CBasePlayerPawn::CommitSuicide
+    - CommitSuicide
+  - name: CBaseCombatCharacter_OnKilled
+    alias:
+    - CBaseCombatCharacter::OnKilled
+  - name: CCSPlayerPawn_Event_KilledOther
+    alias:
+    - CCSPlayerPawn::Event_KilledOther
+  - name: CCSPlayerPawn_Event_Killed
+    alias:
+    - CCSPlayerPawn::Event_Killed
+  - name: CBasePlayerPawn_Event_Killed
+    alias:
+    - CBasePlayerPawn::Event_Killed
+  - name: ScriptBinding_CSPlayerPawn_DestroyWeapon
+    alias:
+    - CSPlayerPawn::DestroyWeapon
+  - name: CBasePlayerPawn_RemovePlayerItem
+    alias:
+    - CBasePlayerPawn::RemovePlayerItem
+  - name: CBasePlayerPawn_DropActivePlayerWeapon
+    alias:
+    - CBasePlayerPawn::DropActivePlayerWeapon
+  - name: CBasePlayerPawn_GetEyePosition
+    alias:
+    - CBasePlayerPawn::GetEyePosition
+  - name: CBaseEntity_GetEyePosition
+    alias:
+    - CBaseEntity::GetEyePosition
+  - name: CCSBotManager_BotPlaceCommand
+    alias:
+    - CCSBotManager::BotPlace
+  - name: CBasePlayerPawn_EyeVectors
+    alias:
+    - CBasePlayerPawn::EyeVectors
+  - name: CBasePlayerPawn_GetEyeAngles
+    alias:
+    - CBasePlayerPawn::GetEyeAngles
+  - name: CBaseEntity_GetEyeAngles
+    alias:
+    - CBaseEntity::GetEyeAngles
+  - name: CCSBot_Upkeep
+    alias:
+    - CCSBot::Upkeep
+  - name: CCSBot_SetState
+    alias:
+    - CCSBot::SetState
+  - name: CCSBot_UpdatePathMovement
+    alias:
+    - CCSBot::UpdatePathMovement
+  - name: CCSBot_PrintIfWatched
+    alias:
+    - CCSBot::PrintIfWatched
+  - name: CHostage_Follow
+    alias:
+    - CHostage::Follow
+  - name: CHostage_DropHostage
+    alias:
+    - CHostage::DropHostage
+  - name: HideState_OnUpdate
+    alias:
+    - HideState::OnUpdate
+  - name: CCSBot_Attack
+    alias:
+    - CCSBot::Attack
+  - name: CCSBot_MoveTo
+    alias:
+    - CCSBot::MoveTo
+  - name: CCSBot_InhibitLookAround
+    alias:
+    - CCSBot::InhibitLookAround
+  - name: CCSBot_SetDisposition
+    alias:
+    - CCSBot::SetDisposition
+  - name: CCSBot_Idle
+    alias:
+    - CCSBot::Idle
+  - name: CCSBot_ComputePath
+    alias:
+    - CCSBot::ComputePath
+  - name: CBaseEntity_IsAlive
+    alias:
+    - CBaseEntity::IsAlive
+  - name: CBaseEntity_SetOwner
+    alias:
+    - CBaseEntity::SetOwner
+  - name: CBaseEntity_CollisionRulesChanged
+    alias:
+    - CBaseEntity::CollisionRulesChanged
+    - CollisionRulesChanged
+  - name: CBaseEntity_Use
+    alias:
+    - CBaseEntity::Use
+  - name: CGameSceneNode_PostSpawnKeyValues
+    alias:
+    - CGameSceneNode::PostSpawnKeyValues
+  - name: CBaseEntity_Spawn
+    alias:
+    - CBaseEntity::Spawn
+    - Spawn
+  - name: CBaseEntity_SpawnRadius
+    alias:
+    - CBaseEntity::SpawnRadius
+  - name: CCSPlayer_ItemServices_DropActivePlayerWeapon
+    alias:
+    - CCSPlayer_ItemServices::DropActivePlayerWeapon
+  - name: CCSPlayer_WeaponServices_DropWeapon
+    alias:
+    - CCSPlayer_WeaponServices::DropWeapon
+  - name: CBasePlayerWeapon_Shoot_Secondary
+    alias:
+    - CBasePlayerWeapon::Shoot_Secondary
+  - name: CCSPlayer_ItemServices_RemoveWeapons
+    alias:
+    - CCSPlayer_ItemServices::RemoveWeapons
+  - name: CCSPlayer_WeaponServices_SelectItem
+    alias:
+    - CCSPlayer_WeaponServices::SelectItem
+  - name: CEntFireOutputAutoCompletionFunctor_FireOutput
+    alias:
+    - CEntFireOutputAutoCompletionFunctor::FireOutput
+  - name: CEntityInstance_FindOutputsByName
+    alias:
+    - CEntityInstance::FindOutputsByName
+  - name: CEntityInstance_ScriptEntityIO
+    alias:
+    - CEntityInstance::ScriptEntityIO
+  - name: CEntityIOOutput_FireOutputInternal
+    alias:
+    - CEntityIOOutput::FireOutputInternal
+  - name: CEntitySystem_AddEntityIOEvent
+    alias:
+    - CEntitySystem::AddEntityIOEvent
+  - name: CEntitySystem_AddEntityIOEvent2
+    alias:
+    - CEntitySystem::AddEntityIOEvent2
+  - name: CEntitySystem_AddEntityIOEventBuildStruct
+    alias:
+    - CEntitySystem::AddEntityIOEventBuildStruct
+  - name: CEntitySystem_AddEntityIOEventToQueue
+    alias:
+    - CEntitySystem::AddEntityIOEventToQueue
+  - name: CEntitySystem_m_EventQueue
+    alias:
+    - CEntitySystem::m_EventQueue
+  - name: CGameEntitySystem_FindEntityByClassName
+    alias:
+    - CGameEntitySystem::FindEntityByClassName
+  - name: CGameEntitySystem_FindEntityByName
+    alias:
+    - CGameEntitySystem::FindEntityByName
+  - name: CGameEntitySystem_OnAddEntity
+    alias:
+    - CGameEntitySystem::OnAddEntity
+  - name: CGameEntitySystem_BuildResourceManifest_ManifestNameOrGroupName
+    alias:
+    - CGameEntitySystem::BuildResourceManifest_ManifestNameOrGroupName
+  - name: CGameEntitySystem_BuildResourceManifest_KeyValuesVectors
+    alias:
+    - CGameEntitySystem::BuildResourceManifest_KeyValuesVectors
+  - name: CGameEntitySystem_FindEntityProcedural
+    alias:
+    - CGameEntitySystem::FindEntityProcedural
+  - name: CGameEntitySystem_Spawn
+    alias:
+    - CGameEntitySystem::Spawn
+  - name: CEntitySystem_Spawn
+    alias:
+    - CEntitySystem::Spawn
+  - name: CBodyGameSystem_SpawnDependencyIsland
+    alias:
+    - CBodyGameSystem::SpawnDependencyIsland
+  - name: CGameEntitySystem_CheckGlobalState
+    alias:
+    - CGameEntitySystem::CheckGlobalState
+  - name: IGameSystem_OnBuildGameSessionManifest
+    alias:
+    - IGameSystem::BuildGameSessionManifest
+  - name: IGameSystem_OnServerPreEntityThink
+    alias:
+    - IGameSystem::OnServerPreEntityThink
+  - name: IGameSystem_OnServerPostEntityThink
+    alias:
+    - IGameSystem::OnServerPostEntityThink
+  - name: IGameSystem_OnServerPreClientUpdate
+    alias:
+    - IGameSystem::ServerPreClientUpdate
+  - name: IGameSystem_OnServerAdvanceTick
+    alias:
+    - IGameSystem::ServerAdvanceTick
+  - name: IGameSystem_OnServerGamePostSimulate
+    alias:
+    - IGameSystem::ServerGamePostSimulate
+  - name: IGameSystem_OnServerPostAdvanceTick
+    alias:
+    - IGameSystem::ServerPostAdvanceTick
+  - name: IGameSystem_OnServerPreBeginAsyncPostTickWork
+    alias:
+    - IGameSystem::OnServerPreBeginAsyncPostTickWork
+  - name: IGameSystem_OnServerBeginAsyncPostTickWork
+    alias:
+    - IGameSystem::OnServerBeginAsyncPostTickWork
+  - name: IGameSystem_OnServerPreEndAsyncPostTickWork
+    alias:
+    - IGameSystem::OnServerPreEndAsyncPostTickWork
+  - name: IGameSystem_OnServerPostEndAsyncPostTickWork
+    alias:
+    - IGameSystem::OnServerPostEndAsyncPostTickWork
+  - name: IGameSystem_OnSaveGame
+    alias:
+    - IGameSystem::OnSaveGame
+  - name: IGameSystem_OnRestoreGame
+    alias:
+    - IGameSystem::OnRestoreGame
+  - name: IGameSystem_OnOutOfGameFrameBoundary
+    alias:
+    - IGameSystem::OnOutOfGameFrameBoundary
+  - name: CSource2GameClients_StartHLTVServer
+    alias:
+    - CSource2GameClients::StartHLTVServer
+  - name: LegacyGameEventListener
+    alias:
+    - GetLegacyGameEventListener
+  - name: CPhysicsGameSystem_ProcessContactEvents
+    alias:
+    - CPhysicsGameSystem::ProcessContactEvents
+  - name: CBaseEntity_VPhysicsStartTouch
+    alias:
+    - CBaseEntity::VPhysicsStartTouch
+  - name: CBaseEntity_PhysicsTouch
+    alias:
+    - CBaseEntity::PhysicsTouch
+  - name: CBaseEntity_VPhysicsEndTouch
+    alias:
+    - CBaseEntity::VPhysicsEndTouch
+  - name: CBaseEntity_StartTouch
+    alias:
+    - CBaseEntity::StartTouch
+    - StartTouch
+  - name: CBaseEntity_Touch
+    alias:
+    - CBaseEntity::Touch
+    - Touch
+  - name: CBaseEntity_EndTouch
+    alias:
+    - CBaseEntity::EndTouch
+    - EndTouch
+  - name: IVPhys2World_GetTouchingList
+    alias:
+    - IVPhys2World::GetTouchingList
+    - CVPhys2World::GetTouchingList
+  - name: CTriggerPush_Touch
+    alias:
+    - CTriggerPush::Touch
+    - TriggerPush_Touch
+  - name: CPhysBox_Use
+    alias:
+    - CPhysBox::Use
+  - name: CBaseEntity_SetGroundEntity
+    alias:
+    - SetGroundEntity
+  - name: CBaseEntity_GetHammerUniqueId
+    alias:
+    - CBaseEntity::GetHammerUniqueId
+    - GetHammerUniqueId
+  - name: CBaseEntity_IsPlayerPawn
+    alias:
+    - CBaseEntity::IsPlayerPawn
+    - IsEntityPawn
+    - IsPlayerPawn
+  - name: CBaseEntity_IsPlayerController
+    alias:
+    - CBaseEntity::IsPlayerController
+    - IsEntityController
+    - IsPlayerController
+  - name: CBaseTrigger_StartTouch
+    alias:
+    - CBaseTrigger::StartTouch
+  - name: CBaseTrigger_EndTouch
+    alias:
+    - CBaseTrigger::EndTouch
+  - name: CBaseTrigger_PassesTriggerFilters
+    alias:
+    - CBaseTrigger::PassesTriggerFilters
+    - PassesTriggerFilters
+  - name: CBaseAnimGraph_GetAnimationController
+    alias:
+    - CBaseAnimGraph::GetAnimationController
+  - name: CBaseAnimGraph_m_skeletonInstance
+    alias:
+    - CBaseAnimGraph::m_skeletonInstance
+  - name: CGameSceneNode_PreInstanceSpawn
+    alias:
+    - CGameSceneNode::PreInstanceSpawn
+  - name: CGameSceneNode_GetSkeletonInstance
+    alias:
+    - CGameSceneNode::GetSkeletonInstance
+  - name: CSkeletonInstance_m_animationController
+    alias:
+    - CSkeletonInstance::m_animationController
+  - name: CSkeletonInstance_PostDataUpdate
+    alias:
+    - CSkeletonInstance::PostDataUpdate
+  - name: CGameSceneNode_PostDataUpdate
+    alias:
+    - CGameSceneNode::PostDataUpdate
+  - name: CGameSceneNode_UpdateEntityForHierarchyChange
+    alias:
+    - CGameSceneNode::UpdateEntityForHierarchyChange
+  - name: CPointTeleportAPI_TeleportEntityInternal
+    alias:
+    - CPointTeleportAPI::TeleportEntityInternal
+  - name: CBaseEntity_Teleport
+    alias:
+    - CBaseEntity::Teleport
+  - name: CPointTeleport_Activate
+    alias:
+    - CPointTeleport::Activate
+  - name: CBaseEntity_Activate
+    alias:
+    - CBaseEntity::Activate
+    - Activate
+  - name: CBaseEntity_DrawDebugTextOverlays
+    alias:
+    - CBaseEntity::DrawDebugTextOverlays
+  - name: CRagdollProp_DrawEntityDebugOverlays
+    alias:
+    - CRagdollProp::DrawEntityDebugOverlays
+  - name: CBaseEntity_ReloadPrivateScripts
+    alias:
+    - CBaseEntity::ReloadPrivateScripts
+  - name: CCheckTransmitInfo_m_nPlayerSlot
+    alias:
+    - CCheckTransmitInfo::m_nPlayerSlot
+    - CheckTransmitPlayerSlot
+  - name: CDedicatedServerWorkshopManager_SwitchToWorkshopMapGroup
+    alias:
+    - CDedicatedServerWorkshopManager::SwitchToWorkshopMapGroup
+  - name: IGameTypes_CreateWorkshopMapGroup
+    alias:
+    - IGameTypes::CreateWorkshopMapGroup
+  - name: CEngineServer_UnloadSpawnGroup
+    alias:
+    - CEngineServer::UnloadSpawnGroup
+  - name: CSpawnGroupMgrGameSystem_GetSpawnGroups
+    alias:
+    - CSpawnGroupMgrGameSystem::GetSpawnGroups
+    - GetSpawnGroups
+  - name: CSpawnGroupMgrGameSystem_DumpSpawnGroups
+    alias:
+    - CSpawnGroupMgrGameSystem::DumpSpawnGroups
+    - DumpSpawnGroups
+  - name: CSpawnGroupMgrGameSystem_SpawnGroupSpawnEntitiesInternal
+    alias:
+    - CSpawnGroupMgrGameSystem::SpawnGroupSpawnEntitiesInternal
+    - SpawnGroupSpawnEntitiesInternal
+  - name: IGameSystem_OnPreSpawnGroupLoad
+    alias:
+    - IGameSystem::OnPreSpawnGroupLoad
+  - name: IGameSystem_OnPostSpawnGroupLoad
+    alias:
+    - IGameSystem::OnPostSpawnGroupLoad
+  - name: CSpawnGroupMgrGameSystem_SpawnGroupShutdown
+    alias:
+    - CSpawnGroupMgrGameSystem::SpawnGroupShutdown
+    - SpawnGroupShutdown
+  - name: CSpawnGroupMgrGameSystem_SpawnGroupActuallyShutdown
+    alias:
+    - CSpawnGroupMgrGameSystem::SpawnGroupActuallyShutdown
+    - SpawnGroupActuallyShutdown
+  - name: IGameSystem_OnPreSpawnGroupUnload
+    alias:
+    - IGameSystem::OnPreSpawnGroupUnload
+  - name: IGameSystem_OnPostSpawnGroupUnload
+    alias:
+    - IGameSystem::OnPostSpawnGroupUnload
+  - name: CLoadingSpawnGroup_CreateEntityToSpawn
+    alias:
+    - CLoadingSpawnGroup::CreateEntityToSpawn
+  - name: CSpawnGroupMgrGameSystem_OnSpawnGroupPrecache
+    alias:
+    - CSpawnGroupMgrGameSystem::OnSpawnGroupPrecache
+    - SpawnGroupPrecache
+  - name: CSpawnGroupMgrGameSystem_AllocateSpawnGroup
+    alias:
+    - CSpawnGroupMgrGameSystem::AllocateSpawnGroup
+  - name: CSpawnGroupMgrGameSystem_ReleaseSpawnGroup
+    alias:
+    - CSpawnGroupMgrGameSystem::ReleaseSpawnGroup
+  - name: CSpawnGroupMgrGameSystem_SpawnGroupInit
+    alias:
+    - CSpawnGroupMgrGameSystem::SpawnGroupInit
+  - name: CSpawnGroupMgrGameSystem_CreateLoadingSpawnGroup
+    alias:
+    - CSpawnGroupMgrGameSystem::CreateLoadingSpawnGroup
+  - name: CSpawnGroupMgrGameSystem_CreateLoadingSpawnGroupForSaveFile
+    alias:
+    - CSpawnGroupMgrGameSystem::CreateLoadingSpawnGroupForSaveFile
+  - name: CSpawnGroupMgrGameSystem_SpawnGroupSpawnEntities
+    alias:
+    - CSpawnGroupMgrGameSystem::SpawnGroupSpawnEntities
+  - name: CSpawnGroupMgrGameSystem_SetActiveSpawnGroup
+    alias:
+    - CSpawnGroupMgrGameSystem::SetActiveSpawnGroup
+  - name: CSpawnGroupMgrGameSystem_UnloadSpawnGroup
+    alias:
+    - CSpawnGroupMgrGameSystem::UnloadSpawnGroup
+  - name: CSpawnGroupMgrGameSystem_SaveGame_Start
+    alias:
+    - CSpawnGroupMgrGameSystem::SaveGame_Start
+  - name: IGameSystem_OnSpawnGroupPrecache
+    alias:
+    - IGameSystem::OnSpawnGroupPrecache
+  - name: IGameSystem_OnSpawnGroupUncache
+    alias:
+    - IGameSystem::OnSpawnGroupUncache
+  - name: CBaseFilter_InputTestActivator
+    alias:
+    - CBaseFilter::InputTestActivator
+  - name: CGamePlayerEquip_InputTriggerForAllPlayers
+    alias:
+    - CGamePlayerEquip::InputTriggerForAllPlayers
+  - name: CGamePlayerEquip_InputTriggerForActivatedPlayer
+    alias:
+    - CGamePlayerEquip::InputTriggerForActivatedPlayer
+  - name: CNavMesh_GetNearestNavArea
+    alias:
+    - CNavMesh::GetNearestNavArea
+  - name: CCSBotManager_AddBot
+    alias:
+    - CCSBotManager::AddBot
+  - name: BotAdd_CommandHandler
+    alias:
+    - CCSBotManager::BotAddCommand
+  - name: BotKill_CommandHandler
+    alias:
+    - CCSBotManager::BotKillCommand
+  - name: EntInfo_CommandHandler
+    alias:
+    - CC_Ent_Info
+  - name: CEntitySystem_DestroyEntityImmediate
+    alias:
+    - CEntitySystem::DestroyEntityImmediate
+  - name: CEntitySystem_OnRemoveEntityFromDatabase
+    alias:
+    - CEntitySystem::OnRemoveEntityFromDatabase
+  - name: CEntitySystem_DoDestructEntity
+    alias:
+    - CEntitySystem::DoDestructEntity
+  - name: CEntitySystem_UpdateOnRemove
+    alias:
+    - CEntitySystem::UpdateOnRemove
+  - name: ClientPrintToController
+    alias:
+    - ClientPrint
+  - name: CCSBotManager_AddBot_BotNavIgnore
+    alias:
+    - BotNavIgnore
+  - name: CEnvHudHint_API_ShowHudHint
+    alias:
+    - CEnvHudHint_API::ShowHudHint
+  - name: UTIL_GetPlayerControllerForEntity
+    alias:
+    - UTIL_GetPlayerControllerForEntity
+  - name: CEntitySystem_ctor
+    alias:
+    - CEntitySystem::CEntitySystem
+  - name: CGameEntitySystem_ctor
+    alias:
+    - CGameEntitySystem::CGameEntitySystem
+  - name: CEntitySystem_RegisterAccessor
+    alias:
+    - CEntitySystem::RegisterAccessor
+  - name: CEntitySystem_Init
+    alias:
+    - CEntitySystem::Init
+  - name: CEntitySystem_ProcessEntityRegistration
+    alias:
+    - CEntitySystem::ProcessEntityRegistration
+  - name: CEntitySystem_PostCreateEntitySystem
+    alias:
+    - CEntitySystem::PostCreateEntitySystem
+  - name: CSource2EntitySystem_StaticInit
+    alias:
+    - CSource2EntitySystem::StaticInit
+  - name: CSpawnGroupEntityFilterRegistrar_RegisterSpawnGroupEntityFilters
+    alias:
+    - CSpawnGroupEntityFilterRegistrar::RegisterSpawnGroupEntityFilters
+  - name: CGameEntitySystem_m_spawnGroupEntityFilters
+    alias:
+    - CGameEntitySystem::m_spawnGroupEntityFilters
+  - name: CGameEntitySystem_m_pEntity2Networkables
+    alias:
+    - CGameEntitySystem::m_pEntity2Networkables
+  - name: CEntity2NetworkClasses_ServerClass_InitEntity2NetworkClasses
+    alias:
+    - CEntity2NetworkClasses<ServerClass>::InitEntity2NetworkClasses
+  - name: CEntitySystem_m_Symbols
+    alias:
+    - CEntitySystem::m_Symbols
+  - name: CEntitySystem_m_pNetworkFieldChangedEventQueue
+    alias:
+    - CEntitySystem::m_pNetworkFieldChangedEventQueue
+  - name: CEntitySystem_m_pNetworkFieldScratchData
+    alias:
+    - CEntitySystem::m_pNetworkFieldScratchData
+  - name: CEntitySystem_m_pFieldChangeLimitSpew
+    alias:
+    - CEntitySystem::m_pFieldChangeLimitSpew
+  - name: CEntitySystem_m_ComponentUnserializerInfoAllocator
+    alias:
+    - CEntitySystem::m_ComponentUnserializerInfoAllocator
+  - name: CEntitySystem_m_EntityMaterialAttributes
+    alias:
+    - CEntitySystem::m_EntityMaterialAttributes
+  - name: CEntitySystem_m_flChangeCallbackSpewThreshold
+    alias:
+    - CEntitySystem::m_flChangeCallbackSpewThreshold
+  - name: CEntitySystem_ClearEntityDatabase
+    alias:
+    - CEntitySystem::ClearEntityDatabase
+  - name: INetworkMessages_SetNetworkSerializationContextData
+    alias:
+    - INetworkMessages::SetNetworkSerializationContextData
+  - name: CFlattenedSerializers_CreateFieldChangedEventQueue
+    alias:
+    - CFlattenedSerializers::CreateFieldChangedEventQueue
+  - name: INetworkMessages_RegisterSchemaTypeOverride
+    alias:
+    - INetworkMessages::RegisterSchemaTypeOverride
+  - name: CSceneEntity_GetScriptDesc
+    alias:
+    - CSceneEntity::GetScriptDesc
+  - name: CEntityInstance_GetScriptDesc
+    alias:
+    - CEntityInstance::GetScriptDesc
+  - name: CEntityInstance_Spawn
+    alias:
+    - CEntityInstance::Spawn
+  - name: CEntityInstance_Activate
+    alias:
+    - CEntityInstance::Activate
+  - name: CEntityInstance_Precache
+    alias:
+    - CEntityInstance::Precache
+  - name: CEntityInstance_GetDataDescMap
+    alias:
+    - CEntityInstance::GetDataDescMap
+  - name: CEntityInstance_ReloadPrivateScripts
+    alias:
+    - CEntityInstance::ReloadPrivateScripts
+  - name: CEntityInstance_ValidatePrivateScriptScope
+    alias:
+    - CEntityInstance::ValidatePrivateScriptScope
+  - name: CEntityInstance_NetworkStateChanged
+    alias:
+    - CEntityInstance::NetworkStateChanged
+  - name: CEntityInstance_FullEdictChanged
+    alias:
+    - CEntityInstance::FullEdictChanged
+  - name: CEntityInstance_NetworkUpdateState
+    alias:
+    - CEntityInstance::NetworkUpdateState
+  - name: CEntityInstance_NetworkStateChangedLog
+    alias:
+    - CEntityInstance::NetworkStateChangedLog
+  - name: CEntityInstance_DrawDebugTextOverlays
+    alias:
+    - CEntityInstance::DrawDebugTextOverlays
+  - name: CEntityInstance_DrawEntityDebugOverlays
+    alias:
+    - CEntityInstance::DrawEntityDebugOverlays
+  - name: CEntityInstance_PostDataUpdateDelta
+    alias:
+    - CEntityInstance::PostDataUpdateDelta
+  - name: CEntityInstance_PreDataUpdate
+    alias:
+    - CEntityInstance::PreDataUpdate
+  - name: CEntityInstance_PostDataUpdate
+    alias:
+    - CEntityInstance::PostDataUpdate
+  - name: CEntityInstance_PostDataUpdatePreserve
+    alias:
+    - CEntityInstance::PostDataUpdatePreserve
+  - name: CEntityInstance_Connect
+    alias:
+    - CEntityInstance::Connect
+  - name: CEntityInstance_UpdateOnRemove
+    alias:
+    - CEntityInstance::UpdateOnRemove
+  - name: CEntityInstance_Disconnect
+    alias:
+    - CEntityInstance::Disconnect
+  - name: CEntityInstance_AddedToEntityDatabase
+    alias:
+    - CEntityInstance::AddedToEntityDatabase
+  - name: CEntityInstance_OnSetDormant
+    alias:
+    - CEntityInstance::OnSetDormant
+  - name: CEntityInstance_Schema_DynamicBinding
+    alias:
+    - CEntityInstance::Schema_DynamicBinding
+  - name: CEntitySystem_OnRemoveEntity
+    alias:
+    - CEntitySystem::OnRemoveEntity
+  - name: CEntityComponentHelperT_Free
+    alias:
+    - CEntityComponentHelperT::Free
+  - name: CScriptedSequence_SynchronizeSequence
+    alias:
+    - CScriptedSequence::SynchronizeSequence
+  - name: CNetworkUtlVectorEmbedded_NetworkStateChanged_m_vecRenderAttributes
+    alias:
+    - CNetworkUtlVectorEmbedded<CRenderAttribute>::NetworkStateChanged_m_vecRenderAttributes
+  - name: CNetworkUtlVectorEmbedded_NetworkStateChanged_m_perRoundStats
+    alias:
+    - CNetworkUtlVectorEmbedded<CSPerRoundStats_t>::NetworkStateChanged_m_perRoundStats
+  - name: CUtlVectorEmbeddedNetworkVar_CSPerRoundStats_t_NetworkVar_m_perRoundStats_SetCount
+    alias:
+    - CUtlVectorEmbeddedNetworkVar<CSPerRoundStats_t, NetworkVar>::SetCount
+  - name: CNetworkUtlVectorEmbedded_TryLateResolve_m_vecRenderAttributes
+    alias:
+    - CNetworkUtlVectorEmbedded<CRenderAttribute>::TryLateResolve
+  - name: INetworkMessages_GetLoggingChannel
+    alias:
+    - INetworkMessages::GetLoggingChannel
+  - name: CPhysicsEntitySolver_PhysEnableEntityCollisions
+    alias:
+    - CPhysicsEntitySolver::PhysEnableEntityCollisions
+  - name: CLoopModeGame_StaticInit
+    alias:
+    - CLoopModeGame::StaticInit
+  - name: CLoopModeGame_ctor
+    alias:
+    - CLoopModeGame::CLoopModeGame
+  - name: CLoopModeFactory_CLoopModeGame_Init
+    alias:
+    - CLoopModeFactory<CLoopModeGame>::Init
+  - name: CLoopModeFactory_CLoopModeGame_CreateLoopMode
+    alias:
+    - CLoopModeFactory<CLoopModeGame>::CreateLoopMode
+  - name: CLoopModeFactory_CLoopModeGame_Shutdown
+    alias:
+    - CLoopModeFactory<CLoopModeGame>::Shutdown
+  - name: CLoopModeGame_OnLoopActivate
+    alias:
+    - CLoopModeGame::OnLoopActivate
+  - name: ILoopMode_OnLoopActivate
+    alias:
+    - ILoopMode::OnLoopActivate
+  - name: CLoopModeGame_AddViewsToSceneSystem
+    alias:
+    - CLoopModeGame::AddViewsToSceneSystem
+  - name: ILoopMode_AddViewsToSceneSystem
+    alias:
+    - ILoopMode::AddViewsToSceneSystem
+  - name: CLoopModeGame_LoopInitInternal
+    alias:
+    - CLoopModeGame::LoopInitInternal
+  - name: CLoopModeGame_LoopInit
+    alias:
+    - CLoopModeGame::LoopInit
+  - name: ILoopMode_LoopInit
+    alias:
+    - ILoopMode::LoopInit
+  - name: ILoopMode_LoopShutdown
+    alias:
+    - ILoopMode::LoopShutdown
+  - name: CLoopModeGame_RegisterEventMapInternal
+    alias:
+    - CLoopModeGame::RegisterEventMapInternal
+  - name: CLoopModeGame_OnServerAdvanceTick
+    alias:
+    - CLoopModeGame::OnServerAdvanceTick
+  - name: CLoopModeGame_OnServerBeginSimulate
+    alias:
+    - CLoopModeGame::OnServerBeginSimulate
+  - name: CLoopModeGame_OnServerPostSimulate
+    alias:
+    - CLoopModeGame::OnServerPostSimulate
+  - name: CLoopModeGame_OnServerPostAdvanceTick
+    alias:
+    - CLoopModeGame::OnServerPostAdvanceTick
+  - name: CLoopModeGame_OnServerBeginAsyncPostTickWork
+    alias:
+    - CLoopModeGame::OnServerBeginAsyncPostTickWork
+  - name: CLoopModeGame_OnServerEndAsyncPostTickWork
+    alias:
+    - CLoopModeGame::OnServerEndAsyncPostTickWork
+  - name: CLoopModeGame_OnFrameBoundary
+    alias:
+    - CLoopModeGame::OnFrameBoundary
+  - name: CLoopModeGame_ReceivedServerInfo
+    alias:
+    - CLoopModeGame::ReceivedServerInfo
+  - name: CLoopModeGame_SetWorldSession
+    alias:
+    - CLoopModeGame::SetWorldSession
+  - name: CLoopModeGame_SetGameSystemState
+    alias:
+    - CLoopModeGame::SetGameSystemState
+  - name: IGameSystem_DestroyAllGameSystems
+    alias:
+    - IGameSystem::DestroyAllGameSystems
+  - name: IGameSystem_ShutdownAllSystems
+    alias:
+    - IGameSystem::ShutdownAllSystems
+  - name: IGameSystem_LoopDestroyAllSystems
+    alias:
+    - IGameSystem::LoopDestroyAllSystems
+  - name: IGameSystem_LoopPreShutdownAllSystems
+    alias:
+    - IGameSystem::LoopPreShutdownAllSystems
+  - name: CLoopModeGame_Shutdown
+    alias:
+    - CLoopModeGame::Shutdown
+  - name: CLoopModeGame_LoopShutdown
+    alias:
+    - CLoopModeGame::LoopShutdown
+  - name: CLoopModeGame_ShutdownServer
+    alias:
+    - CLoopModeGame::ShutdownServer
+  - name: CLoopModeGame_OnLoopDeactivate
+    alias:
+    - CLoopModeGame::OnLoopDeactivate
+  - name: ILoopMode_OnLoopDeactivate
+    alias:
+    - ILoopMode::OnLoopDeactivate
+  - name: CPlayerCommandQueue_ctor
+    alias:
+    - CPlayerCommandQueue::CPlayerCommandQueue
+  - name: IGameResourceService_SetEntityResourceManifestHandler
+    alias:
+    - IGameResourceService::SetEntityResourceManifestHandler
+  - name: CNetworkSerializerBindingBuildFilter_GetFieldPriority
+    alias:
+    - CNetworkSerializerBindingBuildFilter::GetFieldPriority
+  - name: CEntitySystem_FindComponentTypeByName
+    alias:
+    - CEntitySystem::FindComponentTypeByName
+- name: networksystem
+  symbols:
+  - name: INetworkMessages_GetFieldChangeCallbackOrderCount
+    alias:
+    - INetworkMessages::GetFieldChangeCallbackOrderCount
+  - name: INetworkMessages_GetFieldChangeCallbackPriorities
+    alias:
+    - INetworkMessages::GetFieldChangeCallbackPriorities

--- a/gamesymbols/14174.metadata.yaml
+++ b/gamesymbols/14174.metadata.yaml
@@ -1,0 +1,3734 @@
+modules:
+- name: scenesystem
+  symbols:
+  - name: ISceneSystem_GetWorldsInfo
+    alias:
+    - ISceneSystem::GetWorldsInfo
+  - name: ISceneWorld_GetObjectsInfo
+    alias:
+    - ISceneWorld::GetObjectsInfo
+  - name: ISceneWorld_GetWorldName
+    alias:
+    - ISceneWorld::GetWorldName
+  - name: ISceneSystem_GetObjectBounds
+    alias:
+    - ISceneSystem::GetObjectBounds
+  - name: ISceneSystem_GetObjectClassName
+    alias:
+    - ISceneSystem::GetObjectClassName
+  - name: CSceneObject_pDesc
+    alias:
+    - CSceneObject::pDesc
+  - name: CSceneObject_nFlags
+    alias:
+    - CSceneObject::nFlags
+  - name: CSceneObject_fOriginX
+    alias:
+    - CSceneObject::fOriginX
+  - name: CSceneObject_fOriginY
+    alias:
+    - CSceneObject::fOriginY
+  - name: CSceneObject_fOriginZ
+    alias:
+    - CSceneObject::fOriginZ
+  - name: CSceneObject_nClassIndex
+    alias:
+    - CSceneObject::nClassIndex
+- name: networksystem
+  symbols:
+  - name: CNetworkMessages_RegisterNetworkCategory
+    alias:
+    - CNetworkMessages::RegisterNetworkCategory
+  - name: CNetworkMessages_AssociateNetMessageWithChannelCategoryAbstract
+    alias:
+    - CNetworkMessages::AssociateNetMessageWithChannelCategoryAbstract
+  - name: CNetworkMessages_FindOrCreateNetMessage
+    alias:
+    - CNetworkMessages::FindOrCreateNetMessage
+  - name: CNetworkMessages_SerializeInternal
+    alias:
+    - CNetworkMessages::SerializeInternal
+  - name: CNetworkMessages_UnserializeMessageInternal
+    alias:
+    - CNetworkMessages::UnserializeMessageInternal
+  - name: CNetworkMessages_SerializeMessageInternal
+    alias:
+    - CNetworkMessages::SerializeMessageInternal
+  - name: CNetworkMessages_UnserializeFromStream
+    alias:
+    - CNetworkMessages::UnserializeFromStream
+  - name: CNetworkMessages_AllocateAndCopyConstructNetMessageAbstract
+    alias:
+    - CNetworkMessages::AllocateAndCopyConstructNetMessageAbstract
+  - name: CNetworkMessages_DeallocateNetMessageAbstract
+    alias:
+    - CNetworkMessages::DeallocateNetMessageAbstract
+  - name: CNetworkMessages_RegisterNetworkFieldSerializer
+    alias:
+    - CNetworkMessages::RegisterNetworkFieldSerializer
+  - name: CNetworkMessages_RegisterNetworkArrayFieldSerializer
+    alias:
+    - CNetworkMessages::RegisterNetworkArrayFieldSerializer
+  - name: CNetworkMessages_AssociateNetMessageGroupIdWithChannelCategory
+    alias:
+    - CNetworkMessages::AssociateNetMessageGroupIdWithChannelCategory
+  - name: CNetworkMessages_RegisterNetworkFieldChangeCallbackInternal
+    alias:
+    - CNetworkMessages::RegisterNetworkFieldChangeCallbackInternal
+  - name: CNetworkMessages_AllowAdditionalMessageRegistration
+    alias:
+    - CNetworkMessages::AllowAdditionalMessageRegistration
+  - name: CNetworkMessages_IsAdditionalMessageRegistrationAllowed
+    alias:
+    - CNetworkMessages::IsAdditionalMessageRegistrationAllowed
+  - name: CNetworkMessages_RegisterFieldChangeCallbackPriority
+    alias:
+    - CNetworkMessages::RegisterFieldChangeCallbackPriority
+  - name: CNetworkMessages_ComputeOrderForPriority
+    alias:
+    - CNetworkMessages::ComputeOrderForPriority
+  - name: CNetworkMessages_dtor
+    alias:
+    - CNetworkMessages::~CNetworkMessages
+  - name: CNetworkMessages_GetIsForServer
+    alias:
+    - CNetworkMessages::GetIsForServer
+  - name: CNetworkMessages_GetNetworkSerializationContextData
+    alias:
+    - CNetworkMessages::GetNetworkSerializationContextData
+  - name: CNetChan_ParseMessagesDemoInternal
+    alias:
+    - CNetChan::ParseMessagesDemoInternal
+  - name: CNetChan_ParseNetMessageShowFilter
+    alias:
+    - CNetChan::ParseNetMessageShowFilter
+  - name: CNetworkMessages_FindNetworkMessagePartial
+    alias:
+    - CNetworkMessages::FindNetworkMessagePartial
+  - name: CNetworkMessages_FindNetworkMessage
+    alias:
+    - CNetworkMessages::FindNetworkMessage
+  - name: CNetworkMessages_FindNetworkGroup
+    alias:
+    - CNetworkMessages::FindNetworkGroup
+  - name: CNetworkSystem_SendNetworkStats
+    alias:
+    - CNetworkSystem::SendNetworkStats
+  - name: CNetworkMessages_GetNetworkGroupCount
+    alias:
+    - CNetworkMessages::GetNetworkGroupCount
+  - name: CNetworkMessages_GetNetworkGroupName
+    alias:
+    - CNetworkMessages::GetNetworkGroupName
+  - name: CNetworkMessages_GetNetworkGroupColor
+    alias:
+    - CNetworkMessages::GetNetworkGroupColor
+  - name: CNetworkMessages_ConfirmAllMessageHandlersInstalled
+    alias:
+    - CNetworkMessages::ConfirmAllMessageHandlersInstalled
+- name: engine
+  symbols:
+  - name: CServerSideClient_ctor
+    alias:
+    - CServerSideClient::CServerSideClient
+  - name: CNetworkGameServer_CreateNewClient
+    alias:
+    - CNetworkGameServer::CreateNewClient
+  - name: CServerSideClient_IsHearingClient
+    alias:
+    - IsHearingClient
+  - name: CServerSideClient_ExecuteStringCommand
+    alias:
+    - CServerSideClient::ExecuteStringCommand
+  - name: CServerSideClient_ActivatePlayer
+    alias:
+    - CServerSideClient::ActivatePlayer
+  - name: ISource2GameClients_ClientSettingsChanged
+    alias:
+    - ISource2GameClients::ClientSettingsChanged
+  - name: CGameResourceService_BuildResourceManifest
+    alias:
+    - CGameResourceService::BuildResourceManifest
+    - BuildResourceManifest
+  - name: CGameResourceService_m_pEntitySystem
+    alias:
+    - GameEntitySystem
+  - name: CGameResourceService_LoadGameResourceManifestNamed
+    alias:
+    - CGameResourceService::LoadGameResourceManifestNamed
+  - name: CGameResourceService_LoadGameResourceManifestGroup
+    alias:
+    - CGameResourceService::LoadGameResourceManifestGroup
+  - name: CGameResourceService_GetResourceManifestDebugName
+    alias:
+    - CGameResourceService::GetResourceManifestDebugName
+  - name: CGameResourceService_PrecacheEntitiesAndConfirmResourcesAreLoaded
+    alias:
+    - CGameResourceService::PrecacheEntitiesAndConfirmResourcesAreLoaded
+  - name: CGameResourceService_LoadGameResourceManifest_IEntityResourceManifest
+    alias:
+    - CGameResourceService::LoadGameResourceManifest
+  - name: CGameResourceService_DescribeContents
+    alias:
+    - CGameResourceService::DescribeContents
+  - name: CGameResourceService_AppendToGameResourceManifest
+    alias:
+    - CGameResourceService::AppendToGameResourceManifest
+  - name: CGameResourceService_RegisterEventMap
+    alias:
+    - CGameResourceService::RegisterEventMap
+  - name: IEntityResourceManifestBuilder_BuildResourceManifest_ManifestNameOrGroupName
+    alias:
+    - IEntityResourceManifestBuilder::BuildResourceManifest
+  - name: CServerSideClientBase_ClientPrintf
+    alias:
+    - CServerSideClientBase::ClientPrintf
+    - ClientPrintf
+  - name: CNetworkGameServer_ClientList
+    alias:
+    - CNetworkGameServer::ClientList
+  - name: CNetworkGameServerBase_SendPeerList
+    alias:
+    - CNetworkGameServerBase::SendPeerList
+  - name: CNetworkGameServerBase_ConnectClient
+    alias:
+    - CNetworkGameServerBase::ConnectClient
+  - name: CNetworkGameServerBase_CheckPassword
+    alias:
+    - CNetworkGameServerBase::CheckPassword
+  - name: CNetworkGameServerBase_GetClientConnectionType
+    alias:
+    - CNetworkGameServerBase::GetClientConnectionType
+  - name: CNetworkGameServerBase_ServerSimulateInternal
+    alias:
+    - CNetworkGameServerBase::ServerSimulateInternal
+  - name: CNetworkGameServerBase_ServerSimulate
+    alias:
+    - CNetworkGameServerBase::ServerSimulate
+  - name: CNetworkGameServerBase_ServerPollNetworking
+    alias:
+    - CNetworkGameServerBase::ServerPollNetworking
+  - name: INetworkGameServer_IsChangelevelPending
+    alias:
+    - INetworkGameServer::IsChangelevelPending
+  - name: CNetworkGameServerBase_IsChangelevelPending
+    alias:
+    - CNetworkGameServerBase::IsChangelevelPending
+  - name: CNetworkGameServerBase_BroadcastMessage
+    alias:
+    - CNetworkGameServerBase::BroadcastMessage
+  - name: CNetworkGameServerBase_BroadcastPrintf
+    alias:
+    - CNetworkGameServerBase::BroadcastPrintf
+  - name: CNetworkGameServerBase_BroadcastEntityVoice
+    alias:
+    - CNetworkGameServerBase::BroadcastEntityVoice
+  - name: CNetworkGameServerBase_WriteDeltaEntities
+    alias:
+    - CNetworkGameServerBase::WriteDeltaEntities
+  - name: CNetworkGameServerBase_ReserveServerForQueuedGame
+    alias:
+    - CNetworkGameServerBase::ReserveServerForQueuedGame
+  - name: CNetworkGameServerBase_FinishChangeLevel
+    alias:
+    - CNetworkGameServerBase::FinishChangeLevel
+  - name: CNetworkGameServerBase_StartChangeLevel
+    alias:
+    - CNetworkGameServerBase::StartChangeLevel
+  - name: CNetworkGameServerBase_SetServerState
+    alias:
+    - CNetworkGameServerBase::SetServerState
+  - name: CNetworkGameServer_GetFreeClient
+    alias:
+    - CNetworkGameServer::GetFreeClient
+    - GetFreeClient
+  - name: CNetworkGameServerBase_CreateFakeClient
+    alias:
+    - CNetworkGameServerBase::CreateFakeClient
+  - name: CNetworkGameServerBase_UserInfoChanged
+    alias:
+    - CNetworkGameServerBase::UserInfoChanged
+  - name: CNetworkGameServerBase_GetPlayerNetworkIDString
+    alias:
+    - CNetworkGameServerBase::GetPlayerNetworkIDString
+  - name: CNetworkGameServerBase_StartHLTVMaster
+    alias:
+    - CNetworkGameServerBase::StartHLTVMaster
+  - name: CNetworkGameServerBase_RegisterLoadingSpawnGroups
+    alias:
+    - CNetworkGameServerBase::RegisterLoadingSpawnGroups
+  - name: CNetworkServerSpawnGroupCreatePrerequisites_Init
+    alias:
+    - CNetworkServerSpawnGroupCreatePrerequisites::Init
+  - name: CNetworkGameServerBase_LoadSpawnGroup
+    alias:
+    - CNetworkGameServerBase::LoadSpawnGroup
+  - name: CNetworkGameServerBase_SpawnGroupThink
+    alias:
+    - CNetworkGameServerBase::SpawnGroupThink
+  - name: CNetworkGameServerBase_PrintSpawnGroupStatus
+    alias:
+    - CNetworkGameServerBase::PrintSpawnGroupStatus
+  - name: CNetworkGameServerBase_AsyncUnloadSpawnGroup
+    alias:
+    - CNetworkGameServerBase::AsyncUnloadSpawnGroup
+  - name: CNetworkGameServerBase_AsyncUnloadSpawnGroupInternal
+    alias:
+    - CNetworkGameServerBase::AsyncUnloadSpawnGroupInternal
+  - name: CNetworkGameServer_PrepareForAssetLoad
+    alias:
+    - CNetworkGameServer::PrepareForAssetLoad
+  - name: CNetworkGameServerBase_IsSaveRestoreAllowed
+    alias:
+    - CNetworkGameServerBase::IsSaveRestoreAllowed
+  - name: CNetworkGameServer_IsPausable
+    alias:
+    - CNetworkGameServer::IsPausable
+  - name: CNetworkGameServerBase_Init
+    alias:
+    - CNetworkGameServerBase::Init
+  - name: CNetworkGameServerBase_Shutdown
+    alias:
+    - CNetworkGameServerBase::Shutdown
+  - name: CNetworkGameServerBase_ShutdownInternal
+    alias:
+    - CNetworkGameServerBase::ShutdownInternal
+  - name: CNetworkGameServer_ActivateServer
+    alias:
+    - CNetworkGameServer::ActivateServer
+  - name: CNetworkGameServer_DirectUpdate
+    alias:
+    - CNetworkGameServer::DirectUpdate
+  - name: CNetworkGameServerBase_ReplyChallenge
+    alias:
+    - CNetworkGameServerBase::ReplyChallenge
+  - name: CNetworkGameServerBase_GetChallengeType
+    alias:
+    - CNetworkGameServerBase::GetChallengeType
+  - name: CNetworkGameServer_Init
+    alias:
+    - CNetworkGameServer::Init
+  - name: CNetworkGameServer_Shutdown
+    alias:
+    - CNetworkGameServer::Shutdown
+  - name: ISource2Server_GetAllServerClasses
+    alias:
+    - ISource2Server::GetAllServerClasses
+  - name: CNetworkGameServer_SpawnServer
+    alias:
+    - CNetworkGameServer::SpawnServer
+  - name: CNetworkGameServerBase_GetMaxClients
+    alias:
+    - CNetworkGameServerBase::GetMaxClients
+  - name: CNetworkGameServerBase_GetClassBaseline
+    alias:
+    - CNetworkGameServerBase::GetClassBaseline
+  - name: CSteam3Server_SendUpdatedServerDetails
+    alias:
+    - CSteam3Server::SendUpdatedServerDetails
+  - name: CNetworkGameServerBase_GetMapName
+    alias:
+    - CNetworkGameServerBase::GetMapName
+  - name: CNetworkGameServerBase_GetHostName
+    alias:
+    - CNetworkGameServerBase::GetHostName
+  - name: CNetworkGameServerBase_SetMaxClients
+    alias:
+    - CNetworkGameServerBase::SetMaxClients
+  - name: CNetworkGameServerBase_FillKV3ServerInfo
+    alias:
+    - CNetworkGameServerBase::FillKV3ServerInfo
+  - name: CNetworkGameServerBase_CheckTimeouts
+    alias:
+    - CNetworkGameServerBase::CheckTimeouts
+  - name: CNetworkGameServerBase_IsHLTV
+    alias:
+    - CNetworkGameServerBase::IsHLTV
+  - name: ISource2Server_ShouldTimeoutClient
+    alias:
+    - ISource2Server::ShouldTimeoutClient
+  - name: CNetworkGameServerBase_GetPassword
+    alias:
+    - CNetworkGameServerBase::GetPassword
+  - name: CNetworkGameServerBase_OnKickById
+    alias:
+    - CNetworkGameServerBase::OnKickById
+  - name: CNetworkGameServerBase_OnKickByName
+    alias:
+    - CNetworkGameServerBase::OnKickByName
+  - name: CNetworkGameClient_SendMovePacket
+    alias:
+    - CNetworkGameClient::SendMovePacket
+    - SendMovePacket
+  - name: CNetworkGameClient_SendMove
+    alias:
+    - CNetworkGameClient::SendMove
+    - SendMove
+  - name: INetworkMessages_Serialize
+    alias:
+    - INetworkMessages::Serialize
+  - name: CDemoPlayer_SkipToTick
+    alias:
+    - CDemoPlayer::SkipToTick
+  - name: CDemoPlayer_PlayDemo
+    alias:
+    - CDemoPlayer::PlayDemo
+  - name: CDemoPlayer_StopPlayback
+    alias:
+    - CDemoPlayer::StopPlayback
+  - name: CDemoPlayer_StartPlayback
+    alias:
+    - CDemoPlayer::StartPlayback
+  - name: CDemoPlayer_SetIgnorePacketsForResourceLoading
+    alias:
+    - CDemoPlayer::SetIgnorePacketsForResourceLoading
+  - name: CDemoPlayer_InternalReadPacket
+    alias:
+    - CDemoPlayer::InternalReadPacket
+  - name: CDemoPlayer_Pause
+    alias:
+    - CDemoPlayer::Pause
+  - name: CDemoPlayer_m_bIsPlaying
+    alias:
+    - CDemoPlayer::m_bIsPlaying
+  - name: CDemoPlayer_m_bIsPaused
+    alias:
+    - CDemoPlayer::m_bIsPaused
+  - name: CDemoRecorder_ParseMessage
+    alias:
+    - CDemoRecorder::ParseMessage
+  - name: CDemoRecorder_WriteSpawnGroups
+    alias:
+    - CDemoRecorder::WriteSpawnGroups
+  - name: CHLTVDemoRecorder_WriteFrameImmediate
+    alias:
+    - CHLTVDemoRecorder::WriteFrameImmediate
+  - name: INetworkMessages_SerializeAbstract
+    alias:
+    - INetworkMessages::SerializeAbstract
+  - name: INetworkMessages_GetNetMessageInfo
+    alias:
+    - INetworkMessages::GetNetMessageInfo
+  - name: INetworkMessages_FindNetworkMessageById
+    alias:
+    - INetworkMessages::FindNetworkMessageById
+  - name: CNetChan_ProcessMessages
+    alias:
+    - CNetChan::ProcessMessages
+  - name: CNetChan_ParseMessagesDemo
+    alias:
+    - CNetChan::ParseMessagesDemo
+  - name: CNetworkGameClient_ProcessPacketEntitiesInternal
+    alias:
+    - CNetworkGameClient::ProcessPacketEntitiesInternal
+  - name: CNetworkGameClient_ProcessPacketEntities
+    alias:
+    - CNetworkGameClient::ProcessPacketEntities
+    - ProcessPacketEntities
+  - name: CNetworkGameClient_RecordEntityBandwidth
+    alias:
+    - CNetworkGameClient::RecordEntityBandwidth
+    - RecordEntityBandwidth
+  - name: CNetworkGameClient_PrintNetStats
+    alias:
+    - CNetworkGameClient::PrintNetStats
+  - name: CMsgSource2NetworkFlowQuality_PrintStats
+    alias:
+    - CMsgSource2NetworkFlowQuality::PrintStats
+  - name: CNetworkGameClient_CreateMove
+    alias:
+    - CNetworkGameClient::CreateMove
+  - name: ISource2Client_CreateMove
+    alias:
+    - ISource2Client::CreateMove
+  - name: CNetworkGameClient_SetSignonState
+    alias:
+    - CNetworkGameClient::SetSignonState
+  - name: CNetworkGameClient_ProcessReadPacketEntitiesWorkItems
+    alias:
+    - CNetworkGameClient::ProcessReadPacketEntitiesWorkItems
+  - name: CNetworkGameClient_OnPreserveEntity
+    alias:
+    - CNetworkGameClient::OnPreserveEntity
+  - name: CNetworkGameClient_GetClientNetworkable
+    alias:
+    - CNetworkGameClient::GetClientNetworkable
+  - name: CNetworkGameClient_CopyNewEntity
+    alias:
+    - CNetworkGameClient::CopyNewEntity
+  - name: CNetworkGameClient_CopyExistingEntity
+    alias:
+    - CNetworkGameClient::CopyExistingEntity
+  - name: CNetworkGameClient_OnReceivedUncompressedPacket
+    alias:
+    - CNetworkGameClient::OnReceivedUncompressedPacket
+  - name: CNetworkGameClient_Clear
+    alias:
+    - CNetworkGameClient::Clear
+  - name: CNetworkGameClient_DisconnectGame
+    alias:
+    - CNetworkGameClient::DisconnectGame
+  - name: INetworkMessages_FindNetworkGroup
+    alias:
+    - INetworkMessages::FindNetworkGroup
+  - name: INetworkClientService_IsActive
+    alias:
+    - INetworkClientService::IsActive
+  - name: INetworkClientService_IsConnected
+    alias:
+    - INetworkClientService::IsConnected
+  - name: INetworkClientService_IsPutInServer
+    alias:
+    - INetworkClientService::IsPutInServer
+  - name: INetworkClientService_IsConnecting
+    alias:
+    - INetworkClientService::IsConnecting
+  - name: CInputService_ProcessConVar
+    alias:
+    - CInputService::ProcessConVar
+  - name: CInputService_ProcessCommand
+    alias:
+    - CInputService::ProcessCommand
+  - name: CInputService_IsClientOnlyCommandAllowed
+    alias:
+    - CInputService::IsClientOnlyCommandAllowed
+  - name: CServerSideClientBase_SetConVarUserInfo
+    alias:
+    - CServerSideClientBase::SetConVarUserInfo
+  - name: CNetworkClientService_RegisterEventMapInternal
+    alias:
+    - CNetworkClientService::RegisterEventMapInternal
+  - name: CNetworkClientService_RegisterEventMap
+    alias:
+    - CNetworkClientService::RegisterEventMap
+  - name: CNetworkClientService_OnClientAdvanceTick
+    alias:
+    - CNetworkClientService::OnClientAdvanceTick
+  - name: CNetworkClientService_OnClientProcessGameInput
+    alias:
+    - CNetworkClientService::OnClientProcessGameInput
+  - name: ISource2Client_ProcessGameInput
+    alias:
+    - ISource2Client::ProcessGameInput
+  - name: CNetworkClientService_OnClientPollNetworking
+    alias:
+    - CNetworkClientService::OnClientPollNetworking
+  - name: CNetworkClientService_OnClientProcessNetworking
+    alias:
+    - CNetworkClientService::OnClientProcessNetworking
+  - name: CNetworkClientService_OnClientSimulate
+    alias:
+    - CNetworkClientService::OnClientSimulate
+  - name: CNetworkClientService_OnClientPauseSimulate
+    alias:
+    - CNetworkClientService::OnClientPauseSimulate
+  - name: CNetworkClientService_OnClientFrameSimulate
+    alias:
+    - CNetworkClientService::OnClientFrameSimulate
+  - name: CNetworkClientService_OnSimpleLoopFrameUpdate
+    alias:
+    - CNetworkClientService::OnSimpleLoopFrameUpdate
+  - name: CNetworkClientService_OnFrameBoundary
+    alias:
+    - CNetworkClientService::OnFrameBoundary
+  - name: CNetworkClientService_OnServerPostSimulate
+    alias:
+    - CNetworkClientService::OnServerPostSimulate
+  - name: CNetworkClientService_OnServerBeginAsyncPostTickWork
+    alias:
+    - CNetworkClientService::OnServerBeginAsyncPostTickWork
+  - name: CNetworkClientService_ReceivedServerInfo
+    alias:
+    - CNetworkClientService::ReceivedServerInfo
+  - name: CNetworkClientService_SplitScreenConnect
+    alias:
+    - CNetworkClientService::SplitScreenConnect
+  - name: CNetworkClientService_SendNetMessage
+    alias:
+    - CNetworkClientService::SendNetMessage
+  - name: CNetworkClientService_SendStringCmd
+    alias:
+    - CNetworkClientService::SendStringCmd
+  - name: CNetworkClientService_StartChangeLevel
+    alias:
+    - CNetworkClientService::StartChangeLevel
+  - name: CNetworkClientService_FinishChangeLevel
+    alias:
+    - CNetworkClientService::FinishChangeLevel
+  - name: CNetworkClientService_PrintConnectionStatus
+    alias:
+    - CNetworkClientService::PrintConnectionStatus
+  - name: CNetworkClientService_OnStatus
+    alias:
+    - CNetworkClientService::OnStatus
+  - name: CNetworkClientService_ServerCmd
+    alias:
+    - CNetworkClientService::ServerCmd
+  - name: CNetworkClientService_GetDisconnectReason
+    alias:
+    - CNetworkClientService::GetDisconnectReason
+  - name: CNetworkClientService_PrintSpawnGroupStatus
+    alias:
+    - CNetworkClientService::PrintSpawnGroupStatus
+  - name: CNetworkClientService_IsActive
+    alias:
+    - CNetworkClientService::IsActive
+  - name: CNetworkClientService_IsConnected
+    alias:
+    - CNetworkClientService::IsConnected
+  - name: CNetworkClientService_IsPutInServer
+    alias:
+    - CNetworkClientService::IsPutInServer
+  - name: CNetworkClientService_IsConnecting
+    alias:
+    - CNetworkClientService::IsConnecting
+  - name: CEngineSoundServices_ShouldSuppressNonUISounds
+    alias:
+    - CEngineSoundServices::ShouldSuppressNonUISounds
+  - name: CNetworkClientService_ClockDriftAdjustFrameTime
+    alias:
+    - CNetworkClientService::ClockDriftAdjustFrameTime
+  - name: CNetworkClientService_Init
+    alias:
+    - CNetworkClientService::Init
+  - name: CNetworkClientService_Shutdown
+    alias:
+    - CNetworkClientService::Shutdown
+  - name: CNetworkClientService_DisconnectGameNow
+    alias:
+    - CNetworkClientService::DisconnectGameNow
+  - name: CGameClientConnectPrerequisite_ctor
+    alias:
+    - CGameClientConnectPrerequisite::CGameClientConnectPrerequisite
+  - name: CNetworkClientSpawnGroupCreatePrerequisites_GetStatus
+    alias:
+    - CNetworkClientSpawnGroupCreatePrerequisites::GetStatus
+  - name: CWaitForInitialSpawnGroupsPrerequisite_GetStatus
+    alias:
+    - CWaitForInitialSpawnGroupsPrerequisite::GetStatus
+  - name: INetworkGameServer_GetSpawnGroupLoadingStatus
+    alias:
+    - INetworkGameServer::GetSpawnGroupLoadingStatus
+  - name: CNetworkClientService_AddClientPrerequisites
+    alias:
+    - CNetworkClientService::AddClientPrerequisites
+  - name: CNetworkClientService_AllocateRemoteConnectionClient
+    alias:
+    - CNetworkClientService::AllocateRemoteConnectionClient
+  - name: CNetworkServerService_Init
+    alias:
+    - CNetworkServerService::Init
+  - name: CNetworkServerService_StartupServer
+    alias:
+    - CNetworkServerService::StartupServer
+  - name: CNetworkServerService_RegisterEventMapInternal
+    alias:
+    - CNetworkServerService::RegisterEventMapInternal
+  - name: CNetworkServerService_OnServerAdvanceTick
+    alias:
+    - CNetworkServerService::OnServerAdvanceTick
+  - name: CNetworkServerService_OnServerPollNetworking
+    alias:
+    - CNetworkServerService::OnServerPollNetworking
+  - name: CNetworkServerService_OnServerProcessNetworking
+    alias:
+    - CNetworkServerService::OnServerProcessNetworking
+  - name: CNetworkServerService_OnServerBeginSimulate
+    alias:
+    - CNetworkServerService::OnServerBeginSimulate
+  - name: CNetworkServerService_OnServerEndSimulate
+    alias:
+    - CNetworkServerService::OnServerEndSimulate
+  - name: CNetworkServerService_OnServerPostSimulate
+    alias:
+    - CNetworkServerService::OnServerPostSimulate
+  - name: CNetworkServerService_OnServerPostAdvanceTick
+    alias:
+    - CNetworkServerService::OnServerPostAdvanceTick
+  - name: CNetworkServerService_OnFrameBoundary
+    alias:
+    - CNetworkServerService::OnFrameBoundary
+  - name: CNetworkServerService_OnClientPollNetworking
+    alias:
+    - CNetworkServerService::OnClientPollNetworking
+  - name: CNetworkServerService_OnSimpleLoopFrameUpdate
+    alias:
+    - CNetworkServerService::OnSimpleLoopFrameUpdate
+  - name: CNetworkServerService_OnKickByIdHLTV
+    alias:
+    - CNetworkServerService::OnKickByIdHLTV
+  - name: CNetworkServerService_DisconnectGameNow
+    alias:
+    - CNetworkServerService::DisconnectGameNow
+  - name: INetworkGameServer_GetMaxClients
+    alias:
+    - INetworkGameServer::GetMaxClients
+  - name: INetworkGameServer_PreWorldUpdate
+    alias:
+    - INetworkGameServer::PreWorldUpdate
+  - name: CNetworkGameServer_PreWorldUpdate
+    alias:
+    - CNetworkGameServer::PreWorldUpdate
+  - name: INetworkGameServer_ServerEndSimulate
+    alias:
+    - INetworkGameServer::ServerEndSimulate
+  - name: CNetworkGameServerBase_ServerEndSimulate
+    alias:
+    - CNetworkGameServerBase::ServerEndSimulate
+  - name: CNetworkGameServerBase_CalculateCPUUsage
+    alias:
+    - CNetworkGameServerBase::CalculateCPUUsage
+  - name: INetworkGameServer_ServerPostSimulate
+    alias:
+    - INetworkGameServer::ServerPostSimulate
+  - name: CNetworkGameServerBase_ServerPostSimulate
+    alias:
+    - CNetworkGameServerBase::ServerPostSimulate
+  - name: CNetworkGameServer_ServerPostSimulate
+    alias:
+    - CNetworkGameServer::ServerPostSimulate
+  - name: INetworkGameServer_ServerAdvanceTick
+    alias:
+    - INetworkGameServer::ServerAdvanceTick
+  - name: CNetworkGameServerBase_ServerAdvanceTick
+    alias:
+    - CNetworkGameServerBase::ServerAdvanceTick
+  - name: INetworkGameServer_GetTime
+    alias:
+    - INetworkGameServer::GetTime
+  - name: INetworkGameServer_ServerProcessNetworking
+    alias:
+    - INetworkGameServer::ServerProcessNetworking
+  - name: CNetworkGameServerBase_ServerProcessNetworking
+    alias:
+    - CNetworkGameServerBase::ServerProcessNetworking
+  - name: INetworkGameServer_GetTimescale
+    alias:
+    - INetworkGameServer::GetTimescale
+  - name: CNetworkGameServerBase_GetTimescale
+    alias:
+    - CNetworkGameServerBase::GetTimescale
+  - name: INetworkGameServer_GetServerNetworkAddress
+    alias:
+    - INetworkGameServer::GetServerNetworkAddress
+  - name: ISource2Server_PreWorldUpdate
+    alias:
+    - ISource2Server::PreWorldUpdate
+  - name: ISource2Server_UpdateWhenNotInGame
+    alias:
+    - ISource2Server::UpdateWhenNotInGame
+  - name: INetworkMessages_SetIsForServer
+    alias:
+    - INetworkMessages::SetIsForServer
+  - name: CRenderingWorldSession_FindOrCreateWorldSession
+    alias:
+    - CRenderingWorldSession::FindOrCreateWorldSession
+  - name: CRenderingWorldSession_GetEntityLumpForTemplate
+    alias:
+    - CRenderingWorldSession::GetEntityLumpForTemplate
+  - name: CEngineClient_GetEntityLumpForTemplate
+    alias:
+    - CEngineClient::GetEntityLumpForTemplate
+  - name: CEngineClient_FindOrCreateWorldSession
+    alias:
+    - CEngineClient::FindOrCreateWorldSession
+  - name: CEngineClient_GetStatsAppID
+    alias:
+    - CEngineClient::GetStatsAppID
+  - name: CEngineClient_DumpNetStats
+    alias:
+    - CEngineClient::DumpNetStats
+  - name: CEngineClient_ExecuteClientCmd
+    alias:
+    - CEngineClient::ExecuteClientCmd
+  - name: CEngineClient_IsPlayingDemo
+    alias:
+    - CEngineClient::IsPlayingDemo
+  - name: CInputService_ProcessCommandBuffer
+    alias:
+    - CInputService::ProcessCommandBuffer
+  - name: CInputService_ProcessCommandBuffers
+    alias:
+    - CInputService::ProcessCommandBuffers
+  - name: CInputService_HandleAnalogValueChange
+    alias:
+    - CInputService::HandleAnalogValueChange
+  - name: CInputService_HandleInputEvent
+    alias:
+    - CInputService::HandleInputEvent
+  - name: CEngineClient_ClientCmd_Unrestricted
+    alias:
+    - CEngineClient::ClientCmd_Unrestricted
+  - name: INetworkGameClient_SendStringCmd
+    alias:
+    - INetworkGameClient::SendStringCmd
+  - name: CEngineServer_DumpNetStats
+    alias:
+    - CEngineServer::DumpNetStats
+  - name: CEngineServer_ClientPrintf
+    alias:
+    - CEngineServer::ClientPrintf
+  - name: CEngineServer_GetFrameTimeAmnesty
+    alias:
+    - CEngineServer::GetFrameTimeAmnesty
+  - name: CEngineServer_ShowFrameTimeReport
+    alias:
+    - CEngineServer::ShowFrameTimeReport
+  - name: CEngineServer_SetFrameTimeAmnesty
+    alias:
+    - CEngineServer::SetFrameTimeAmnesty
+  - name: CEngineServer_GetSteamUniverse
+    alias:
+    - CEngineServer::GetSteamUniverse
+  - name: CEngineServer_ChangeLevel
+    alias:
+    - CEngineServer::ChangeLevel
+  - name: CMapListService_IsMapValid
+    alias:
+    - CMapListService::IsMapValid
+    - IMapListService::IsMapValid
+  - name: CEngineServer_IsMapValid
+    alias:
+    - CEngineServer::IsMapValid
+  - name: CEngineServer_PrecacheGeneric
+    alias:
+    - CEngineServer::PrecacheGeneric
+  - name: CEngineServer_ClientCommand
+    alias:
+    - CEngineServer::ClientCommand
+  - name: CEngineServer_GetClientConVarValue
+    alias:
+    - CEngineServer::GetClientConVarValue
+  - name: CEngineServer_SetFakeClientConVarValue
+    alias:
+    - CEngineServer::SetFakeClientConVarValue
+  - name: CEngineServer_CreateFakeClient
+    alias:
+    - CEngineServer::CreateFakeClient
+  - name: CEngineServer_GetPlayerInfo
+    alias:
+    - CEngineServer::GetPlayerInfo
+  - name: CEngineServer_ClientCommandKeyValues
+    alias:
+    - CEngineServer::ClientCommandKeyValues
+  - name: CLog_Print
+    alias:
+    - CLog::Print
+  - name: CEngineServer_LogPrint
+    alias:
+    - CEngineServer::LogPrint
+  - name: CEngineServer_KickClient
+    alias:
+    - CEngineServer::KickClient
+  - name: CEngineServer_IsDedicatedServer
+    alias:
+    - CEngineServer::IsDedicatedServer
+  - name: CEngineServer_GetServerGlobals
+    alias:
+    - CEngineServer::GetServerGlobals
+  - name: CEngineServer_GetAchievementMgr
+    alias:
+    - CEngineServer::GetAchievementMgr
+  - name: CEngineServer_IsLogEnabled
+    alias:
+    - CEngineServer::IsLogEnabled
+  - name: CEngineServer_ServerCommand
+    alias:
+    - CEngineServer::ServerCommand
+  - name: CLoopTypeClientSimple_ActivateEngineServices
+    alias:
+    - CLoopTypeClientServer::ActivateEngineServices
+  - name: CLoopTypeClientServer_LoopTypeInit
+    alias:
+    - CLoopTypeClientServer::LoopTypeInit
+  - name: CLoopTypeClientServer_AdvanceTime
+    alias:
+    - CLoopTypeClientServer::AdvanceTime
+  - name: CLoopTypeClientServer_Update
+    alias:
+    - CLoopTypeClientServer::Update
+  - name: CLoopTypeClientServer_ActivateLoop
+    alias:
+    - CLoopTypeClientServer::ActivateLoop
+  - name: ISource2Server_GetActiveWorldName
+    alias:
+    - ISource2Server::GetActiveWorldName
+  - name: CLoopTypeClientServer_AllocateLoopMode
+    alias:
+    - CLoopTypeClientServer::AllocateLoopMode
+  - name: CLoopTypeClientServer_WritePerfStats
+    alias:
+    - CLoopTypeClientServer::WritePerfStats
+  - name: CLoopTypeClientServer_DeactivateLoop
+    alias:
+    - CLoopTypeClientServer::DeactivateLoop
+  - name: CLoopTypeClientServer_OutputListeners
+    alias:
+    - CLoopTypeClientServer::OutputListeners
+  - name: CLoopTypeSimple_FrameUpdate
+    alias:
+    - CLoopTypeSimple::FrameUpdate
+  - name: CLoopTypeClientServerService_OnLoopActivate
+    alias:
+    - CLoopTypeClientServerService::OnLoopActivate
+  - name: CLoopTypeSimpleService_OnLoopActivate
+    alias:
+    - CLoopTypeSimpleService::OnLoopActivate
+  - name: CLoopTypeClientServerService_HandleInputEvent
+    alias:
+    - CLoopTypeClientServerService::HandleInputEvent
+  - name: ILoopMode_HandleInputEvent
+    alias:
+    - ILoopMode::HandleInputEvent
+  - name: ILoopType_AddEngineService
+    alias:
+    - ILoopType::AddEngineService
+  - name: CLoopTypeBase_DeallocateLoopMode
+    alias:
+    - CLoopTypeBase::DeallocateLoopMode
+  - name: CLoopTypeBase_EngineLoop
+    alias:
+    - CLoopTypeBase::EngineLoop
+  - name: CLoopTypeBase_FrameUpdate
+    alias:
+    - CLoopTypeBase::FrameUpdate
+  - name: CLoopTypeBase_ActivateLoop
+    alias:
+    - CLoopTypeBase::ActivateLoop
+  - name: CLoopTypeBase_AllocateLoopMode
+    alias:
+    - CLoopTypeBase::AllocateLoopMode
+  - name: CLoopTypeBase_DeactivateLoop
+    alias:
+    - CLoopTypeBase::DeactivateLoop
+  - name: CLoopTypeBase_LoopTypeInit
+    alias:
+    - CLoopTypeBase::LoopTypeInit
+  - name: CLoopTypeBase_LoopTypeShutdown
+    alias:
+    - CLoopTypeBase::LoopTypeShutdown
+  - name: CLoopTypeBase_GetClientServerMode
+    alias:
+    - CLoopTypeBase::GetClientServerMode
+  - name: CLoopTypeBase_GetImplType
+    alias:
+    - CLoopTypeBase::GetImplType
+  - name: CLoopTypeBase_AddDependentServices
+    alias:
+    - CLoopTypeBase::AddDependentServices
+  - name: CLoopTypeBase_GenerateServiceDependencies
+    alias:
+    - CLoopTypeBase::GenerateServiceDependencies
+  - name: CLoopTypeBase_GenerateSecondaryDependencies
+    alias:
+    - CLoopTypeBase::GenerateSecondaryDependencies
+  - name: CLoopTypeBase_LoadDependentServices
+    alias:
+    - CLoopTypeBase::LoadDependentServices
+  - name: IEngineService_GetServiceDependencies
+    alias:
+    - IEngineService::GetServiceDependencies
+  - name: IEngineService_GetName
+    alias:
+    - IEngineService::GetName
+  - name: ILoopModeFactory_GetLoopModeType
+    alias:
+    - ILoopModeFactory::GetLoopModeType
+  - name: ILoopModeFactory_Shutdown
+    alias:
+    - ILoopModeFactory::Shutdown
+  - name: CEngineServiceMgr_RegisterEngineService
+    alias:
+    - CEngineServiceMgr::RegisterEngineService
+  - name: CEngineServiceMgr_RegisterLoopMode
+    alias:
+    - CEngineServiceMgr::RegisterLoopMode
+  - name: CEngineServiceMgr_UnregisterLoopMode
+    alias:
+    - CEngineServiceMgr::UnregisterLoopMode
+  - name: CEngineServiceMgr_UnregisterEngineService
+    alias:
+    - CEngineServiceMgr::UnregisterEngineService
+  - name: CEngineServiceMgr_SwitchToLoop
+    alias:
+    - CEngineServiceMgr::SwitchToLoop
+  - name: CEngineServiceMgr_PrintStatus
+    alias:
+    - CEngineServiceMgr::PrintStatus
+  - name: CEngineServiceMgr__MainLoop
+    alias:
+    - CEngineServiceMgr::_MainLoop
+  - name: CEngineServiceMgr_DeactivateLoop
+    alias:
+    - CEngineServiceMgr::DeactivateLoop
+  - name: CEngineServiceMgr_Shutdown
+    alias:
+    - CEngineServiceMgr::Shutdown
+  - name: CEngineServiceMgr_GetActiveLoopClientServerMode
+    alias:
+    - CEngineServiceMgr::GetActiveLoopClientServerMode
+  - name: CEngineServiceMgr_GetEventDispatcher
+    alias:
+    - CEngineServiceMgr::GetEventDispatcher
+  - name: CEngineGameUI_Shutdown
+    alias:
+    - CEngineGameUI::Shutdown
+  - name: IAppSystem_Shutdown
+    alias:
+    - IAppSystem::Shutdown
+  - name: CSplitScreenService_AddSplitScreenUser
+    alias:
+    - CSplitScreenService::AddSplitScreenUser
+  - name: CSplitScreenService_LoadUserConfiguration
+    alias:
+    - CSplitScreenService::LoadUserConfiguration
+  - name: CHLTVClient_ProcessSetConVar
+    alias:
+    - CHLTVClient::ProcessSetConVar
+  - name: CHLTVBroadcast_RecordSnapshot
+    alias:
+    - CHLTVBroadcast::RecordSnapshot
+  - name: CServerSideClientBase_SendServerInfo
+    alias:
+    - CServerSideClientBase::SendServerInfo
+  - name: CNetworkGameServerBase_FillServerInfo
+    alias:
+    - CNetworkGameServerBase::FillServerInfo
+  - name: CServerSideClientBase_ProcessTick
+    alias:
+    - CServerSideClientBase::ProcessTick
+  - name: CServerSideClientBase_ProcessStringCmd
+    alias:
+    - CServerSideClientBase::ProcessStringCmd
+  - name: CServerSideClientBase_MarkSpawnGroupLoadCompleted
+    alias:
+    - CServerSideClientBase::MarkSpawnGroupLoadCompleted
+  - name: CServerSideClientBase_ProcessSpawnGroup_LoadCompleted
+    alias:
+    - CServerSideClientBase::ProcessSpawnGroup_LoadCompleted
+  - name: CServerSideClientBase_ProcessClientInfo
+    alias:
+    - CServerSideClientBase::ProcessClientInfo
+  - name: CServerSideClientBase_ProcessBaselineAck
+    alias:
+    - CServerSideClientBase::ProcessBaselineAck
+  - name: CServerSideClientBase_ProcessSplitPlayerConnectInternal
+    alias:
+    - CServerSideClientBase::ProcessSplitPlayerConnectInternal
+  - name: CServerSideClientBase_ProcessSplitPlayerConnect
+    alias:
+    - CServerSideClientBase::ProcessSplitPlayerConnect
+  - name: CServerSideClientBase_GetUserIDString
+    alias:
+    - CServerSideClientBase::GetUserIDString
+  - name: CServerSideClientBase_GetNetworkIDString
+    alias:
+    - CServerSideClientBase::GetNetworkIDString
+  - name: CServerSideClientBase_dtor
+    alias:
+    - CServerSideClientBase::~CServerSideClientBase
+  - name: CServerSideClientBase_Connect
+    alias:
+    - CServerSideClientBase::Connect
+  - name: CServerSideClientBase_GetPlayerInfo
+    alias:
+    - CServerSideClientBase::GetPlayerInfo
+  - name: CNetworkGameServer_GetPlayerNetworkIDString
+    alias:
+    - CNetworkGameServer::GetPlayerNetworkIDString
+  - name: CNetworkGameServer_RemoveClientFromGame
+    alias:
+    - CNetworkGameServer::RemoveClientFromGame
+  - name: CEngineServer_GetPlayerNetworkIDString
+    alias:
+    - CEngineServer::GetPlayerNetworkIDString
+  - name: CNetworkGameClientBase_ServerCmd
+    alias:
+    - CNetworkGameClientBase::ServerCmd
+  - name: CNetworkGameClientBase_ProcessSetConVar
+    alias:
+    - CNetworkGameClientBase::ProcessSetConVar
+  - name: CNetworkGameClientBase_SendStringCmd
+    alias:
+    - CNetworkGameClientBase::SendStringCmd
+  - name: CNetworkGameClientBase_StartChangeLevel
+    alias:
+    - CNetworkGameClientBase::StartChangeLevel
+  - name: CNetworkGameClientBase_FinishChangeLevel
+    alias:
+    - CNetworkGameClientBase::FinishChangeLevel
+  - name: CNetworkGameClientBase_DeferActivate
+    alias:
+    - CNetworkGameClientBase::DeferActivate
+  - name: CNetworkGameClientBase_ClockDrift_AdjustFrameTime
+    alias:
+    - CNetworkGameClientBase::ClockDrift_AdjustFrameTime
+  - name: CNetworkGameClientBase_Connect
+    alias:
+    - CNetworkGameClientBase::Connect
+  - name: CNetworkGameClientBase_DisconnectGame
+    alias:
+    - CNetworkGameClientBase::DisconnectGame
+  - name: CNetSupportImpl_Connect
+    alias:
+    - CNetSupportImpl::Connect
+- name: client
+  symbols:
+  - name: CLoopModeGame_RegisterEventMapInternal
+    alias:
+    - CLoopModeGame::RegisterEventMapInternal
+  - name: CLoopModeGame_OnClientPollNetworking
+    alias:
+    - CLoopModeGame::OnClientPollNetworking
+  - name: CLoopModeGame_OnClientAdvanceTick
+    alias:
+    - CLoopModeGame::OnClientAdvanceTick
+  - name: CLoopModeGame_OnClientPostAdvanceTick
+    alias:
+    - CLoopModeGame::OnClientPostAdvanceTick
+  - name: CLoopModeGame_OnClientPreSimulate
+    alias:
+    - CLoopModeGame::OnClientPreSimulate
+  - name: CLoopModeGame_OnClientPreOutput
+    alias:
+    - CLoopModeGame::OnClientPreOutput
+  - name: CLoopModeGame_OnClientPreOutputParallelWithServer
+    alias:
+    - CLoopModeGame::OnClientPreOutputParallelWithServer
+  - name: CLoopModeGame_OnClientPostOutput
+    alias:
+    - CLoopModeGame::OnClientPostOutput
+  - name: CLoopModeGame_OnClientFrameSimulate
+    alias:
+    - CLoopModeGame::OnClientFrameSimulate
+  - name: CLoopModeGame_OnClientAdvanceNonRenderedFrame
+    alias:
+    - CLoopModeGame::OnClientAdvanceNonRenderedFrame
+  - name: CLoopModeGame_OnClientPostSimulate
+    alias:
+    - CLoopModeGame::OnClientPostSimulate
+  - name: CLoopModeGame_OnClientPauseSimulate
+    alias:
+    - CLoopModeGame::OnClientPauseSimulate
+  - name: CLoopModeGame_OnClientSimulate
+    alias:
+    - CLoopModeGame::OnClientSimulate
+  - name: CLoopModeGame_OnPostDataUpdate
+    alias:
+    - CLoopModeGame::OnPostDataUpdate
+  - name: CLoopModeGame_OnPreDataUpdate
+    alias:
+    - CLoopModeGame::OnPreDataUpdate
+  - name: CLoopModeGame_OnFrameBoundary
+    alias:
+    - CLoopModeGame::OnFrameBoundary
+  - name: CLoopModeGame_StaticInit
+    alias:
+    - CLoopModeGame::StaticInit
+  - name: CLoopModeFactory_CLoopModeGame_Init
+    alias:
+    - CLoopModeFactory<CLoopModeGame>::Init
+  - name: CLoopModeFactory_CLoopModeGame_Shutdown
+    alias:
+    - CLoopModeFactory<CLoopModeGame>::Shutdown
+  - name: CLoopModeGame_OnLoopActivate
+    alias:
+    - CLoopModeGame::OnLoopActivate
+  - name: ILoopMode_OnLoopActivate
+    alias:
+    - ILoopMode::OnLoopActivate
+  - name: CLoopModeGame_AddViewsToSceneSystem
+    alias:
+    - CLoopModeGame::AddViewsToSceneSystem
+  - name: ILoopMode_AddViewsToSceneSystem
+    alias:
+    - ILoopMode::AddViewsToSceneSystem
+  - name: CLoopModeGame_LoopInitInternal
+    alias:
+    - CLoopModeGame::LoopInitInternal
+  - name: CLoopModeGame_LoopInit
+    alias:
+    - CLoopModeGame::LoopInit
+  - name: ILoopMode_LoopInit
+    alias:
+    - ILoopMode::LoopInit
+  - name: ILoopMode_LoopShutdown
+    alias:
+    - ILoopMode::LoopShutdown
+  - name: CLoopModeGame_ReceivedServerInfo
+    alias:
+    - CLoopModeGame::ReceivedServerInfo
+  - name: CLoopModeGame_RegisterEventMap
+    alias:
+    - CLoopModeGame::RegisterEventMap
+  - name: ILoopMode_RegisterEventMap
+    alias:
+    - ILoopMode::RegisterEventMap
+  - name: CLoopModeGame_SetWorldSession
+    alias:
+    - CLoopModeGame::SetWorldSession
+  - name: CLoopModeGame_SetGameSystemState
+    alias:
+    - CLoopModeGame::SetGameSystemState
+  - name: CLoopModeGame_LoopShutdown
+    alias:
+    - CLoopModeGame::LoopShutdown
+  - name: IGameSystem_AddByName
+    alias:
+    - IGameSystem::AddByName
+  - name: IGameSystem_Add
+    alias:
+    - IGameSystem::Add
+  - name: IGameSystem_PostInit
+    alias:
+    - IGameSystem::PostInit
+  - name: IGameSystem_InitAllSystems
+    alias:
+    - IGameSystem::InitAllSystems
+  - name: IGameSystem_LoopInitAllSystems
+    alias:
+    - IGameSystem::LoopInitAllSystems
+  - name: IGameSystemFactory_PostInit
+    alias:
+    - IGameSystemFactory::PostInit
+  - name: IGameSystemFactory_GetStaticGameSystem
+    alias:
+    - IGameSystemFactory::GetStaticGameSystem
+  - name: IGameSystemFactory_ShouldAutoAdd
+    alias:
+    - IGameSystemFactory::ShouldAutoAdd
+  - name: IGameSystemFactory_CreateGameSystem
+    alias:
+    - IGameSystemFactory::CreateGameSystem
+  - name: IGameSystemFactory_IsReallocating
+    alias:
+    - IGameSystemFactory::IsReallocating
+  - name: IGameSystem_SetName
+    alias:
+    - IGameSystem::SetName
+  - name: CSpawnGroupMgrGameSystem_DoesGameSystemReallocate
+    alias:
+    - IGameSystem::DoesGameSystemReallocate
+  - name: IGameSystem_DestroyAllGameSystems
+    alias:
+    - IGameSystem::DestroyAllGameSystems
+  - name: IGameSystem_ShutdownAllSystems
+    alias:
+    - IGameSystem::ShutdownAllSystems
+  - name: IGameSystem_LoopDestroyAllSystems
+    alias:
+    - IGameSystem::LoopDestroyAllSystems
+  - name: IGameSystem_LoopPreShutdownAllSystems
+    alias:
+    - IGameSystem::LoopPreShutdownAllSystems
+  - name: IGameSystem_OnClientPollNetworking
+    alias:
+    - IGameSystem::OnClientPollNetworking
+  - name: IGameSystem_OnClientGamePostSimulate
+    alias:
+    - IGameSystem::ClientGamePostSimulate
+  - name: IGameSystem_OnClientPauseSimulate
+    alias:
+    - IGameSystem::OnClientPauseSimulate
+  - name: IGameSystem_OnClientPreUpdate
+    alias:
+    - IGameSystem::OnClientPreUpdate
+  - name: IGameSystem_OnClientPostUpdate
+    alias:
+    - IGameSystem::OnClientPostUpdate
+  - name: IGameSystem_OnClientPostDataUpdate
+    alias:
+    - IGameSystem::OnClientPostDataUpdate
+  - name: IGameSystem_OnGameFrameBoundary
+    alias:
+    - IGameSystem::OnGameFrameBoundary
+  - name: IGameSystem_OnClientAdvanceNonRenderedFrame
+    alias:
+    - IGameSystem::OnClientAdvanceNonRenderedFrame
+  - name: IGameSystem_OnClientFrameSimulate
+    alias:
+    - IGameSystem::OnClientFrameSimulate
+  - name: IGameSystem_OnClientAdvanceTick
+    alias:
+    - IGameSystem::ClientAdvanceTick
+  - name: IGameSystem_OnClientPostAdvanceTick
+    alias:
+    - IGameSystem::ClientPostAdvanceTick
+  - name: IGameSystem_OnClientPostRender
+    alias:
+    - IGameSystem::OnClientPostRender
+  - name: IGameSystem_OnClientPreRender
+    alias:
+    - IGameSystem::OnClientPreRender
+  - name: IGameSystem_OnClientPreRenderAlt
+    alias:
+    - IGameSystem::OnClientPreRenderAlt
+  - name: CSource2Client_CreateMove
+    alias:
+    - CSource2Client::CreateMove
+  - name: CClientInput_CreateMove
+    alias:
+    - CClientInput::CreateMove
+  - name: CClientInput_m_viewangles
+    alias:
+    - CClientInput::m_viewangles
+  - name: CSource2Client_ProcessGameInput
+    alias:
+    - CSource2Client::ProcessGameInput
+  - name: ISource2Client_FrameStageNotify
+    alias:
+    - ISource2Client::FrameStageNotify
+  - name: CSource2Client_FrameStageNotify
+    alias:
+    - CSource2Client::FrameStageNotify
+  - name: IViewRender_OnRenderStart
+    alias:
+    - IViewRender::OnRenderStart
+  - name: CViewRender_OnRenderStart
+    alias:
+    - CViewRender::OnRenderStart
+  - name: CViewRender_Render
+    alias:
+    - CViewRender::Render
+  - name: C_BaseEntity_SetInterpolationPhase
+    alias:
+    - C_BaseEntity::SetInterpolationPhase
+  - name: CSource2Client_SetGlobals
+    alias:
+    - CSource2Client::SetGlobals
+  - name: CSource2Client_Connect
+    alias:
+    - CSource2Client::Connect
+  - name: CBasePlayerController_CheckForLocalPlayer
+    alias:
+    - CBasePlayerController::CheckForLocalPlayer
+  - name: CSource2Client_OnDisconnect
+    alias:
+    - CSource2Client::OnDisconnect
+  - name: IGameSystem_OnClientDisconnect
+    alias:
+    - IGameSystem::OnClientDisconnect
+  - name: IGameSystem_OnClientPreEntityThink
+    alias:
+    - IGameSystem::OnClientPreEntityThink
+  - name: CNetworkGameClient_OnSource1Source1LegacyGameEvent
+    alias:
+    - CNetworkGameClient::OnSource1Source1LegacyGameEvent
+  - name: CMapAnNodeManager_FireGameEvent
+    alias:
+    - CMapAnNodeManager::FireGameEvent
+  - name: C_ServerVoiceHandler_OnServerVoiceData
+    alias:
+    - C_ServerVoiceHandler::OnServerVoiceData
+  - name: IVEngineClient2_IsPlayingDemo
+    alias:
+    - IVEngineClient2::IsPlayingDemo
+  - name: IVEngineClient2_ExecuteClientCmd
+    alias:
+    - IVEngineClient2::ExecuteClientCmd
+  - name: IGameEventManager2_UnserializeEvent
+    alias:
+    - IGameEventManager2::UnserializeEvent
+  - name: IGameEventManager2_FireEventClientSide
+    alias:
+    - IGameEventManager2::FireEventClientSide
+  - name: CGameEventManager_FireEventClientSide
+    alias:
+    - CGameEventManager::FireEventClientSide
+  - name: CGameEventManager_UnserializeEvent
+    alias:
+    - CGameEventManager::UnserializeEvent
+  - name: CSteamworksGameStats_OnReceivedSessionID
+    alias:
+    - CSteamworksGameStats::OnReceivedSessionID
+  - name: IGameSystem_GetName
+    alias:
+    - IGameSystem::GetName
+  - name: IGameSystemFactory_DestroyGameSystem
+    alias:
+    - IGameSystemFactory::DestroyGameSystem
+  - name: IGameSystemFactory_Init
+    alias:
+    - IGameSystemFactory::Init
+  - name: IGameSystemFactory_GetPriority
+    alias:
+    - IGameSystemFactory::GetPriority
+  - name: IGameSystemFactory_Shutdown
+    alias:
+    - IGameSystemFactory::Shutdown
+  - name: IGameSystemFactory_SetGlobalPtr
+    alias:
+    - IGameSystemFactory::SetGlobalPtr
+  - name: CPrediction_PostNetworkDataReceived
+    alias:
+    - CPrediction::PostNetworkDataReceived
+  - name: IEngineServiceMgr_GetActiveLoopClientServerMode
+    alias:
+    - IEngineServiceMgr::GetActiveLoopClientServerMode
+  - name: IEngineServiceMgr_GetEventDispatcher
+    alias:
+    - IEngineServiceMgr::GetEventDispatcher
+  - name: ClientModeCSNormal_Update
+    alias:
+    - ClientModeCSNormal::Update
+  - name: CEntitySystem_ctor
+    alias:
+    - CEntitySystem::CEntitySystem
+  - name: CGameEntitySystem_ctor
+    alias:
+    - CGameEntitySystem::CGameEntitySystem
+  - name: CEntitySystem_Init
+    alias:
+    - CEntitySystem::Init
+  - name: CEntitySystem_PostCreateEntitySystem
+    alias:
+    - CEntitySystem::PostCreateEntitySystem
+  - name: CSource2EntitySystem_StaticInit
+    alias:
+    - CSource2EntitySystem::StaticInit
+  - name: CGameSystemReallocatingFactory_CSource2EntitySystem_Init
+    alias:
+    - CGameSystemReallocatingFactory<CSource2EntitySystem>::Init
+  - name: CGameSystemReallocatingFactory_CSource2EntitySystem_CreateGameSystem
+    alias:
+    - CGameSystemReallocatingFactory<CSource2EntitySystem>::CreateGameSystem
+  - name: CSkeletonInstance_PostDataUpdate
+    alias:
+    - CSkeletonInstance::PostDataUpdate
+  - name: CSkeletonInstance_m_modelState_m_simulationState
+    alias:
+    - CSkeletonInstance::m_modelState.m_simulationState
+  - name: CSkeletonInstance_m_modelState_m_hModel
+    alias:
+    - CSkeletonInstance::m_modelState.m_hModel
+  - name: CSimulationState_SetupJointState
+    alias:
+    - CSimulationState::SetupJointState
+  - name: CSimulationState_m_nTotalTransformCount
+    alias:
+    - CSimulationState::m_nTotalTransformCount
+  - name: CSimulationState_m_nBoneCount
+    alias:
+    - CSimulationState::m_nBoneCount
+  - name: CSimulationState_m_nAttachmentCount
+    alias:
+    - CSimulationState::m_nAttachmentCount
+  - name: IVEngineClient2_GetNetworkClient
+    alias:
+    - IVEngineClient2::GetNetworkClient
+  - name: INetworkClient_GetLocalAddress
+    alias:
+    - INetworkClient::GetLocalAddress
+  - name: INetworkClientService_IsConnected
+    alias:
+    - INetworkClientService::IsConnected
+  - name: INetworkClientService_SendNetMessage
+    alias:
+    - INetworkClientService::SendNetMessage
+  - name: C_GameRules_ctor
+    alias:
+    - C_GameRules::C_GameRules
+  - name: IGameResourceService_SetEntityResourceManifestHandler
+    alias:
+    - IGameResourceService::SetEntityResourceManifestHandler
+  - name: CNetworkSerializerBindingBuildFilter_GetFieldPriority
+    alias:
+    - CNetworkSerializerBindingBuildFilter::GetFieldPriority
+  - name: GameStateAPI_RegisterAPIs
+    alias:
+    - GameStateAPI::RegisterAPIs
+  - name: GameStateAPI_IsLatched
+    alias:
+    - GameStateAPI::IsLatched
+  - name: GameStateAPI_GetPlayerSlot
+    alias:
+    - GameStateAPI::GetPlayerSlot
+  - name: GameStateAPI_GetPlayerName
+    alias:
+    - GameStateAPI::GetPlayerName
+  - name: GameStateAPI_GetPlayerXuidStringFromPlayerSlot
+    alias:
+    - GameStateAPI::GetPlayerXuidStringFromPlayerSlot
+  - name: GameStateAPI_GetLocalPlayerXuid
+    alias:
+    - GameStateAPI::GetLocalPlayerXuid
+  - name: GameStateAPI_GetLocalOrInEyePlayerXuid
+    alias:
+    - GameStateAPI::GetLocalOrInEyePlayerXuid
+  - name: GameStateAPI_GetHudPlayerXuid
+    alias:
+    - GameStateAPI::GetHudPlayerXuid
+  - name: GameStateAPI_GetPlayerTeamName
+    alias:
+    - GameStateAPI::GetPlayerTeamName
+  - name: GameStateAPI_GetPlayerTeamNumber
+    alias:
+    - GameStateAPI::GetPlayerTeamNumber
+  - name: GameStateAPI_GetCoachingTeamNumber
+    alias:
+    - GameStateAPI::GetCoachingTeamNumber
+  - name: GameStateAPI_GetAssociatedTeamNumber
+    alias:
+    - GameStateAPI::GetAssociatedTeamNumber
+  - name: GameStateAPI_IsPlayerConnected
+    alias:
+    - GameStateAPI::IsPlayerConnected
+  - name: GameStateAPI_IsPlayerAlive
+    alias:
+    - GameStateAPI::IsPlayerAlive
+  - name: GameStateAPI_GetPlayerPing
+    alias:
+    - GameStateAPI::GetPlayerPing
+  - name: GameStateAPI_GetPlayerKills
+    alias:
+    - GameStateAPI::GetPlayerKills
+  - name: GameStateAPI_GetPlayerRoundKills
+    alias:
+    - GameStateAPI::GetPlayerRoundKills
+  - name: GameStateAPI_GetPlayerAssists
+    alias:
+    - GameStateAPI::GetPlayerAssists
+  - name: GameStateAPI_GetPlayerDeaths
+    alias:
+    - GameStateAPI::GetPlayerDeaths
+  - name: GameStateAPI_GetPlayerMVPs
+    alias:
+    - GameStateAPI::GetPlayerMVPs
+  - name: GameStateAPI_GetPlayerMoney
+    alias:
+    - GameStateAPI::GetPlayerMoney
+  - name: GameStateAPI_GetPlayerScore
+    alias:
+    - GameStateAPI::GetPlayerScore
+  - name: GameStateAPI_GetPlayerClanTag
+    alias:
+    - GameStateAPI::GetPlayerClanTag
+  - name: GameStateAPI_GetPlayerActiveCoinRank
+    alias:
+    - GameStateAPI::GetPlayerActiveCoinRank
+  - name: GameStateAPI_GetPlayerCompetitiveRankType
+    alias:
+    - GameStateAPI::GetPlayerCompetitiveRankType
+  - name: GameStateAPI_GetPlayerCompetitiveRanking
+    alias:
+    - GameStateAPI::GetPlayerCompetitiveRanking
+  - name: GameStateAPI_GetPlayerCompetitiveWins
+    alias:
+    - GameStateAPI::GetPlayerCompetitiveWins
+  - name: GameStateAPI_GetPlayerPremierRankStatsObject
+    alias:
+    - GameStateAPI::GetPlayerPremierRankStatsObject
+  - name: GameStateAPI_GetPlayerDisplayFlairItem
+    alias:
+    - GameStateAPI::GetPlayerDisplayFlairItem
+  - name: GameStateAPI_GetPlayerStatus
+    alias:
+    - GameStateAPI::GetPlayerStatus
+  - name: GameStateAPI_IsFakePlayer
+    alias:
+    - GameStateAPI::IsFakePlayer
+  - name: GameStateAPI_GetPlayerActiveWeaponItemId
+    alias:
+    - GameStateAPI::GetPlayerActiveWeaponItemId
+  - name: GameStateAPI_IsXuidValid
+    alias:
+    - GameStateAPI::IsXuidValid
+  - name: GameStateAPI_GetPlayerVoiceVolume
+    alias:
+    - GameStateAPI::GetPlayerVoiceVolume
+  - name: GameStateAPI_SetPlayerVoiceVolume
+    alias:
+    - GameStateAPI::SetPlayerVoiceVolume
+  - name: GameStateAPI_GetMapsInMapGroup
+    alias:
+    - GameStateAPI::GetMapsInMapGroup
+  - name: GameStateAPI_GetMapDisplayNameToken
+    alias:
+    - GameStateAPI::GetMapDisplayNameToken
+  - name: GameStateAPI_GetMapsInCurrentMapGroup
+    alias:
+    - GameStateAPI::GetMapsInCurrentMapGroup
+  - name: GameStateAPI_GetPlayerLifetime
+    alias:
+    - GameStateAPI::GetPlayerLifetime
+  - name: GameStateAPI_GetPlayerColor
+    alias:
+    - GameStateAPI::GetPlayerColor
+  - name: GameStateAPI_GetPlayerXpLevel
+    alias:
+    - GameStateAPI::GetPlayerXpLevel
+  - name: GameStateAPI_GetPlayerXpTrailLevel
+    alias:
+    - GameStateAPI::GetPlayerXpTrailLevel
+  - name: GameStateAPI_GetPlayerCommendsLeader
+    alias:
+    - GameStateAPI::GetPlayerCommendsLeader
+  - name: GameStateAPI_GetPlayerCommendsTeacher
+    alias:
+    - GameStateAPI::GetPlayerCommendsTeacher
+  - name: GameStateAPI_GetPlayerCommendsFriendly
+    alias:
+    - GameStateAPI::GetPlayerCommendsFriendly
+  - name: GameStateAPI_HasCommunicationAbuseMute
+    alias:
+    - GameStateAPI::HasCommunicationAbuseMute
+  - name: GameStateAPI_HasCommunicationBan
+    alias:
+    - GameStateAPI::HasCommunicationBan
+  - name: GameStateAPI_ShouldShowHudElements
+    alias:
+    - GameStateAPI::ShouldShowHudElements
+  - name: GameStateAPI_IsQueuedMatchmaking
+    alias:
+    - GameStateAPI::IsQueuedMatchmaking
+  - name: GameStateAPI_GetKickTargets
+    alias:
+    - GameStateAPI::GetKickTargets
+  - name: GameStateAPI_GetPlayerCharacterItemID
+    alias:
+    - GameStateAPI::GetPlayerCharacterItemID
+  - name: GameStateAPI_GetCharacterDefaultCheerByXuid
+    alias:
+    - GameStateAPI::GetCharacterDefaultCheerByXuid
+  - name: GameStateAPI_GetCharacterDefaultDefeatByXuid
+    alias:
+    - GameStateAPI::GetCharacterDefaultDefeatByXuid
+  - name: GameStateAPI_ArePlayersEnemies
+    alias:
+    - GameStateAPI::ArePlayersEnemies
+  - name: GameStateAPI_GetCSGOGameUIStateName
+    alias:
+    - GameStateAPI::GetCSGOGameUIStateName
+  - name: GameStateAPI_IsLocalPlayerPlayingMatch
+    alias:
+    - GameStateAPI::IsLocalPlayerPlayingMatch
+  - name: GameStateAPI_IsConnectedOrConnectingToServer
+    alias:
+    - GameStateAPI::IsConnectedOrConnectingToServer
+  - name: GameStateAPI_AreTeamsPlayingSwitchedSides
+    alias:
+    - GameStateAPI::AreTeamsPlayingSwitchedSides
+  - name: GameStateAPI_AreTeamsPlayingSwitchedSidesInRound
+    alias:
+    - GameStateAPI::AreTeamsPlayingSwitchedSidesInRound
+  - name: GameStateAPI_IsReportCategoryEnabledForSelectedPlayer
+    alias:
+    - GameStateAPI::IsReportCategoryEnabledForSelectedPlayer
+  - name: GameStateAPI_SubmitPlayerReport
+    alias:
+    - GameStateAPI::SubmitPlayerReport
+  - name: GameStateAPI_SubmitServerReport
+    alias:
+    - GameStateAPI::SubmitServerReport
+  - name: GameStateAPI_QueryServersForCommendation
+    alias:
+    - GameStateAPI::QueryServersForCommendation
+  - name: GameStateAPI_GetCommendationTokensAvailable
+    alias:
+    - GameStateAPI::GetCommendationTokensAvailable
+  - name: GameStateAPI_GetMyCommendationsJSOForUser
+    alias:
+    - GameStateAPI::GetMyCommendationsJSOForUser
+  - name: GameStateAPI_SubmitCommendation
+    alias:
+    - GameStateAPI::SubmitCommendation
+  - name: GameStateAPI_IsSelectedPlayerMuted
+    alias:
+    - GameStateAPI::IsSelectedPlayerMuted
+  - name: GameStateAPI_ToggleMute
+    alias:
+    - GameStateAPI::ToggleMute
+  - name: GameStateAPI_GetCrosshairCode
+    alias:
+    - GameStateAPI::GetCrosshairCode
+  - name: GameStateAPI_IsDemoOrHltv
+    alias:
+    - GameStateAPI::IsDemoOrHltv
+  - name: GameStateAPI_IsOverwatch
+    alias:
+    - GameStateAPI::IsOverwatch
+  - name: GameStateAPI_IsLocalPlayerWatchingOwnDemo
+    alias:
+    - GameStateAPI::IsLocalPlayerWatchingOwnDemo
+  - name: GameStateAPI_IsLocalPlayerHLTV
+    alias:
+    - GameStateAPI::IsLocalPlayerHLTV
+  - name: GameStateAPI_IsHLTVAutodirectorOn
+    alias:
+    - GameStateAPI::IsHLTVAutodirectorOn
+  - name: GameStateAPI_SetCasterIsCameraman
+    alias:
+    - GameStateAPI::SetCasterIsCameraman
+  - name: GameStateAPI_SetCasterIsHeard
+    alias:
+    - GameStateAPI::SetCasterIsHeard
+  - name: GameStateAPI_SetCasterControlsXray
+    alias:
+    - GameStateAPI::SetCasterControlsXray
+  - name: GameStateAPI_SetCasterControlsUI
+    alias:
+    - GameStateAPI::SetCasterControlsUI
+  - name: GameStateAPI_GetServerName
+    alias:
+    - GameStateAPI::GetServerName
+  - name: GameStateAPI_GetMapName
+    alias:
+    - GameStateAPI::GetMapName
+  - name: GameStateAPI_GetTournamentEventStage
+    alias:
+    - GameStateAPI::GetTournamentEventStage
+  - name: GameStateAPI_GetGameModeInternalName
+    alias:
+    - GameStateAPI::GetGameModeInternalName
+  - name: GameStateAPI_GetGameModeImagePath
+    alias:
+    - GameStateAPI::GetGameModeImagePath
+  - name: GameStateAPI_GetGameModeName
+    alias:
+    - GameStateAPI::GetGameModeName
+  - name: GameStateAPI_GetViewerCount
+    alias:
+    - GameStateAPI::GetViewerCount
+  - name: GameStateAPI_GetMapBSPName
+    alias:
+    - GameStateAPI::GetMapBSPName
+  - name: GameStateAPI_IsQueuedMatchmakingMode_Team
+    alias:
+    - GameStateAPI::IsQueuedMatchmakingMode_Team
+  - name: GameStateAPI_HasHalfTime
+    alias:
+    - GameStateAPI::HasHalfTime
+  - name: GameStateAPI_GetPlayerModel
+    alias:
+    - GameStateAPI::GetPlayerModel
+  - name: GameStateAPI_GetAllPlayersMatchDataJSO
+    alias:
+    - GameStateAPI::GetAllPlayersMatchDataJSO
+  - name: GameStateAPI_GetPlayerDataJSO
+    alias:
+    - GameStateAPI::GetPlayerDataJSO
+  - name: GameStateAPI_GetTimeDataJSO
+    alias:
+    - GameStateAPI::GetTimeDataJSO
+  - name: GameStateAPI_GetScoreDataJSO
+    alias:
+    - GameStateAPI::GetScoreDataJSO
+  - name: GameStateAPI_GetPlayerStatsJSO
+    alias:
+    - GameStateAPI::GetPlayerStatsJSO
+  - name: GameStateAPI_GetMatchInfoJSO
+    alias:
+    - GameStateAPI::GetMatchInfoJSO
+  - name: GameStateAPI_GetMatchEndWinDataJSO
+    alias:
+    - GameStateAPI::GetMatchEndWinDataJSO
+  - name: GameStateAPI_GetAccoladeLocalizationString
+    alias:
+    - GameStateAPI::GetAccoladeLocalizationString
+  - name: GameStateAPI_GetTeamClanName
+    alias:
+    - GameStateAPI::GetTeamClanName
+  - name: GameStateAPI_GetTeamLogoImagePath
+    alias:
+    - GameStateAPI::GetTeamLogoImagePath
+  - name: GameStateAPI_GetTeamFlagImagePath
+    alias:
+    - GameStateAPI::GetTeamFlagImagePath
+  - name: GameStateAPI_GetTeamTotalPlayerCount
+    alias:
+    - GameStateAPI::GetTeamTotalPlayerCount
+  - name: GameStateAPI_GetTeamLivingPlayerCount
+    alias:
+    - GameStateAPI::GetTeamLivingPlayerCount
+  - name: GameStateAPI_GetTeamNextRoundLossBonus
+    alias:
+    - GameStateAPI::GetTeamNextRoundLossBonus
+  - name: GameStateAPI_GetActiveQuestID
+    alias:
+    - GameStateAPI::GetActiveQuestID
+  - name: GameStateAPI_GetAnnotationsViewingLevel
+    alias:
+    - GameStateAPI::GetAnnotationsViewingLevel
+  - name: GameStateAPI_BIsLocalServerHost
+    alias:
+    - GameStateAPI::BIsLocalServerHost
+- name: server
+  symbols:
+  - name: CSource2Server_GetAllServerClasses
+    alias:
+    - CSource2Server::GetAllServerClasses
+  - name: CSource2Server_GetActiveWorldName
+    alias:
+    - CSource2Server::GetActiveWorldName
+  - name: CSource2Server_ShouldTimeoutClient
+    alias:
+    - CSource2Server::ShouldTimeoutClient
+  - name: CSource2Server_OnStreamEntitiesFromFileCompleted
+    alias:
+    - CSource2Server::OnStreamEntitiesFromFileCompleted
+  - name: CSource2Server_PreWorldUpdate
+    alias:
+    - CSource2Server::PreWorldUpdate
+  - name: CSource2Server_UpdateWhenNotInGame
+    alias:
+    - CSource2Server::UpdateWhenNotInGame
+  - name: CGameSystemReallocatingFactory_CSource2EntitySystem_Init
+    alias:
+    - CGameSystemReallocatingFactory<CSource2EntitySystem>::Init
+  - name: CGameSystemReallocatingFactory_CSource2EntitySystem_CreateGameSystem
+    alias:
+    - CGameSystemReallocatingFactory<CSource2EntitySystem>::CreateGameSystem
+  - name: IGameSystemFactory_Init
+    alias:
+    - IGameSystemFactory::Init
+  - name: IGameSystemFactory_Shutdown
+    alias:
+    - IGameSystemFactory::Shutdown
+  - name: IGameSystemFactory_SetGlobalPtr
+    alias:
+    - IGameSystemFactory::SetGlobalPtr
+  - name: CGameSystemReallocatingFactory_CSpawnGroupMgrGameSystem_DestroyGameSystem
+    alias:
+    - CGameSystemReallocatingFactory<CSpawnGroupMgrGameSystem>::Deallocate
+  - name: IGameSystem_SetGameSystemGlobalPtrs
+    alias:
+    - IGameSystem::SetGameSystemGlobalPtrs
+  - name: IGameSystem_vdtor
+    alias:
+    - IGameSystem::~IGameSystem
+  - name: IGameSystem_OnGameInit
+    alias:
+    - IGameSystem::GameInit
+  - name: CMultiplayRules_ctor
+    alias:
+    - CMultiplayRules::CMultiplayRules
+  - name: CGameMoney_OnMoneySpent
+    alias:
+    - CGameMoney::OnMoneySpent
+  - name: CGameMoney_m_DataMap
+    alias:
+    - CGameMoney::m_DataMap
+  - name: CGameMoney_GetDataDescMap
+    alias:
+    - CGameMoney::GetDataDescMap
+  - name: CCSPlayer_UseServices_OnUseImpl
+    alias:
+    - CCSPlayer_UseServices::OnUseImpl
+  - name: CCSPlayer_UseServices_OnUse
+    alias:
+    - CCSPlayer_UseServices::OnUse
+  - name: CCSPlayer_MovementServices_ProcessMovement
+    alias:
+    - CCSPlayer_MovementServices::ProcessMovement
+    - ProcessMovement
+  - name: CCSPlayer_MovementServices_CheckMovingGround
+    alias:
+    - CCSPlayer_MovementServices::CheckMovingGround
+    - CheckMovingGround
+  - name: CCSPlayer_MovementServices_WalkMove
+    alias:
+    - CCSPlayer_MovementServices::WalkMove
+    - WalkMove
+  - name: CCSPlayer_MovementServices_FullWalkMove
+    alias:
+    - CCSPlayer_MovementServices::FullWalkMove
+    - FullWalkMove
+  - name: CCSPlayer_MovementServices_CheckVelocity
+    alias:
+    - CCSPlayer_MovementServices::CheckVelocity
+    - CheckVelocity
+  - name: CCSPlayer_MovementServices_WaterMove
+    alias:
+    - CCSPlayer_MovementServices::WaterMove
+    - WaterMove
+  - name: CCSPlayer_MovementServices_FullWalkMove_SpeedClamp
+    alias:
+    - ServerMovementUnlock
+  - name: CCSPlayer_MovementServices_CheckJumpButton
+    alias:
+    - CCSPlayer_MovementServices::CheckJumpButton
+  - name: CCSPlayer_MovementServices_CheckJumpButton_WaterPatch
+    alias:
+    - CheckJumpButtonWater
+    - FixWaterFloorJump
+  - name: CPlayer_MovementServices_PlayWaterStepSound
+    alias:
+    - CPlayer_MovementServices::PlayWaterStepSound
+  - name: CPlayer_MovementServices_ForceButtons
+    alias:
+    - CPlayer_MovementServices::ForceButtons
+  - name: CPlayer_MovementServices_ForceButtonState
+    alias:
+    - CPlayer_MovementServices::ForceButtonState
+  - name: CPlayer_MovementServices_s_pRunCommandPawn
+    alias:
+    - CPlayer_MovementServices::s_pRunCommandPawn
+  - name: CEntityInstance_m_pEntity
+    alias:
+    - CEntityInstance::m_pEntity
+  - name: CEntityInstance_m_hPrivateScope
+    alias:
+    - CEntityInstance::m_hPrivateScope
+  - name: CEntityInstance_m_CScriptComponent
+    alias:
+    - CEntityInstance::m_CScriptComponent
+  - name: CEntityInstance_m_pKeyValues
+    alias:
+    - CEntityInstance::m_pKeyValues
+  - name: CEntityInstance_m_iszPrivateVScripts
+    alias:
+    - CEntityInstance::m_iszPrivateVScripts
+  - name: CBaseEntity_OnRestore
+    alias:
+    - CBaseEntity::OnRestore
+  - name: CBaseEntity_UpdateOnRemove
+    alias:
+    - CBaseEntity::UpdateOnRemove
+  - name: CBaseEntity_ModifyOrAppendCriteria
+    alias:
+    - CBaseEntity::ModifyOrAppendCriteria
+  - name: CEntityInstance_OnRestore
+    alias:
+    - CEntityInstance::OnRestore
+  - name: CBaseEntity_ctor
+    alias:
+    - CBaseEntity::CBaseEntity
+  - name: CBaseEntity_dtor
+    alias:
+    - CBaseEntity::~CBaseEntity
+  - name: CBaseEntity_vdtor
+    alias:
+    - CBaseEntity::~CBaseEntity (virtual)
+  - name: CEntityInstance_vdtor
+    alias:
+    - CEntityInstance::~CEntityInstance (virtual)
+  - name: CEntityInstance_dtor
+    alias:
+    - CEntityInstance::~CEntityInstance
+  - name: CEntitySaveRestoreBlockHandler_PreSave
+    alias:
+    - CEntitySaveRestoreBlockHandler::PreSave
+  - name: CEntitySaveRestoreBlockHandler_SaveInternal
+    alias:
+    - CEntitySaveRestoreBlockHandler::SaveInternal
+  - name: CEntitySaveRestoreBlockHandler_Save
+    alias:
+    - CEntitySaveRestoreBlockHandler::Save
+  - name: CEntitySaveRestoreBlockHandler_Restore
+    alias:
+    - CEntitySaveRestoreBlockHandler::Restore
+  - name: CEntitySaveRestoreBlockHandler_DoRestoreEntity
+    alias:
+    - CEntitySaveRestoreBlockHandler::DoRestoreEntity
+  - name: CEntitySaveRestoreBlockHandler_RestoreEntity
+    alias:
+    - CEntitySaveRestoreBlockHandler::RestoreEntity
+  - name: CreateEntityTransitionList
+    alias:
+    - CreateEntityTransitionList
+  - name: CEntitySaveRestoreBlockHandler_WriteSaveHeaders
+    alias:
+    - CEntitySaveRestoreBlockHandler::WriteSaveHeaders
+  - name: CEntitySaveRestoreBlockHandler_ReadRestoreHeaders
+    alias:
+    - CEntitySaveRestoreBlockHandler::ReadRestoreHeaders
+  - name: CEntity2SaveRestore_StreamEntitiesFromFile
+    alias:
+    - CEntity2SaveRestore::StreamEntitiesFromFile
+  - name: CSaveRestoreBlockSet_PreRestore
+    alias:
+    - CSaveRestoreBlockSet::PreRestore
+  - name: CSaveRestoreBlockSet_PostRestore
+    alias:
+    - CSaveRestoreBlockSet::PostRestore
+  - name: CEntitySaveRestoreBlockHandler_PreRestore
+    alias:
+    - CEntitySaveRestoreBlockHandler::PreRestore
+  - name: CEntitySaveRestoreBlockHandler_PostRestore
+    alias:
+    - CEntitySaveRestoreBlockHandler::PostRestore
+  - name: CEntitySystem_ForceSetInPVSCallsIntoQueue
+    alias:
+    - CEntitySystem::ForceSetInPVSCallsIntoQueue
+  - name: CEntitySystem_ExecuteQueuedSetInPVS
+    alias:
+    - CEntitySystem::ExecuteQueuedSetInPVS
+  - name: CEntitySystem_m_nSuppressDormancyChangeCount
+    alias:
+    - CEntitySystem::m_nSuppressDormancyChangeCount
+  - name: CEntitySystem_m_nExecuteQueuedCreationDepth
+    alias:
+    - CEntitySystem::m_nExecuteQueuedCreationDepth
+  - name: CEntitySystem_m_queuedDormancyChanges
+    alias:
+    - CEntitySystem::m_queuedDormancyChanges
+  - name: CEntitySystem_SetInPVS
+    alias:
+    - CEntitySystem::SetInPVS
+  - name: CEntitySystem_OnSetDormant
+    alias:
+    - CEntitySystem::OnSetDormant
+  - name: CEntitySystem_BuildResourceManifestForEntity
+    alias:
+    - CEntitySystem::BuildResourceManifestForEntity
+  - name: CEntityInstance_ObjectCaps
+    alias:
+    - CEntityInstance::ObjectCaps
+  - name: CEntityInstance_Save
+    alias:
+    - CEntityInstance::Save
+  - name: CEntityInstance_Restore
+    alias:
+    - CEntityInstance::Restore
+  - name: CEntitySaveRestoreBlockHandler_SaveInitEntities
+    alias:
+    - CEntitySaveRestoreBlockHandler::SaveInitEntities
+  - name: CEntityInstance_OnSave
+    alias:
+    - CEntityInstance::OnSave
+  - name: CEntityInstance_RequiredEdictIndex
+    alias:
+    - CEntityInstance::RequiredEdictIndex
+  - name: PolymorphicHelper_t__SetPolymorphicPointer
+    alias:
+    - PolymorphicHelper_t::SetPolymorphicPointer
+  - name: CEntityInstance_AddChangeAccessorPathPolymorphic
+    alias:
+    - CEntityInstance::AddChangeAccessorPathPolymorphic
+  - name: CEntityInstance_AssignChangeAccessorPathIdsPolymorphic
+    alias:
+    - CEntityInstance::AssignChangeAccessorPathIdsPolymorphic
+  - name: CEntityInstance_AddChangeAccessorPath
+    alias:
+    - CEntityInstance::AddChangeAccessorPath
+  - name: CBaseEntity_AddChangeAccessorPath
+    alias:
+    - CBaseEntity::AddChangeAccessorPath
+  - name: CEntityInstance_AssignChangeAccessorPathIds
+    alias:
+    - CEntityInstance::AssignChangeAccessorPathIds
+  - name: CEntityInstance_GetChangeAccessorPathInfo_2
+    alias:
+    - CEntityInstance::GetChangeAccessorPathInfo_2
+  - name: CBaseEntity_GetChangeAccessorPathInfo_2
+    alias:
+    - CBaseEntity::GetChangeAccessorPathInfo_2
+  - name: CBaseEntity_GetChangeAccessorPathInfo_1
+    alias:
+    - CBaseEntity::GetChangeAccessorPathInfo_1
+  - name: CMomentaryRotButton_Use
+    alias:
+    - CMomentaryRotButton::Use
+  - name: CBaseEntity_TakeDamageOld
+    alias:
+    - CBaseEntity::TakeDamageOld
+  - name: CBaseEntity_OnTakeDamage
+    alias:
+    - CBasePlayerPawn::OnTakeDamage
+  - name: CBasePlayerPawn_OnTakeDamage_Alive
+    alias:
+    - CBasePlayerPawn::OnTakeDamage_Alive
+  - name: CBasePlayerPawn_OnTakeDamage_Dying
+    alias:
+    - CBasePlayerPawn::OnTakeDamage_Dying
+  - name: CBasePlayerPawn_OnTakeDamage_Dead
+    alias:
+    - CBasePlayerPawn::OnTakeDamage_Dead
+  - name: DecalPlacementInfo_ctor
+    alias:
+    - DecalPlacementInfo::DecalPlacementInfo
+  - name: CBaseModelEntity_GetBoneTransform
+    alias:
+    - CBaseModelEntity::GetBoneTransform
+  - name: CBasePlayerPawn_OnTakeDamage
+    alias:
+    - CBasePlayerPawn::OnTakeDamage
+  - name: CCSPlayerPawn_OnTakeDamage_Alive
+    alias:
+    - CCSPlayerPawn::OnTakeDamage_Alive
+  - name: CCSPlayerPawn_OnTakeDamage_Dying
+    alias:
+    - CCSPlayerPawn::OnTakeDamage_Dying
+  - name: CCSPlayerPawn_OnTakeDamage_Dead
+    alias:
+    - CCSPlayerPawn::OnTakeDamage_Dead
+  - name: CFlashbangProjectile_Spawn
+    alias:
+    - CFlashbangProjectile::Spawn
+  - name: CFlashbangProjectile_Detonate
+    alias:
+    - CFlashbangProjectile::Detonate
+  - name: CSmokeGrenadeProjectile_Detonate
+    alias:
+    - CSmokeGrenadeProjectile::Detonate
+  - name: CSmokeGrenadeProjectile_Create
+    alias:
+    - CSmokeGrenadeProjectile::Create
+  - name: CSmokeGrenadeProjectile_m_SmokeVolume
+    alias:
+    - CSmokeGrenadeProjectile::m_SmokeVolume
+  - name: SmokeVolume_BuildSmokeSimulation
+    alias:
+    - SmokeVolume::BuildSmokeSimulation
+  - name: SmokeVolume_BuildSmokeSimulation_Initialize
+    alias:
+    - sub_1402310
+  - name: SmokeVolume_m_vecCenterOrigin
+    alias:
+    - SmokeVolume::m_vecCenterOrigin
+  - name: SmokeVolume_m_pStorage
+    alias:
+    - SmokeVolume::m_pStorage
+  - name: SmokeVolume_m_flStartTime
+    alias:
+    - SmokeVolume::m_flStartTime
+  - name: SmokeVolume_GetSmokeDensityInLine_Lambda1_operator_call
+    alias:
+    - SmokeVolume::GetSmokeDensityInLine::<lambda_1>::operator()
+  - name: SmokeVolume_m_nFrame
+    alias:
+    - SmokeVolume::m_nFrame
+  - name: CEntitySystem_QueueDestroyEntity
+    alias:
+    - CEntitySystem::QueueDestroyEntity
+  - name: CEntitySystem_ExecuteQueuedDeletion
+    alias:
+    - CEntitySystem::ExecuteQueuedDeletion
+  - name: CEntitySystem_m_nExecuteQueuedDeletionDepth
+    alias:
+    - CEntitySystem::m_nExecuteQueuedDeletionDepth
+  - name: CBaseModelEntity_SetModel
+    alias:
+    - CBaseModelEntity::SetModel
+  - name: CBaseModelEntity_SetRenderAttribute
+    alias:
+    - CBaseModelEntity::SetRenderAttribute
+  - name: CBaseEntity_GetScriptDescInternal
+    alias:
+    - CBaseEntity::GetScriptDescInternal
+  - name: CBaseModelEntity_GetScriptDescInternal
+    alias:
+    - CBaseModelEntity::GetScriptDescInternal
+  - name: CBaseModelEntity_GetModelScale
+    alias:
+    - CBaseModelEntity::GetModelScale
+  - name: CBaseModelEntity_Script_SetModelScale
+    alias:
+    - CBaseModelEntity::Script_SetModelScale
+  - name: CBaseModelEntity_ScriptLookupAttachment
+    alias:
+    - CBaseModelEntity::ScriptLookupAttachment
+  - name: CBaseModelEntity_ScriptGetAttachmentOrigin
+    alias:
+    - CBaseModelEntity::ScriptGetAttachmentOrigin
+  - name: CBaseModelEntity_ScriptGetAttachmentAngles
+    alias:
+    - CBaseModelEntity::ScriptGetAttachmentAngles
+  - name: CBaseModelEntity_ScriptGetAttachmentForward
+    alias:
+    - CBaseModelEntity::ScriptGetAttachmentForward
+  - name: CBaseModelEntity_ScriptSetSize
+    alias:
+    - CBaseModelEntity::ScriptSetSize
+  - name: CBaseModelEntity_ScriptSetModel
+    alias:
+    - CBaseModelEntity::ScriptSetModel
+  - name: ScriptBinding_CBaseModelEntity_SetModel
+    alias:
+    - CS_Script_SetModel
+  - name: CBaseModelEntity_ScriptGetRenderAlpha
+    alias:
+    - CBaseModelEntity::ScriptGetRenderAlpha
+  - name: CBaseModelEntity_ScriptSetRenderAlpha
+    alias:
+    - CBaseModelEntity::ScriptSetRenderAlpha
+  - name: CBaseModelEntity_ScriptSetRenderMode
+    alias:
+    - CBaseModelEntity::ScriptSetRenderMode
+  - name: CBaseModelEntity_ScriptSetRenderColor
+    alias:
+    - CBaseModelEntity::ScriptSetRenderColor
+  - name: CBaseModelEntity_ScriptGetRenderColor
+    alias:
+    - CBaseModelEntity::ScriptGetRenderColor
+  - name: CBaseModelEntity_ScriptSetMaterialGroup
+    alias:
+    - CBaseModelEntity::ScriptSetMaterialGroup
+  - name: CBaseModelEntity_ScriptSetMaterialGroupHash
+    alias:
+    - CBaseModelEntity::ScriptSetMaterialGroupHash
+  - name: CBaseModelEntity_ScriptGetMaterialGroupHash
+    alias:
+    - CBaseModelEntity::ScriptGetMaterialGroupHash
+  - name: CBaseModelEntity_ScriptSetSingleMeshGroup
+    alias:
+    - CBaseModelEntity::ScriptSetSingleMeshGroup
+  - name: CBaseModelEntity_ScriptSetMeshGroupMask
+    alias:
+    - CBaseModelEntity::ScriptSetMeshGroupMask
+  - name: CBaseModelEntity_ScriptGetMeshGroupMask
+    alias:
+    - CBaseModelEntity::ScriptGetMeshGroupMask
+  - name: CBaseModelEntity_ScriptSetBodygroupByName
+    alias:
+    - CBaseModelEntity::ScriptSetBodygroupByName
+  - name: CBaseModelEntity_Script_SetBodygroup
+    alias:
+    - CBaseModelEntity::Script_SetBodygroup
+  - name: CBaseModelEntity_Script_SetSkin
+    alias:
+    - CBaseModelEntity::Script_SetSkin
+  - name: CEntityInstance_NetworkUpdateState_thunk
+    alias:
+    - CEntityInstance::NetworkUpdateState_thunk
+  - name: CBaseEntity_SetGravityScale
+    alias:
+    - CBaseEntity::SetGravityScale
+  - name: CTriggerGravity_GravityTouch
+    alias:
+    - CTriggerGravity::GravityTouch
+  - name: CTriggerGravity_GetTouchFunction
+    alias:
+    - CTriggerGravity::GetTouchFunction
+  - name: CBasePlayerController_HandleCommand_JoinTeam
+    alias:
+    - CBasePlayerController::HandleCommand_JoinTeam
+  - name: CBasePlayerController_SetPlayerName
+    alias:
+    - CBasePlayerController::SetPlayerName
+  - name: CBasePlayerController_ProcessUsercmds
+    alias:
+    - ProcessUsercmds
+  - name: CBasePlayerController_SetPawn
+    alias:
+    - CBasePlayerController::SetPawn
+  - name: CBasePlayerController_GetPawn
+    alias:
+    - CBasePlayerController::GetPawn
+  - name: CBasePlayerController_Connect
+    alias:
+    - CBasePlayerController::Connect
+  - name: CBasePlayerController_SetConnectedState
+    alias:
+    - CBasePlayerController::SetConnectedState
+  - name: CSource2GameClients_ClientSettingsChanged
+    alias:
+    - CSource2GameClients::ClientSettingsChanged
+  - name: CSource2GameClients_ClientSetConVarUserInfoSet
+    alias:
+    - CSource2GameClients::ClientSetConVarUserInfoSet
+  - name: CSource2GameClients_ClientSetupVisibility
+    alias:
+    - CSource2GameClients::ClientSetupVisibility
+  - name: CSource2GameClients_ClientDisconnect
+    alias:
+    - CSource2GameClients::ClientDisconnect
+  - name: CSource2GameClients_ClientPutInServer
+    alias:
+    - CSource2GameClients::ClientPutInServer
+  - name: CSource2GameClients_ClientConnect
+    alias:
+    - CSource2GameClients::ClientConnect
+  - name: CSource2GameClients_ClientActive
+    alias:
+    - CSource2GameClients::ClientActive
+  - name: CSource2GameClients_ClientFullyConnect
+    alias:
+    - CSource2GameClients::ClientFullyConnect
+  - name: CSource2GameClients_ClientCommand
+    alias:
+    - CSource2GameClients::ClientCommand
+  - name: CSource2GameClients_ProcessUsercmds
+    alias:
+    - CSource2GameClients::ProcessUsercmds
+  - name: CSource2GameClients_GetBugReportInfo
+    alias:
+    - CSource2GameClients::GetBugReportInfo
+  - name: CSource2GameClients_ClientDiagnostic
+    alias:
+    - CSource2GameClients::ClientDiagnostic
+  - name: CSource2GameClients_SendHLTVStatusMessage
+    alias:
+    - CSource2GameClients::SendHLTVStatusMessage
+  - name: CSource2GameClients_OnClientConnected
+    alias:
+    - CSource2GameClients::OnClientConnected
+  - name: CGameRules_FindPickerEntity
+    alias:
+    - CGameRules::FindPickerEntity
+  - name: CCSGameRules_FindPickerEntity
+    alias:
+    - CCSGameRules::FindPickerEntity
+  - name: CCSGameRules_TerminateRound
+    alias:
+    - CCSGameRules::TerminateRound
+    - CGameRules::TerminateRound
+    - CGameRules_TerminateRound
+  - name: CCSGameRules_GoToIntermission
+    alias:
+    - CCSGameRules::GoToIntermission
+  - name: CEntityInstance_AcceptInput
+    alias:
+    - CEntityInstance::AcceptInput
+    - AcceptInput
+  - name: CEntityIdentity_AcceptInput
+    alias:
+    - CEntityIdentity::AcceptInput
+  - name: CEntityIdentity_AcceptInputInternal
+    alias:
+    - CEntityIdentity::AcceptInputInternal
+  - name: CEntityInstance_ScriptAcceptInput
+    alias:
+    - CEntityInstance::ScriptAcceptInput
+  - name: CEntityIdentity_SetEntityName
+    alias:
+    - CEntityIdentity::SetEntityName
+  - name: CEntitySystem_RemoveEntityFromNameMap
+    alias:
+    - CEntitySystem::RemoveEntityFromNameMap
+  - name: CEntitySystem_AddEntityToNameMap
+    alias:
+    - CEntitySystem::AddEntityToNameMap
+  - name: ScriptBinding_Entity_SetEntityName
+    alias:
+    - Entity::SetEntityName
+  - name: CBtActionCoordinatedBuy_Update
+    alias:
+    - CBtActionCoordinatedBuy::Update
+  - name: CCSPlayer_ItemServices_CanAcquire
+    alias:
+    - CCSPlayer_ItemServices::CanAcquire
+  - name: CCSPlayer_ItemServices_GiveDefaultItems
+    alias:
+    - CCSPlayer_ItemServices::GiveDefaultItems
+  - name: CCSPlayer_ItemServices_GiveNamedItem
+    alias:
+    - CCSPlayer_ItemServices::GiveNamedItem
+  - name: CCSPlayer_ItemServices_GiveNamedItemBool
+    alias:
+    - CCSPlayer_ItemServices::GiveNamedItemBool
+  - name: CCSPlayer_WeaponServices_CanUse
+    alias:
+    - CCSPlayer_WeaponServices::CanUse
+  - name: CCSPlayer_WeaponServices_PickupItem
+    alias:
+    - CCSPlayer_WeaponServices::PickupItem
+  - name: CCSPlayer_WeaponServices_EquipWeapon
+    alias:
+    - CCSPlayer_WeaponServices::EquipWeapon
+  - name: CCSPlayer_WeaponServices_Weapon_GetSlot
+    alias:
+    - CCSPlayer_WeaponServices_Weapon_GetSlot
+  - name: CCSPlayerController_ChangeTeam
+    alias:
+    - CCSPlayerController::ChangeTeam
+  - name: CCSPlayerController_GetThinkFunction
+    alias:
+    - CCSPlayerController::GetThinkFunction
+  - name: CCSPlayerController_PlayerForceTeamThink
+    alias:
+    - PlayerForceTeamThink
+    - CCSPlayerController::PlayerForceTeamThink
+  - name: CCSPlayerController_ResetForceTeamThink
+    alias:
+    - ResetForceTeamThink
+    - CCSPlayerController::ResetForceTeamThink
+  - name: CCSPlayerController_ResourceDataThink
+    alias:
+    - ResourceDataThink
+    - CCSPlayerController::ResourceDataThink
+  - name: CCSPlayerController_InventoryUpdateThink
+    alias:
+    - InventoryUpdateThink
+    - CCSPlayerController::InventoryUpdateThink
+  - name: g_CCSPlayerController_PlayerForceTeamThink
+    alias:
+    - g_CCSPlayerController::PlayerForceTeamThink
+  - name: g_CCSPlayerController_ResetForceTeamThink
+    alias:
+    - g_CCSPlayerController::ResetForceTeamThink
+  - name: g_CCSPlayerController_ResourceDataThink
+    alias:
+    - g_CCSPlayerController::ResourceDataThink
+  - name: g_CCSPlayerController_InventoryUpdateThink
+    alias:
+    - g_CCSPlayerController::InventoryUpdateThink
+  - name: CCSGameRules__sm_mapGcBanInformation
+    alias:
+    - CCSGameRules::sm_mapGcBanInformation
+  - name: CCSGameRules_BeginRound
+    alias:
+    - CCSGameRules::BeginRound
+  - name: CCSGameRules_PlayerSpawn
+    alias:
+    - CCSGameRules::PlayerSpawn
+  - name: CCSPlayerController_Respawn
+    alias:
+    - CCSPlayerController::Respawn
+  - name: CCSPlayerController_Connect
+    alias:
+    - CCSPlayerController::Connect
+  - name: CCSPlayerController_Disconnect
+    alias:
+    - CCSPlayerController::Disconnect
+  - name: CCSPlayerController_SwitchTeam
+    alias:
+    - CCSPlayerController::SwitchTeam
+  - name: CCSPlayerPawnBase_OnSetDormant
+    alias:
+    - CCSPlayerPawnBase::OnSetDormant
+  - name: CCSPlayerPawnBase_CheckForIdle
+    alias:
+    - CCSPlayerPawnBase::CheckForIdle
+  - name: CCSPlayerPawnBase_CheckForIdleInternal
+    alias:
+    - CCSPlayerPawnBase::CheckForIdleInternal
+  - name: CCSPlayerPawn_PostThink
+    alias:
+    - CCSPlayerPawnBase::PostThink
+    - CCSPlayerPawn::PostThink
+    - CCSPlayerPawnBase_PostThink
+    - CCSPlayerPawn_PostThink
+    - PostThink
+  - name: CCSPlayerPawn_OnSwitchWeapons
+    alias:
+    - CCSPlayerPawn::OnSwitchWeapons
+  - name: CCSPlayerPawn_ProcessSuicideAsKillReward
+    alias:
+    - CCSPlayerPawn::ProcessSuicideAsKillReward
+  - name: CGameRules_ClientSettingsChanged
+    alias:
+    - CGameRules::ClientSettingsChanged
+  - name: CGameRulesGameSystem_OnGameInit
+    alias:
+    - CGameRulesGameSystem::GameInit
+  - name: CGameRulesGameSystem_OnGameShutdown
+    alias:
+    - CGameRulesGameSystem::GameShutdown
+  - name: IGameSystem_OnGameShutdown
+    alias:
+    - IGameSystem::GameShutdown
+  - name: IGameSystem_OnGamePostInit
+    alias:
+    - IGameSystem::GamePostInit
+  - name: IGameSystem_OnGamePreShutdown
+    alias:
+    - IGameSystem::GamePreShutdown
+  - name: CMultiplayRules_ClientDisconnected
+    alias:
+    - CMultiplayRules::ClientDisconnected
+  - name: CSource2Server_Init
+    alias:
+    - CSource2Server::Init
+  - name: CSource2Server_ApplyGameSettings
+    alias:
+    - CSource2Server::ApplyGameSettings
+  - name: CSource2Server_GetEntityReport
+    alias:
+    - CSource2Server::GetEntityReport
+  - name: CSource2Server_BroadcastServerFrameTime
+    alias:
+    - CSource2Server::BroadcastServerFrameTime
+  - name: CSource2Server_WriteSignonMessages
+    alias:
+    - CSource2Server::WriteSignonMessages
+  - name: CSource2Server_GameCreateNetworkStringTables
+    alias:
+    - CSource2Server::GameCreateNetworkStringTables
+  - name: CSource2Server_GetMatchmakingGameData
+    alias:
+    - CSource2Server::GetMatchmakingGameData
+  - name: CSource2Server_GameServerSteamAPIActivated
+    alias:
+    - CSource2Server::GameServerSteamAPIActivated
+  - name: CSource2Server_GameServerSteamAPIDeactivated
+    alias:
+    - CSource2Server::GameServerSteamAPIDeactivated
+  - name: CSource2Server_OnHostNameChanged
+    alias:
+    - CSource2Server::OnHostNameChanged
+  - name: CSource2Server_GetLevelsFromSaveFile
+    alias:
+    - CSource2Server::GetLevelsFromSaveFile
+  - name: CSource2Server_ServerConVarChanged
+    alias:
+    - CSource2Server::ServerConVarChanged
+  - name: CSource2Server_Save
+    alias:
+    - CSource2Server::Save
+  - name: CSource2Server_Connect
+    alias:
+    - CSource2Server::Connect
+  - name: CSource2Server_PreShutdown
+    alias:
+    - CSource2Server::PreShutdown
+  - name: IAppSystem_Connect
+    alias:
+    - IAppSystem::Connect
+  - name: IAppSystem_PreShutdown
+    alias:
+    - IAppSystem::PreShutdown
+  - name: IVEngineServer2_ServerCommand
+    alias:
+    - IVEngineServer2::ServerCommand
+  - name: IVEngineServer2_IsDedicatedServer
+    alias:
+    - IVEngineServer2::IsDedicatedServer
+  - name: IVEngineServer2_GetServerGlobals
+    alias:
+    - IVEngineServer2::GetServerGlobals
+  - name: IVEngineServer2_GetAchievementMgr
+    alias:
+    - IVEngineServer2::GetAchievementMgr
+  - name: IVEngineServer2_IsLogEnabled
+    alias:
+    - IVEngineServer2::IsLogEnabled
+  - name: CSource2Server_Shutdown
+    alias:
+    - CSource2Server::Shutdown
+  - name: CGameEventManager_Shutdown
+    alias:
+    - CGameEventManager::Shutdown
+  - name: CLoopModeRegistry_UnregisterLoopModes
+    alias:
+    - CLoopModeRegistry::UnregisterLoopModes
+  - name: CEngineServiceRegistry_UnregisterEngineServices
+    alias:
+    - CEngineServiceRegistry::UnregisterEngineServices
+  - name: IEngineServiceMgr_UnregisterLoopMode
+    alias:
+    - IEngineServiceMgr::UnregisterLoopMode
+  - name: IEngineServiceMgr_UnregisterEngineService
+    alias:
+    - IEngineServiceMgr::UnregisterEngineService
+  - name: CSource2Server_GameFrame
+    alias:
+    - CSource2Server::GameFrame
+  - name: CGameEventManager_Init
+    alias:
+    - CGameEventManager::Init
+  - name: CTakeDamageInfo_HitGroupInfo
+    alias:
+    - CTakeDamageInfo::HitGroupInfo
+    - CTakeDamageInfo::HitGroup
+    - CTakeDamageInfo_HitGroup
+  - name: CEntitySystem_RegisterEntityClass
+    alias:
+    - CEntitySystem::RegisterEntityClass
+  - name: CEntitySystem_CreateEntityByName
+    alias:
+    - CEntitySystem::CreateEntityByName
+  - name: CEntitySystem_CreateEntity
+    alias:
+    - CEntitySystem::CreateEntity
+  - name: CEntitySystem_AddEntityToEntityDataBase
+    alias:
+    - CEntitySystem::AddEntityToEntityDataBase
+  - name: CEntitySystem_OnAddEntity
+    alias:
+    - CEntitySystem::OnAddEntity
+  - name: CEntitySystem_OnEntityParentChanged
+    alias:
+    - CEntitySystem::OnEntityParentChanged
+  - name: CEntitySystem_PrecacheEntity
+    alias:
+    - CEntitySystem::PrecacheEntity
+  - name: CEntitySystem_InvokePrecacheCallback
+    alias:
+    - CEntitySystem::InvokePrecacheCallback
+  - name: CEntitySystem_DestroyEntity
+    alias:
+    - CEntitySystem::DestroyEntity
+  - name: CConcreteEntityList_AllocEntity
+    alias:
+    - CConcreteEntityList::AllocEntity
+  - name: CEntitySystem_ConstructEntity
+    alias:
+    - CEntitySystem::ConstructEntity
+  - name: CEntitySystem_DoConstructEntity
+    alias:
+    - CEntitySystem::DoConstructEntity
+  - name: CEntitySystem_GetSpawnGroupWorldId
+    alias:
+    - CEntitySystem::GetSpawnGroupWorldId
+  - name: CEntitySystem_FindClassByDesignName
+    alias:
+    - CEntitySystem::FindClassByDesignName
+  - name: CEntitySystem_m_EntityList
+    alias:
+    - CEntitySystem::m_EntityList
+  - name: CEntitySystem_m_entityNames
+    alias:
+    - CEntitySystem::m_entityNames
+  - name: CEntitySystem_m_entityComponentHelpers
+    alias:
+    - CEntitySystem::m_entityComponentHelpers
+  - name: CEntitySystem_m_DataDescKeyUnserializers
+    alias:
+    - CEntitySystem::m_DataDescKeyUnserializers
+  - name: CEntitySystem_m_EntityPostSpawnCallback
+    alias:
+    - CEntitySystem::m_EntityPostSpawnCallback
+  - name: CEntityIdentity_FreeAttributes
+    alias:
+    - CEntityIdentity::FreeAttributes
+  - name: CConcreteEntityList_FreeEntity
+    alias:
+    - CConcreteEntityList::FreeEntity
+  - name: UTIL_CreateEntityByName
+    alias:
+    - CreateEntityByName
+  - name: CBaseEntity_DispatchSpawn
+    alias:
+    - CBaseEntity::DispatchSpawn
+    - DispatchSpawn
+  - name: CEntitySystem_QueueSpawnEntity
+    alias:
+    - CEntitySystem::QueueSpawnEntity
+  - name: CEntitySystem_HelperExecuteQueuedSpawn
+    alias:
+    - CEntitySystem::HelperExecuteQueuedSpawn
+  - name: CEntitySystem_SortEntities
+    alias:
+    - CEntitySystem::SortEntities
+  - name: CGameEntitySystem_SortEntities
+    alias:
+    - CGameEntitySystem::SortEntities
+  - name: CEntitySystem_InstallCreationWrapperCallbacks
+    alias:
+    - CEntitySystem::InstallCreationWrapperCallbacks
+  - name: CEntitySystem_ExecuteQueuedCreation
+    alias:
+    - CEntitySystem::ExecuteQueuedCreation
+  - name: CEntitySystem_ExecuteQueuedActivates
+    alias:
+    - CEntitySystem::ExecuteQueuedActivates
+  - name: CEntitySystem_ExecuteQueuedPostDataUpdateAndActivates
+    alias:
+    - CEntitySystem::ExecuteQueuedPostDataUpdateAndActivates
+  - name: CEntitySystem_Activate
+    alias:
+    - CEntitySystem::Activate
+  - name: CEntitySystem_PostDataUpdate
+    alias:
+    - CEntitySystem::PostDataUpdate
+  - name: CBaseEntity_NetworkStateChangedLog
+    alias:
+    - CBaseEntity::NetworkStateChangedLog
+  - name: CBaseEntity_NetworkStateChanged
+    alias:
+    - CBaseEntity::NetworkStateChanged
+  - name: CBaseEntity_FullEdictChanged
+    alias:
+    - CBaseEntity::FullEdictChanged
+  - name: CBaseEntity_m_NetworkTransmitComponent
+    alias:
+    - CBaseEntity::m_NetworkTransmitComponent
+  - name: CNetworkTransmitComponent_StateChanged
+    alias:
+    - CNetworkTransmitComponent::StateChanged
+  - name: CNetworkTransmitComponent_m_nStateFlags
+    alias:
+    - CNetworkTransmitComponent::m_nStateFlags
+  - name: CInferno_InfernoThink
+    alias:
+    - CInferno::InfernoThink
+  - name: CPhysExplosion_Activate
+    alias:
+    - CPhysExplosion::Activate
+  - name: CPhysExplosion_Explode
+    alias:
+    - CPhysExplosion::Explode
+  - name: UTIL_SayTextFilter2
+    alias:
+    - UTIL_SayText2Filter
+  - name: CCSWeaponBase_ItemPostFrame_ProcessReloadAction
+    alias:
+    - CCSWeaponBase::ItemPostFrame::ProcessReloadAction
+  - name: CCSPlayer_WeaponServices_HandleDropWeapon
+    alias:
+    - CCSPlayer_WeaponServices::HandleDropWeapon
+  - name: CCSPlayer_UseServices_BumpWeapon
+    alias:
+    - CCSPlayer_UseServices::BumpWeapon
+  - name: CCSPlayerPawn_HandleDropWeapon
+    alias:
+    - CCSPlayerPawn::HandleDropWeapon
+  - name: CCSPlayerPawn_ClientCommand
+    alias:
+    - CCSPlayerPawn::ClientCommand
+  - name: CCSPlayerPawn_SprayPaint
+    alias:
+    - CCSPlayerPawn::SprayPaint
+  - name: CEntitySpawner_CPlayerSprayDecal_Spawn
+    alias:
+    - CEntitySpawner<CPlayerSprayDecal>::Spawn
+  - name: CEntityKeyValuesAllocator_GetTempBuffer
+    alias:
+    - CEntityKeyValuesAllocator::GetTempBuffer
+  - name: CEntityKeyValues_LoadFromContext
+    alias:
+    - CEntityKeyValues::LoadFromContext
+  - name: CEntityKeyValues_Initialized
+    alias:
+    - CEntityKeyValues::Initialized
+  - name: CEntitySystem_m_nEntityKeyValuesAllocatorRefCount
+    alias:
+    - CEntitySystem::m_nEntityKeyValuesAllocatorRefCount
+  - name: CEntitySystem_AddRefKeyValues
+    alias:
+    - CEntitySystem::AddRefKeyValues
+  - name: CEntitySystem_ReleaseKeyValues
+    alias:
+    - CEntitySystem::ReleaseKeyValues
+  - name: CCSPlayerController_HandleCommandDrop
+    alias:
+    - CCSPlayerController::HandleCommandDrop
+  - name: IGameSystem_InitAllSystems
+    alias:
+    - IGameSystem::InitAllSystems
+  - name: IGameSystem_LoopInitAllSystems
+    alias:
+    - IGameSystem::LoopInitAllSystems
+  - name: IGameSystem_LoopPostInitAllSystems
+    alias:
+    - IGameSystem::LoopPostInitAllSystems
+  - name: IGameSystem_PostInit
+    alias:
+    - IGameSystem::PostInit
+  - name: IGameSystemFactory_PostInit
+    alias:
+    - IGameSystemFactory::PostInit
+  - name: IGameSystemFactory_GetStaticGameSystem
+    alias:
+    - IGameSystemFactory::GetStaticGameSystem
+  - name: IGameSystem_InitAllSystems_pFirst
+    alias:
+    - IGameSystem::InitAllSystems::pFirst
+    - IGameSystem::InitAllSystems->pFirst
+  - name: IGameSystem_LoopPostInitAllSystems_pEventDispatcher
+    alias:
+    - IGameSystem::LoopPostInitAllSystems::pEventDispatcher
+    - IGameSystem::LoopPostInitAllSystems->pEventDispatcher
+  - name: IGameSystem_LoopDestroyAllSystems_s_GameSystems
+    alias:
+    - IGameSystem::LoopDestroyAllSystems::s_GameSystems
+    - IGameSystem::LoopDestroyAllSystems->s_GameSystems
+  - name: CSource2GameEntities_CheckTransmit
+    alias:
+    - CSource2GameEntities::CheckTransmit
+    - ISource2GameEntities::CheckTransmit
+    - ISource2GameEntities_CheckTransmit
+    - CheckTransmit
+  - name: CSource2GameEntities_ShouldClientReceiveStringTableUserData
+    alias:
+    - CSource2GameEntities::ShouldClientReceiveStringTableUserData
+    - ISource2GameEntities::ShouldClientReceiveStringTableUserData
+    - ISource2GameEntities_ShouldClientReceiveStringTableUserData
+    - ShouldClientReceiveStringTableUserData
+  - name: INetworkGameServer_IsBackgroundMap
+    alias:
+    - INetworkGameServer::IsBackgroundMap
+  - name: ILoopModeGameSharedState_IsBackgroundMap
+    alias:
+    - ILoopModeGameSharedState::IsBackgroundMap
+  - name: CNetworkGameServerBase_IsBackgroundMap
+    alias:
+    - CNetworkGameServerBase::IsBackgroundMap
+  - name: CBaseEntity_EmitSoundFilter
+    alias:
+    - CBaseEntity::EmitSoundFilter
+  - name: CBaseEntity_ScriptInputKill
+    alias:
+    - CBaseEntity::ScriptInputKill
+  - name: CBaseEntity_ScriptGetForward
+    alias:
+    - CBaseEntity::ScriptGetForward
+  - name: CBaseEntity_ScriptGetRight
+    alias:
+    - CBaseEntity::ScriptGetRight
+  - name: CBaseEntity_ScriptGetLeft
+    alias:
+    - CBaseEntity::ScriptGetLeft
+  - name: CBaseEntity_ScriptGetUp
+    alias:
+    - CBaseEntity::ScriptGetUp
+  - name: CBaseEntity_ScriptGetModelName
+    alias:
+    - CBaseEntity::ScriptGetModelName
+  - name: CBaseEntity_ScriptGetMoveParent
+    alias:
+    - CBaseEntity::ScriptGetMoveParent
+  - name: CBaseEntity_ScriptGetRootMoveParent
+    alias:
+    - CBaseEntity::ScriptGetRootMoveParent
+  - name: CBaseEntity_ScriptFirstMoveChild
+    alias:
+    - CBaseEntity::ScriptFirstMoveChild
+  - name: CBaseEntity_ScriptNextMovePeer
+    alias:
+    - CBaseEntity::ScriptNextMovePeer
+  - name: CBaseEntity_ScriptGetOwnerEntity
+    alias:
+    - CBaseEntity::ScriptGetOwnerEntity
+  - name: CBaseEntity_Script_GetChildren
+    alias:
+    - CBaseEntity::Script_GetChildren
+  - name: CBaseEntity_ScriptSetParent
+    alias:
+    - CBaseEntity::ScriptSetParent
+  - name: CBaseEntity_ScriptEyePosition
+    alias:
+    - CBaseEntity::ScriptEyePosition
+  - name: CBaseEntity_ScriptSetAngles
+    alias:
+    - CBaseEntity::ScriptSetAngles
+  - name: CBaseEntity_ScriptSetAbsAngles
+    alias:
+    - CBaseEntity::ScriptSetAbsAngles
+  - name: CBaseEntity_ScriptGetAngles
+    alias:
+    - CBaseEntity::ScriptGetAngles
+  - name: CBaseEntity_ScriptEyeAngles
+    alias:
+    - CBaseEntity::ScriptEyeAngles
+  - name: CBaseEntity_ScriptSetOrigin
+    alias:
+    - CBaseEntity::ScriptSetOrigin
+  - name: CBaseEntity_ScriptSetLocalAngles
+    alias:
+    - CBaseEntity::ScriptSetLocalAngles
+  - name: CBaseEntity_ScriptGetLocalAngles
+    alias:
+    - CBaseEntity::ScriptGetLocalAngles
+  - name: CBaseEntity_ScriptSetLocalOrigin
+    alias:
+    - CBaseEntity::ScriptSetLocalOrigin
+  - name: CBaseEntity_ScriptGetLocalOrigin
+    alias:
+    - CBaseEntity::ScriptGetLocalOrigin
+  - name: CBaseEntity_ScriptTransformPointEntityToWorld
+    alias:
+    - CBaseEntity::ScriptTransformPointEntityToWorld
+  - name: CBaseEntity_ScriptTransformPointWorldToEntity
+    alias:
+    - CBaseEntity::ScriptTransformPointWorldToEntity
+  - name: CBaseEntity_ScriptSetForward
+    alias:
+    - CBaseEntity::ScriptSetForward
+  - name: CBaseEntity_ScriptGetBoundingMins
+    alias:
+    - CBaseEntity::ScriptGetBoundingMins
+  - name: CBaseEntity_ScriptGetBoundingMaxs
+    alias:
+    - CBaseEntity::ScriptGetBoundingMaxs
+  - name: CBaseEntity_ScriptGetBounds
+    alias:
+    - CBaseEntity::ScriptGetBounds
+  - name: CBaseEntity_ScriptGetLocalAngularVelocity_OBSOLETE
+    alias:
+    - CBaseEntity::ScriptGetLocalAngularVelocity_OBSOLETE
+  - name: CBaseEntity_ScriptSetLocalAngularVelocity_OBSOLETE
+    alias:
+    - CBaseEntity::ScriptSetLocalAngularVelocity_OBSOLETE
+  - name: CBaseEntity_ScriptAddEffects
+    alias:
+    - CBaseEntity::ScriptAddEffects
+  - name: CBaseEntity_ScriptRemoveEffects
+    alias:
+    - CBaseEntity::ScriptRemoveEffects
+  - name: CBaseEntity_ScriptSetAttributeFloatValue
+    alias:
+    - CBaseEntity::ScriptSetAttributeFloatValue
+  - name: CBaseEntity_ScriptGetAttributeFloatValue
+    alias:
+    - CBaseEntity::ScriptGetAttributeFloatValue
+  - name: CBaseEntity_ScriptSetAttributeIntValue
+    alias:
+    - CBaseEntity::ScriptSetAttributeIntValue
+  - name: CBaseEntity_ScriptGetAttributeIntValue
+    alias:
+    - CBaseEntity::ScriptGetAttributeIntValue
+  - name: CBaseEntity_ScriptHasAttribute
+    alias:
+    - CBaseEntity::ScriptHasAttribute
+  - name: CBaseEntity_ScriptDeleteAttribute
+    alias:
+    - CBaseEntity::ScriptDeleteAttribute
+  - name: CBaseEntity_GetScriptOwnerEntity
+    alias:
+    - CBaseEntity::GetScriptOwnerEntity
+  - name: CBaseEntity_SetScriptOwnerEntity
+    alias:
+    - CBaseEntity::SetScriptOwnerEntity
+  - name: CBaseEntity_ScriptSetEntityName
+    alias:
+    - CBaseEntity::ScriptSetEntityName
+  - name: CBaseEntity_ScriptGetMass
+    alias:
+    - CBaseEntity::ScriptGetMass
+  - name: CBaseEntity_ScriptSetMass
+    alias:
+    - CBaseEntity::ScriptSetMass
+  - name: CBaseEntity_ScriptGetSpawnGroupHandle
+    alias:
+    - CBaseEntity::ScriptGetSpawnGroupHandle
+  - name: CBaseEntity_GetAbsAngles
+    alias:
+    - CBaseEntity::GetAbsAngles
+  - name: CBaseEntity_Script_GetTeamNumber
+    alias:
+    - CBaseEntity::Script_GetTeamNumber
+  - name: CBaseEntity_Script_FollowEntity
+    alias:
+    - CBaseEntity::Script_FollowEntity
+  - name: CBaseEntity_Script_FollowEntityMerge
+    alias:
+    - CBaseEntity::Script_FollowEntityMerge
+  - name: CBaseEntity_Script_Trigger
+    alias:
+    - CBaseEntity::Script_Trigger
+  - name: CBaseEntity_Script_SetContextThink
+    alias:
+    - CBaseEntity::Script_SetContextThink
+  - name: CBaseEntity_AddContextForScript
+    alias:
+    - CBaseEntity::AddContextForScript
+  - name: CBaseEntity_AddContextForScriptNumeric
+    alias:
+    - CBaseEntity::AddContextForScriptNumeric
+  - name: CBaseEntity_GetContextForScript
+    alias:
+    - CBaseEntity::GetContextForScript
+  - name: CBaseEntity_ScriptGatherCriteria
+    alias:
+    - CBaseEntity::ScriptGatherCriteria
+  - name: CBaseEntity_Script_TakeDamage
+    alias:
+    - CBaseEntity::Script_TakeDamage
+  - name: CBaseEntity_SetAbsVelocity
+    alias:
+    - CBaseEntity::SetAbsVelocity
+  - name: CBaseEntity_GetAbsVelocity
+    alias:
+    - CBaseEntity::GetAbsVelocity
+  - name: CBaseEntity_Script_ApplyLocalAngularVelocityImpulse
+    alias:
+    - CBaseEntity::Script_ApplyLocalAngularVelocityImpulse
+  - name: CBaseEntity_GetLocalAngularVelocity_OBSOLETE
+    alias:
+    - CBaseEntity::GetLocalAngularVelocity_OBSOLETE
+  - name: CBaseEntity_ScriptEmitSoundParams
+    alias:
+    - CBaseEntity::ScriptEmitSoundParams
+    - CBaseEntity::EmitSoundParams
+    - CBaseEntity_EmitSoundParams
+  - name: CBaseEntity_ScriptStopSound
+    alias:
+    - CBaseEntity::ScriptStopSound
+  - name: CBaseEntity_ScriptSoundDuration
+    alias:
+    - CBaseEntity::ScriptSoundDuration
+  - name: CBaseEntity_ScriptGetAbsOrigin
+    alias:
+    - CBaseEntity::ScriptGetAbsOrigin
+  - name: CBaseEntity_OnSetDormant
+    alias:
+    - CBaseEntity::OnSetDormant
+  - name: CBaseEntity_Precache
+    alias:
+    - CBaseEntity::Precache
+    - Precache
+  - name: CCSPlayerController_AddedToEntityDatabase
+    alias:
+    - CCSPlayerController::AddedToEntityDatabase
+  - name: CEnvEntityIgniter_Precache
+    alias:
+    - CEnvEntityIgniter::Precache
+  - name: CEnvShake_Spawn
+    alias:
+    - CEnvShake::Spawn
+  - name: CBaseEntity_SetMoveType
+    alias:
+    - CBaseEntity::SetMoveType
+  - name: CBasePlayerPawn_CommitSuicide
+    alias:
+    - CBasePlayerPawn::CommitSuicide
+    - CommitSuicide
+  - name: CBaseCombatCharacter_OnKilled
+    alias:
+    - CBaseCombatCharacter::OnKilled
+  - name: CCSPlayerPawn_Event_KilledOther
+    alias:
+    - CCSPlayerPawn::Event_KilledOther
+  - name: CCSPlayerPawn_Event_Killed
+    alias:
+    - CCSPlayerPawn::Event_Killed
+  - name: CBasePlayerPawn_Event_Killed
+    alias:
+    - CBasePlayerPawn::Event_Killed
+  - name: ScriptBinding_CSPlayerPawn_DestroyWeapon
+    alias:
+    - CSPlayerPawn::DestroyWeapon
+  - name: CBasePlayerPawn_RemovePlayerItem
+    alias:
+    - CBasePlayerPawn::RemovePlayerItem
+  - name: CBasePlayerPawn_DropActivePlayerWeapon
+    alias:
+    - CBasePlayerPawn::DropActivePlayerWeapon
+  - name: CBasePlayerPawn_GetEyePosition
+    alias:
+    - CBasePlayerPawn::GetEyePosition
+  - name: CBaseEntity_GetEyePosition
+    alias:
+    - CBaseEntity::GetEyePosition
+  - name: CCSBotManager_BotPlaceCommand
+    alias:
+    - CCSBotManager::BotPlace
+  - name: CBasePlayerPawn_EyeVectors
+    alias:
+    - CBasePlayerPawn::EyeVectors
+  - name: CBasePlayerPawn_GetEyeAngles
+    alias:
+    - CBasePlayerPawn::GetEyeAngles
+  - name: CBaseEntity_GetEyeAngles
+    alias:
+    - CBaseEntity::GetEyeAngles
+  - name: CCSBot_Upkeep
+    alias:
+    - CCSBot::Upkeep
+  - name: CCSBot_SetState
+    alias:
+    - CCSBot::SetState
+  - name: CCSBot_UpdatePathMovement
+    alias:
+    - CCSBot::UpdatePathMovement
+  - name: CCSBot_PrintIfWatched
+    alias:
+    - CCSBot::PrintIfWatched
+  - name: CHostage_Follow
+    alias:
+    - CHostage::Follow
+  - name: CHostage_DropHostage
+    alias:
+    - CHostage::DropHostage
+  - name: HideState_OnUpdate
+    alias:
+    - HideState::OnUpdate
+  - name: CCSBot_Attack
+    alias:
+    - CCSBot::Attack
+  - name: CCSBot_MoveTo
+    alias:
+    - CCSBot::MoveTo
+  - name: CCSBot_InhibitLookAround
+    alias:
+    - CCSBot::InhibitLookAround
+  - name: CCSBot_SetDisposition
+    alias:
+    - CCSBot::SetDisposition
+  - name: CCSBot_Idle
+    alias:
+    - CCSBot::Idle
+  - name: CCSBot_ComputePath
+    alias:
+    - CCSBot::ComputePath
+  - name: CBaseEntity_IsAlive
+    alias:
+    - CBaseEntity::IsAlive
+  - name: CBaseEntity_SetOwner
+    alias:
+    - CBaseEntity::SetOwner
+  - name: CBaseEntity_CollisionRulesChanged
+    alias:
+    - CBaseEntity::CollisionRulesChanged
+    - CollisionRulesChanged
+  - name: CBaseEntity_Use
+    alias:
+    - CBaseEntity::Use
+  - name: CGameSceneNode_PostSpawnKeyValues
+    alias:
+    - CGameSceneNode::PostSpawnKeyValues
+  - name: CBaseEntity_Spawn
+    alias:
+    - CBaseEntity::Spawn
+    - Spawn
+  - name: CBaseEntity_SpawnRadius
+    alias:
+    - CBaseEntity::SpawnRadius
+  - name: CCSPlayer_ItemServices_DropActivePlayerWeapon
+    alias:
+    - CCSPlayer_ItemServices::DropActivePlayerWeapon
+  - name: CCSPlayer_WeaponServices_DropWeapon
+    alias:
+    - CCSPlayer_WeaponServices::DropWeapon
+  - name: CBasePlayerWeapon_Shoot_Secondary
+    alias:
+    - CBasePlayerWeapon::Shoot_Secondary
+  - name: CCSPlayer_ItemServices_RemoveWeapons
+    alias:
+    - CCSPlayer_ItemServices::RemoveWeapons
+  - name: CCSPlayer_WeaponServices_SelectItem
+    alias:
+    - CCSPlayer_WeaponServices::SelectItem
+  - name: CEntFireOutputAutoCompletionFunctor_FireOutput
+    alias:
+    - CEntFireOutputAutoCompletionFunctor::FireOutput
+  - name: CEntityInstance_FindOutputsByName
+    alias:
+    - CEntityInstance::FindOutputsByName
+  - name: CEntityInstance_ScriptEntityIO
+    alias:
+    - CEntityInstance::ScriptEntityIO
+  - name: CEntityIOOutput_FireOutputInternal
+    alias:
+    - CEntityIOOutput::FireOutputInternal
+  - name: CEntitySystem_AddEntityIOEvent
+    alias:
+    - CEntitySystem::AddEntityIOEvent
+  - name: CEntitySystem_AddEntityIOEvent2
+    alias:
+    - CEntitySystem::AddEntityIOEvent2
+  - name: CEntitySystem_AddEntityIOEventBuildStruct
+    alias:
+    - CEntitySystem::AddEntityIOEventBuildStruct
+  - name: CEntitySystem_AddEntityIOEventToQueue
+    alias:
+    - CEntitySystem::AddEntityIOEventToQueue
+  - name: CEntitySystem_m_EventQueue
+    alias:
+    - CEntitySystem::m_EventQueue
+  - name: CGameEntitySystem_FindEntityByClassName
+    alias:
+    - CGameEntitySystem::FindEntityByClassName
+  - name: CGameEntitySystem_FindEntityByName
+    alias:
+    - CGameEntitySystem::FindEntityByName
+  - name: CChicken_Event_Killed
+    alias:
+    - CChicken::Event_Killed
+  - name: CBaseEntity_EmitSound
+    alias:
+    - CBaseEntity::EmitSound
+  - name: CBaseModelEntity_FindBone
+    alias:
+    - CBaseModelEntity::FindBone
+  - name: CGameEntitySystem_OnAddEntity
+    alias:
+    - CGameEntitySystem::OnAddEntity
+  - name: CGameEntitySystem_BuildResourceManifest_ManifestNameOrGroupName
+    alias:
+    - CGameEntitySystem::BuildResourceManifest_ManifestNameOrGroupName
+  - name: CGameEntitySystem_BuildResourceManifest_KeyValuesVectors
+    alias:
+    - CGameEntitySystem::BuildResourceManifest_KeyValuesVectors
+  - name: CGameEntitySystem_FindEntityProcedural
+    alias:
+    - CGameEntitySystem::FindEntityProcedural
+  - name: CGameEntitySystem_Spawn
+    alias:
+    - CGameEntitySystem::Spawn
+  - name: CEntitySystem_Spawn
+    alias:
+    - CEntitySystem::Spawn
+  - name: CBodyGameSystem_SpawnDependencyIsland
+    alias:
+    - CBodyGameSystem::SpawnDependencyIsland
+  - name: CGameEntitySystem_CheckGlobalState
+    alias:
+    - CGameEntitySystem::CheckGlobalState
+  - name: IGameSystem_OnBuildGameSessionManifest
+    alias:
+    - IGameSystem::BuildGameSessionManifest
+  - name: IGameSystem_OnServerPreEntityThink
+    alias:
+    - IGameSystem::OnServerPreEntityThink
+  - name: IGameSystem_OnServerPostEntityThink
+    alias:
+    - IGameSystem::OnServerPostEntityThink
+  - name: IGameSystem_OnServerPreClientUpdate
+    alias:
+    - IGameSystem::ServerPreClientUpdate
+  - name: IGameSystem_OnServerAdvanceTick
+    alias:
+    - IGameSystem::ServerAdvanceTick
+  - name: IGameSystem_OnServerGamePostSimulate
+    alias:
+    - IGameSystem::ServerGamePostSimulate
+  - name: IGameSystem_OnServerPostAdvanceTick
+    alias:
+    - IGameSystem::ServerPostAdvanceTick
+  - name: IGameSystem_OnServerPreBeginAsyncPostTickWork
+    alias:
+    - IGameSystem::OnServerPreBeginAsyncPostTickWork
+  - name: IGameSystem_OnServerBeginAsyncPostTickWork
+    alias:
+    - IGameSystem::OnServerBeginAsyncPostTickWork
+  - name: IGameSystem_OnServerPreEndAsyncPostTickWork
+    alias:
+    - IGameSystem::OnServerPreEndAsyncPostTickWork
+  - name: IGameSystem_OnServerPostEndAsyncPostTickWork
+    alias:
+    - IGameSystem::OnServerPostEndAsyncPostTickWork
+  - name: IGameSystem_OnSaveGame
+    alias:
+    - IGameSystem::OnSaveGame
+  - name: IGameSystem_OnRestoreGame
+    alias:
+    - IGameSystem::OnRestoreGame
+  - name: IGameSystem_OnOutOfGameFrameBoundary
+    alias:
+    - IGameSystem::OnOutOfGameFrameBoundary
+  - name: CSource2GameClients_StartHLTVServer
+    alias:
+    - CSource2GameClients::StartHLTVServer
+  - name: LegacyGameEventListener
+    alias:
+    - GetLegacyGameEventListener
+  - name: CPhysicsGameSystem_ProcessContactEvents
+    alias:
+    - CPhysicsGameSystem::ProcessContactEvents
+  - name: CBaseEntity_VPhysicsStartTouch
+    alias:
+    - CBaseEntity::VPhysicsStartTouch
+  - name: CBaseEntity_PhysicsTouch
+    alias:
+    - CBaseEntity::PhysicsTouch
+  - name: CBaseEntity_VPhysicsEndTouch
+    alias:
+    - CBaseEntity::VPhysicsEndTouch
+  - name: CBaseEntity_StartTouch
+    alias:
+    - CBaseEntity::StartTouch
+    - StartTouch
+  - name: CBaseEntity_Touch
+    alias:
+    - CBaseEntity::Touch
+    - Touch
+  - name: CBaseEntity_EndTouch
+    alias:
+    - CBaseEntity::EndTouch
+    - EndTouch
+  - name: IVPhys2World_GetTouchingList
+    alias:
+    - IVPhys2World::GetTouchingList
+    - CVPhys2World::GetTouchingList
+  - name: CTriggerPush_Touch
+    alias:
+    - CTriggerPush::Touch
+    - TriggerPush_Touch
+  - name: CPhysBox_Use
+    alias:
+    - CPhysBox::Use
+  - name: CBaseEntity_SetGroundEntity
+    alias:
+    - SetGroundEntity
+  - name: CBaseEntity_GetHammerUniqueId
+    alias:
+    - CBaseEntity::GetHammerUniqueId
+    - GetHammerUniqueId
+  - name: CBaseEntity_IsPlayerPawn
+    alias:
+    - CBaseEntity::IsPlayerPawn
+    - IsEntityPawn
+    - IsPlayerPawn
+  - name: CBaseEntity_IsPlayerController
+    alias:
+    - CBaseEntity::IsPlayerController
+    - IsEntityController
+    - IsPlayerController
+  - name: CBaseTrigger_StartTouch
+    alias:
+    - CBaseTrigger::StartTouch
+  - name: CBaseTrigger_EndTouch
+    alias:
+    - CBaseTrigger::EndTouch
+  - name: CBaseTrigger_PassesTriggerFilters
+    alias:
+    - CBaseTrigger::PassesTriggerFilters
+    - PassesTriggerFilters
+  - name: CBaseAnimGraph_GetAnimationController
+    alias:
+    - CBaseAnimGraph::GetAnimationController
+  - name: CBaseAnimGraph_m_skeletonInstance
+    alias:
+    - CBaseAnimGraph::m_skeletonInstance
+  - name: CGameSceneNode_PreInstanceSpawn
+    alias:
+    - CGameSceneNode::PreInstanceSpawn
+  - name: CGameSceneNode_GetSkeletonInstance
+    alias:
+    - CGameSceneNode::GetSkeletonInstance
+  - name: CSkeletonInstance_m_animationController
+    alias:
+    - CSkeletonInstance::m_animationController
+  - name: CSkeletonInstance_PostDataUpdate
+    alias:
+    - CSkeletonInstance::PostDataUpdate
+  - name: CGameSceneNode_PostDataUpdate
+    alias:
+    - CGameSceneNode::PostDataUpdate
+  - name: CGameSceneNode_UpdateEntityForHierarchyChange
+    alias:
+    - CGameSceneNode::UpdateEntityForHierarchyChange
+  - name: CPointTeleportAPI_TeleportEntityInternal
+    alias:
+    - CPointTeleportAPI::TeleportEntityInternal
+  - name: CBaseEntity_Teleport
+    alias:
+    - CBaseEntity::Teleport
+  - name: CPointTeleport_Activate
+    alias:
+    - CPointTeleport::Activate
+  - name: CBaseEntity_Activate
+    alias:
+    - CBaseEntity::Activate
+    - Activate
+  - name: CBaseEntity_DrawDebugTextOverlays
+    alias:
+    - CBaseEntity::DrawDebugTextOverlays
+  - name: CRagdollProp_DrawEntityDebugOverlays
+    alias:
+    - CRagdollProp::DrawEntityDebugOverlays
+  - name: CBaseEntity_ReloadPrivateScripts
+    alias:
+    - CBaseEntity::ReloadPrivateScripts
+  - name: CCheckTransmitInfo_m_nPlayerSlot
+    alias:
+    - CCheckTransmitInfo::m_nPlayerSlot
+    - CheckTransmitPlayerSlot
+  - name: CCheckTransmitInfo_m_bFullUpdate
+    alias:
+    - CCheckTransmitInfo::m_bFullUpdate
+  - name: CDedicatedServerWorkshopManager_SwitchToWorkshopMapGroup
+    alias:
+    - CDedicatedServerWorkshopManager::SwitchToWorkshopMapGroup
+  - name: IGameTypes_CreateWorkshopMapGroup
+    alias:
+    - IGameTypes::CreateWorkshopMapGroup
+  - name: CEngineServer_UnloadSpawnGroup
+    alias:
+    - CEngineServer::UnloadSpawnGroup
+  - name: CNetworkServerService_SetGameSpawnGroupMgr
+    alias:
+    - CNetworkServerService::SetGameSpawnGroupMgr
+  - name: CNetworkServerService_AddServerPrerequisites
+    alias:
+    - CNetworkServerService::AddServerPrerequisites
+  - name: CNetworkServerService_SetFinalSimulationTickThisFrame
+    alias:
+    - CNetworkServerService::SetFinalSimulationTickThisFrame
+  - name: CSpawnGroupMgrGameSystem_GetSpawnGroups
+    alias:
+    - CSpawnGroupMgrGameSystem::GetSpawnGroups
+    - GetSpawnGroups
+  - name: CSpawnGroupMgrGameSystem_DumpSpawnGroups
+    alias:
+    - CSpawnGroupMgrGameSystem::DumpSpawnGroups
+    - DumpSpawnGroups
+  - name: CSpawnGroupMgrGameSystem_SpawnGroupSpawnEntitiesInternal
+    alias:
+    - CSpawnGroupMgrGameSystem::SpawnGroupSpawnEntitiesInternal
+    - SpawnGroupSpawnEntitiesInternal
+  - name: IGameSystem_OnPreSpawnGroupLoad
+    alias:
+    - IGameSystem::OnPreSpawnGroupLoad
+  - name: IGameSystem_OnPostSpawnGroupLoad
+    alias:
+    - IGameSystem::OnPostSpawnGroupLoad
+  - name: CSpawnGroupMgrGameSystem_SpawnGroupShutdown
+    alias:
+    - CSpawnGroupMgrGameSystem::SpawnGroupShutdown
+    - SpawnGroupShutdown
+  - name: CSpawnGroupMgrGameSystem_SpawnGroupActuallyShutdown
+    alias:
+    - CSpawnGroupMgrGameSystem::SpawnGroupActuallyShutdown
+    - SpawnGroupActuallyShutdown
+  - name: IGameSystem_OnPreSpawnGroupUnload
+    alias:
+    - IGameSystem::OnPreSpawnGroupUnload
+  - name: IGameSystem_OnPostSpawnGroupUnload
+    alias:
+    - IGameSystem::OnPostSpawnGroupUnload
+  - name: CLoadingSpawnGroup_CreateEntityToSpawn
+    alias:
+    - CLoadingSpawnGroup::CreateEntityToSpawn
+  - name: CSpawnGroupMgrGameSystem_OnSpawnGroupPrecache
+    alias:
+    - CSpawnGroupMgrGameSystem::OnSpawnGroupPrecache
+    - SpawnGroupPrecache
+  - name: CSpawnGroupMgrGameSystem_AllocateSpawnGroup
+    alias:
+    - CSpawnGroupMgrGameSystem::AllocateSpawnGroup
+  - name: CSpawnGroupMgrGameSystem_ReleaseSpawnGroup
+    alias:
+    - CSpawnGroupMgrGameSystem::ReleaseSpawnGroup
+  - name: CSpawnGroupMgrGameSystem_SpawnGroupInit
+    alias:
+    - CSpawnGroupMgrGameSystem::SpawnGroupInit
+  - name: CSpawnGroupMgrGameSystem_CreateLoadingSpawnGroup
+    alias:
+    - CSpawnGroupMgrGameSystem::CreateLoadingSpawnGroup
+  - name: CSpawnGroupMgrGameSystem_CreateLoadingSpawnGroupForSaveFile
+    alias:
+    - CSpawnGroupMgrGameSystem::CreateLoadingSpawnGroupForSaveFile
+  - name: CSpawnGroupMgrGameSystem_SpawnGroupSpawnEntities
+    alias:
+    - CSpawnGroupMgrGameSystem::SpawnGroupSpawnEntities
+  - name: CSpawnGroupMgrGameSystem_SetActiveSpawnGroup
+    alias:
+    - CSpawnGroupMgrGameSystem::SetActiveSpawnGroup
+  - name: IVEngineServer2_MakeSpawnGroupActive
+    alias:
+    - IVEngineServer2::MakeSpawnGroupActive
+  - name: CSpawnGroupMgrGameSystem_UnloadSpawnGroup
+    alias:
+    - CSpawnGroupMgrGameSystem::UnloadSpawnGroup
+  - name: CSpawnGroupMgrGameSystem_SaveGame_Start
+    alias:
+    - CSpawnGroupMgrGameSystem::SaveGame_Start
+  - name: IGameSystem_OnSpawnGroupPrecache
+    alias:
+    - IGameSystem::OnSpawnGroupPrecache
+  - name: IGameSystem_OnSpawnGroupUncache
+    alias:
+    - IGameSystem::OnSpawnGroupUncache
+  - name: CBaseFilter_InputTestActivator
+    alias:
+    - CBaseFilter::InputTestActivator
+  - name: CGamePlayerEquip_InputTriggerForAllPlayers
+    alias:
+    - CGamePlayerEquip::InputTriggerForAllPlayers
+  - name: CGamePlayerEquip_InputTriggerForActivatedPlayer
+    alias:
+    - CGamePlayerEquip::InputTriggerForActivatedPlayer
+  - name: CNavMesh_GetNearestNavArea
+    alias:
+    - CNavMesh::GetNearestNavArea
+  - name: CCSBotManager_AddBot
+    alias:
+    - CCSBotManager::AddBot
+  - name: BotAdd_CommandHandler
+    alias:
+    - CCSBotManager::BotAddCommand
+  - name: BotKill_CommandHandler
+    alias:
+    - CCSBotManager::BotKillCommand
+  - name: EntInfo_CommandHandler
+    alias:
+    - CC_Ent_Info
+  - name: CEntitySystem_DestroyEntityImmediate
+    alias:
+    - CEntitySystem::DestroyEntityImmediate
+  - name: CEntitySystem_OnRemoveEntityFromDatabase
+    alias:
+    - CEntitySystem::OnRemoveEntityFromDatabase
+  - name: CEntitySystem_DoDestructEntity
+    alias:
+    - CEntitySystem::DoDestructEntity
+  - name: CEntitySystem_UpdateOnRemove
+    alias:
+    - CEntitySystem::UpdateOnRemove
+  - name: ClientPrintToController
+    alias:
+    - ClientPrint
+  - name: CCSBotManager_AddBot_BotNavIgnore
+    alias:
+    - BotNavIgnore
+  - name: CEnvHudHint_API_ShowHudHint
+    alias:
+    - CEnvHudHint_API::ShowHudHint
+  - name: UTIL_GetPlayerControllerForEntity
+    alias:
+    - UTIL_GetPlayerControllerForEntity
+  - name: CEntitySystem_ctor
+    alias:
+    - CEntitySystem::CEntitySystem
+  - name: CGameEntitySystem_ctor
+    alias:
+    - CGameEntitySystem::CGameEntitySystem
+  - name: CEntitySystem_RegisterAccessor
+    alias:
+    - CEntitySystem::RegisterAccessor
+  - name: CEntitySystem_Init
+    alias:
+    - CEntitySystem::Init
+  - name: CEntitySystem_ProcessEntityRegistration
+    alias:
+    - CEntitySystem::ProcessEntityRegistration
+  - name: CEntitySystem_PostCreateEntitySystem
+    alias:
+    - CEntitySystem::PostCreateEntitySystem
+  - name: CSource2EntitySystem_StaticInit
+    alias:
+    - CSource2EntitySystem::StaticInit
+  - name: CSpawnGroupEntityFilterRegistrar_RegisterSpawnGroupEntityFilters
+    alias:
+    - CSpawnGroupEntityFilterRegistrar::RegisterSpawnGroupEntityFilters
+  - name: CGameEntitySystem_m_spawnGroupEntityFilters
+    alias:
+    - CGameEntitySystem::m_spawnGroupEntityFilters
+  - name: CGameEntitySystem_m_pEntity2Networkables
+    alias:
+    - CGameEntitySystem::m_pEntity2Networkables
+  - name: CEntity2NetworkClasses_ServerClass_InitEntity2NetworkClasses
+    alias:
+    - CEntity2NetworkClasses<ServerClass>::InitEntity2NetworkClasses
+  - name: CEntitySystem_m_Symbols
+    alias:
+    - CEntitySystem::m_Symbols
+  - name: CEntitySystem_m_pNetworkFieldChangedEventQueue
+    alias:
+    - CEntitySystem::m_pNetworkFieldChangedEventQueue
+  - name: CEntitySystem_m_pNetworkFieldScratchData
+    alias:
+    - CEntitySystem::m_pNetworkFieldScratchData
+  - name: CEntitySystem_m_pFieldChangeLimitSpew
+    alias:
+    - CEntitySystem::m_pFieldChangeLimitSpew
+  - name: CEntitySystem_m_ComponentUnserializerInfoAllocator
+    alias:
+    - CEntitySystem::m_ComponentUnserializerInfoAllocator
+  - name: CEntitySystem_m_EntityMaterialAttributes
+    alias:
+    - CEntitySystem::m_EntityMaterialAttributes
+  - name: CEntitySystem_m_flChangeCallbackSpewThreshold
+    alias:
+    - CEntitySystem::m_flChangeCallbackSpewThreshold
+  - name: CEntitySystem_ClearEntityDatabase
+    alias:
+    - CEntitySystem::ClearEntityDatabase
+  - name: INetworkMessages_SetNetworkSerializationContextData
+    alias:
+    - INetworkMessages::SetNetworkSerializationContextData
+  - name: CFlattenedSerializers_CreateFieldChangedEventQueue
+    alias:
+    - CFlattenedSerializers::CreateFieldChangedEventQueue
+  - name: INetworkMessages_RegisterSchemaTypeOverride
+    alias:
+    - INetworkMessages::RegisterSchemaTypeOverride
+  - name: CSceneEntity_GetScriptDesc
+    alias:
+    - CSceneEntity::GetScriptDesc
+  - name: CEntityInstance_GetScriptDesc
+    alias:
+    - CEntityInstance::GetScriptDesc
+  - name: CEntityInstance_Spawn
+    alias:
+    - CEntityInstance::Spawn
+  - name: CEntityInstance_Activate
+    alias:
+    - CEntityInstance::Activate
+  - name: CEntityInstance_Precache
+    alias:
+    - CEntityInstance::Precache
+  - name: CEntityInstance_GetDataDescMap
+    alias:
+    - CEntityInstance::GetDataDescMap
+  - name: CEntityInstance_ReloadPrivateScripts
+    alias:
+    - CEntityInstance::ReloadPrivateScripts
+  - name: CEntityInstance_ValidatePrivateScriptScope
+    alias:
+    - CEntityInstance::ValidatePrivateScriptScope
+  - name: CEntityInstance_NetworkStateChanged
+    alias:
+    - CEntityInstance::NetworkStateChanged
+  - name: CEntityInstance_FullEdictChanged
+    alias:
+    - CEntityInstance::FullEdictChanged
+  - name: CEntityInstance_NetworkUpdateState
+    alias:
+    - CEntityInstance::NetworkUpdateState
+  - name: CEntityInstance_NetworkStateChangedLog
+    alias:
+    - CEntityInstance::NetworkStateChangedLog
+  - name: CEntityInstance_DrawDebugTextOverlays
+    alias:
+    - CEntityInstance::DrawDebugTextOverlays
+  - name: CEntityInstance_DrawEntityDebugOverlays
+    alias:
+    - CEntityInstance::DrawEntityDebugOverlays
+  - name: CEntityInstance_PostDataUpdateDelta
+    alias:
+    - CEntityInstance::PostDataUpdateDelta
+  - name: CEntityInstance_PreDataUpdate
+    alias:
+    - CEntityInstance::PreDataUpdate
+  - name: CEntityInstance_PostDataUpdate
+    alias:
+    - CEntityInstance::PostDataUpdate
+  - name: CEntityInstance_PostDataUpdatePreserve
+    alias:
+    - CEntityInstance::PostDataUpdatePreserve
+  - name: CEntityInstance_Connect
+    alias:
+    - CEntityInstance::Connect
+  - name: CEntityInstance_UpdateOnRemove
+    alias:
+    - CEntityInstance::UpdateOnRemove
+  - name: CEntityInstance_Disconnect
+    alias:
+    - CEntityInstance::Disconnect
+  - name: CEntityInstance_AddedToEntityDatabase
+    alias:
+    - CEntityInstance::AddedToEntityDatabase
+  - name: CEntityInstance_OnSetDormant
+    alias:
+    - CEntityInstance::OnSetDormant
+  - name: CEntityInstance_Schema_DynamicBinding
+    alias:
+    - CEntityInstance::Schema_DynamicBinding
+  - name: CEntitySystem_OnRemoveEntity
+    alias:
+    - CEntitySystem::OnRemoveEntity
+  - name: CEntityComponentHelperT_Free
+    alias:
+    - CEntityComponentHelperT::Free
+  - name: CScriptedSequence_SynchronizeSequence
+    alias:
+    - CScriptedSequence::SynchronizeSequence
+  - name: CNetworkUtlVectorEmbedded_NetworkStateChanged_m_vecRenderAttributes
+    alias:
+    - CNetworkUtlVectorEmbedded<CRenderAttribute>::NetworkStateChanged_m_vecRenderAttributes
+  - name: CNetworkUtlVectorEmbedded_NetworkStateChanged_m_perRoundStats
+    alias:
+    - CNetworkUtlVectorEmbedded<CSPerRoundStats_t>::NetworkStateChanged_m_perRoundStats
+  - name: CUtlVectorEmbeddedNetworkVar_CSPerRoundStats_t_NetworkVar_m_perRoundStats_SetCount
+    alias:
+    - CUtlVectorEmbeddedNetworkVar<CSPerRoundStats_t, NetworkVar>::SetCount
+  - name: CNetworkUtlVectorEmbedded_TryLateResolve_m_vecRenderAttributes
+    alias:
+    - CNetworkUtlVectorEmbedded<CRenderAttribute>::TryLateResolve
+  - name: INetworkMessages_GetLoggingChannel
+    alias:
+    - INetworkMessages::GetLoggingChannel
+  - name: CPhysicsEntitySolver_PhysEnableEntityCollisions
+    alias:
+    - CPhysicsEntitySolver::PhysEnableEntityCollisions
+  - name: CLoopModeGame_StaticInit
+    alias:
+    - CLoopModeGame::StaticInit
+  - name: CLoopModeGame_ctor
+    alias:
+    - CLoopModeGame::CLoopModeGame
+  - name: CLoopModeFactory_CLoopModeGame_Init
+    alias:
+    - CLoopModeFactory<CLoopModeGame>::Init
+  - name: CLoopModeFactory_CLoopModeGame_CreateLoopMode
+    alias:
+    - CLoopModeFactory<CLoopModeGame>::CreateLoopMode
+  - name: CLoopModeFactory_CLoopModeGame_Shutdown
+    alias:
+    - CLoopModeFactory<CLoopModeGame>::Shutdown
+  - name: CLoopModeGame_OnLoopActivate
+    alias:
+    - CLoopModeGame::OnLoopActivate
+  - name: ILoopMode_OnLoopActivate
+    alias:
+    - ILoopMode::OnLoopActivate
+  - name: CLoopModeGame_AddViewsToSceneSystem
+    alias:
+    - CLoopModeGame::AddViewsToSceneSystem
+  - name: ILoopMode_AddViewsToSceneSystem
+    alias:
+    - ILoopMode::AddViewsToSceneSystem
+  - name: CLoopModeGame_LoopInitInternal
+    alias:
+    - CLoopModeGame::LoopInitInternal
+  - name: CLoopModeGame_LoopInit
+    alias:
+    - CLoopModeGame::LoopInit
+  - name: ILoopMode_LoopInit
+    alias:
+    - ILoopMode::LoopInit
+  - name: ILoopMode_LoopShutdown
+    alias:
+    - ILoopMode::LoopShutdown
+  - name: CLoopModeGame_RegisterEventMapInternal
+    alias:
+    - CLoopModeGame::RegisterEventMapInternal
+  - name: CLoopModeGame_OnServerAdvanceTick
+    alias:
+    - CLoopModeGame::OnServerAdvanceTick
+  - name: CLoopModeGame_OnServerBeginSimulate
+    alias:
+    - CLoopModeGame::OnServerBeginSimulate
+  - name: CLoopModeGame_OnServerPostSimulate
+    alias:
+    - CLoopModeGame::OnServerPostSimulate
+  - name: CLoopModeGame_OnServerPostAdvanceTick
+    alias:
+    - CLoopModeGame::OnServerPostAdvanceTick
+  - name: CLoopModeGame_OnServerBeginAsyncPostTickWork
+    alias:
+    - CLoopModeGame::OnServerBeginAsyncPostTickWork
+  - name: CLoopModeGame_OnServerEndAsyncPostTickWork
+    alias:
+    - CLoopModeGame::OnServerEndAsyncPostTickWork
+  - name: CLoopModeGame_OnFrameBoundary
+    alias:
+    - CLoopModeGame::OnFrameBoundary
+  - name: CLoopModeGame_ReceivedServerInfo
+    alias:
+    - CLoopModeGame::ReceivedServerInfo
+  - name: CLoopModeGame_SetWorldSession
+    alias:
+    - CLoopModeGame::SetWorldSession
+  - name: CLoopModeGame_SetGameSystemState
+    alias:
+    - CLoopModeGame::SetGameSystemState
+  - name: IGameSystem_DestroyAllGameSystems
+    alias:
+    - IGameSystem::DestroyAllGameSystems
+  - name: IGameSystem_ShutdownAllSystems
+    alias:
+    - IGameSystem::ShutdownAllSystems
+  - name: IGameSystem_LoopDestroyAllSystems
+    alias:
+    - IGameSystem::LoopDestroyAllSystems
+  - name: IGameSystem_LoopPreShutdownAllSystems
+    alias:
+    - IGameSystem::LoopPreShutdownAllSystems
+  - name: CLoopModeGame_Shutdown
+    alias:
+    - CLoopModeGame::Shutdown
+  - name: CLoopModeGame_LoopShutdown
+    alias:
+    - CLoopModeGame::LoopShutdown
+  - name: CLoopModeGame_ShutdownServer
+    alias:
+    - CLoopModeGame::ShutdownServer
+  - name: CLoopModeGame_OnLoopDeactivate
+    alias:
+    - CLoopModeGame::OnLoopDeactivate
+  - name: ILoopMode_OnLoopDeactivate
+    alias:
+    - ILoopMode::OnLoopDeactivate
+  - name: CPlayerCommandQueue_ctor
+    alias:
+    - CPlayerCommandQueue::CPlayerCommandQueue
+  - name: CBasePlayerController_IsFakeClient
+    alias:
+    - CBasePlayerController::IsFakeClient
+    - IsFakeClient
+  - name: INetworkGameServer_GetClientConnectionType
+    alias:
+    - INetworkGameServer::GetClientConnectionType
+  - name: IGameResourceService_SetEntityResourceManifestHandler
+    alias:
+    - IGameResourceService::SetEntityResourceManifestHandler
+  - name: CNetworkSerializerBindingBuildFilter_GetFieldPriority
+    alias:
+    - CNetworkSerializerBindingBuildFilter::GetFieldPriority
+  - name: CEntitySystem_FindComponentTypeByName
+    alias:
+    - CEntitySystem::FindComponentTypeByName
+- name: networksystem
+  symbols:
+  - name: INetworkMessages_GetFieldChangeCallbackOrderCount
+    alias:
+    - INetworkMessages::GetFieldChangeCallbackOrderCount
+  - name: INetworkMessages_GetFieldChangeCallbackPriorities
+    alias:
+    - INetworkMessages::GetFieldChangeCallbackPriorities

--- a/gamesymbols/14174b.metadata.yaml
+++ b/gamesymbols/14174b.metadata.yaml
@@ -1,0 +1,3734 @@
+modules:
+- name: scenesystem
+  symbols:
+  - name: ISceneSystem_GetWorldsInfo
+    alias:
+    - ISceneSystem::GetWorldsInfo
+  - name: ISceneWorld_GetObjectsInfo
+    alias:
+    - ISceneWorld::GetObjectsInfo
+  - name: ISceneWorld_GetWorldName
+    alias:
+    - ISceneWorld::GetWorldName
+  - name: ISceneSystem_GetObjectBounds
+    alias:
+    - ISceneSystem::GetObjectBounds
+  - name: ISceneSystem_GetObjectClassName
+    alias:
+    - ISceneSystem::GetObjectClassName
+  - name: CSceneObject_pDesc
+    alias:
+    - CSceneObject::pDesc
+  - name: CSceneObject_nFlags
+    alias:
+    - CSceneObject::nFlags
+  - name: CSceneObject_fOriginX
+    alias:
+    - CSceneObject::fOriginX
+  - name: CSceneObject_fOriginY
+    alias:
+    - CSceneObject::fOriginY
+  - name: CSceneObject_fOriginZ
+    alias:
+    - CSceneObject::fOriginZ
+  - name: CSceneObject_nClassIndex
+    alias:
+    - CSceneObject::nClassIndex
+- name: networksystem
+  symbols:
+  - name: CNetworkMessages_RegisterNetworkCategory
+    alias:
+    - CNetworkMessages::RegisterNetworkCategory
+  - name: CNetworkMessages_AssociateNetMessageWithChannelCategoryAbstract
+    alias:
+    - CNetworkMessages::AssociateNetMessageWithChannelCategoryAbstract
+  - name: CNetworkMessages_FindOrCreateNetMessage
+    alias:
+    - CNetworkMessages::FindOrCreateNetMessage
+  - name: CNetworkMessages_SerializeInternal
+    alias:
+    - CNetworkMessages::SerializeInternal
+  - name: CNetworkMessages_UnserializeMessageInternal
+    alias:
+    - CNetworkMessages::UnserializeMessageInternal
+  - name: CNetworkMessages_SerializeMessageInternal
+    alias:
+    - CNetworkMessages::SerializeMessageInternal
+  - name: CNetworkMessages_UnserializeFromStream
+    alias:
+    - CNetworkMessages::UnserializeFromStream
+  - name: CNetworkMessages_AllocateAndCopyConstructNetMessageAbstract
+    alias:
+    - CNetworkMessages::AllocateAndCopyConstructNetMessageAbstract
+  - name: CNetworkMessages_DeallocateNetMessageAbstract
+    alias:
+    - CNetworkMessages::DeallocateNetMessageAbstract
+  - name: CNetworkMessages_RegisterNetworkFieldSerializer
+    alias:
+    - CNetworkMessages::RegisterNetworkFieldSerializer
+  - name: CNetworkMessages_RegisterNetworkArrayFieldSerializer
+    alias:
+    - CNetworkMessages::RegisterNetworkArrayFieldSerializer
+  - name: CNetworkMessages_AssociateNetMessageGroupIdWithChannelCategory
+    alias:
+    - CNetworkMessages::AssociateNetMessageGroupIdWithChannelCategory
+  - name: CNetworkMessages_RegisterNetworkFieldChangeCallbackInternal
+    alias:
+    - CNetworkMessages::RegisterNetworkFieldChangeCallbackInternal
+  - name: CNetworkMessages_AllowAdditionalMessageRegistration
+    alias:
+    - CNetworkMessages::AllowAdditionalMessageRegistration
+  - name: CNetworkMessages_IsAdditionalMessageRegistrationAllowed
+    alias:
+    - CNetworkMessages::IsAdditionalMessageRegistrationAllowed
+  - name: CNetworkMessages_RegisterFieldChangeCallbackPriority
+    alias:
+    - CNetworkMessages::RegisterFieldChangeCallbackPriority
+  - name: CNetworkMessages_ComputeOrderForPriority
+    alias:
+    - CNetworkMessages::ComputeOrderForPriority
+  - name: CNetworkMessages_dtor
+    alias:
+    - CNetworkMessages::~CNetworkMessages
+  - name: CNetworkMessages_GetIsForServer
+    alias:
+    - CNetworkMessages::GetIsForServer
+  - name: CNetworkMessages_GetNetworkSerializationContextData
+    alias:
+    - CNetworkMessages::GetNetworkSerializationContextData
+  - name: CNetChan_ParseMessagesDemoInternal
+    alias:
+    - CNetChan::ParseMessagesDemoInternal
+  - name: CNetChan_ParseNetMessageShowFilter
+    alias:
+    - CNetChan::ParseNetMessageShowFilter
+  - name: CNetworkMessages_FindNetworkMessagePartial
+    alias:
+    - CNetworkMessages::FindNetworkMessagePartial
+  - name: CNetworkMessages_FindNetworkMessage
+    alias:
+    - CNetworkMessages::FindNetworkMessage
+  - name: CNetworkMessages_FindNetworkGroup
+    alias:
+    - CNetworkMessages::FindNetworkGroup
+  - name: CNetworkSystem_SendNetworkStats
+    alias:
+    - CNetworkSystem::SendNetworkStats
+  - name: CNetworkMessages_GetNetworkGroupCount
+    alias:
+    - CNetworkMessages::GetNetworkGroupCount
+  - name: CNetworkMessages_GetNetworkGroupName
+    alias:
+    - CNetworkMessages::GetNetworkGroupName
+  - name: CNetworkMessages_GetNetworkGroupColor
+    alias:
+    - CNetworkMessages::GetNetworkGroupColor
+  - name: CNetworkMessages_ConfirmAllMessageHandlersInstalled
+    alias:
+    - CNetworkMessages::ConfirmAllMessageHandlersInstalled
+- name: engine
+  symbols:
+  - name: CServerSideClient_ctor
+    alias:
+    - CServerSideClient::CServerSideClient
+  - name: CNetworkGameServer_CreateNewClient
+    alias:
+    - CNetworkGameServer::CreateNewClient
+  - name: CServerSideClient_IsHearingClient
+    alias:
+    - IsHearingClient
+  - name: CServerSideClient_ExecuteStringCommand
+    alias:
+    - CServerSideClient::ExecuteStringCommand
+  - name: CServerSideClient_ActivatePlayer
+    alias:
+    - CServerSideClient::ActivatePlayer
+  - name: ISource2GameClients_ClientSettingsChanged
+    alias:
+    - ISource2GameClients::ClientSettingsChanged
+  - name: CGameResourceService_BuildResourceManifest
+    alias:
+    - CGameResourceService::BuildResourceManifest
+    - BuildResourceManifest
+  - name: CGameResourceService_m_pEntitySystem
+    alias:
+    - GameEntitySystem
+  - name: CGameResourceService_LoadGameResourceManifestNamed
+    alias:
+    - CGameResourceService::LoadGameResourceManifestNamed
+  - name: CGameResourceService_LoadGameResourceManifestGroup
+    alias:
+    - CGameResourceService::LoadGameResourceManifestGroup
+  - name: CGameResourceService_GetResourceManifestDebugName
+    alias:
+    - CGameResourceService::GetResourceManifestDebugName
+  - name: CGameResourceService_PrecacheEntitiesAndConfirmResourcesAreLoaded
+    alias:
+    - CGameResourceService::PrecacheEntitiesAndConfirmResourcesAreLoaded
+  - name: CGameResourceService_LoadGameResourceManifest_IEntityResourceManifest
+    alias:
+    - CGameResourceService::LoadGameResourceManifest
+  - name: CGameResourceService_DescribeContents
+    alias:
+    - CGameResourceService::DescribeContents
+  - name: CGameResourceService_AppendToGameResourceManifest
+    alias:
+    - CGameResourceService::AppendToGameResourceManifest
+  - name: CGameResourceService_RegisterEventMap
+    alias:
+    - CGameResourceService::RegisterEventMap
+  - name: IEntityResourceManifestBuilder_BuildResourceManifest_ManifestNameOrGroupName
+    alias:
+    - IEntityResourceManifestBuilder::BuildResourceManifest
+  - name: CServerSideClientBase_ClientPrintf
+    alias:
+    - CServerSideClientBase::ClientPrintf
+    - ClientPrintf
+  - name: CNetworkGameServer_ClientList
+    alias:
+    - CNetworkGameServer::ClientList
+  - name: CNetworkGameServerBase_SendPeerList
+    alias:
+    - CNetworkGameServerBase::SendPeerList
+  - name: CNetworkGameServerBase_ConnectClient
+    alias:
+    - CNetworkGameServerBase::ConnectClient
+  - name: CNetworkGameServerBase_CheckPassword
+    alias:
+    - CNetworkGameServerBase::CheckPassword
+  - name: CNetworkGameServerBase_GetClientConnectionType
+    alias:
+    - CNetworkGameServerBase::GetClientConnectionType
+  - name: CNetworkGameServerBase_ServerSimulateInternal
+    alias:
+    - CNetworkGameServerBase::ServerSimulateInternal
+  - name: CNetworkGameServerBase_ServerSimulate
+    alias:
+    - CNetworkGameServerBase::ServerSimulate
+  - name: CNetworkGameServerBase_ServerPollNetworking
+    alias:
+    - CNetworkGameServerBase::ServerPollNetworking
+  - name: INetworkGameServer_IsChangelevelPending
+    alias:
+    - INetworkGameServer::IsChangelevelPending
+  - name: CNetworkGameServerBase_IsChangelevelPending
+    alias:
+    - CNetworkGameServerBase::IsChangelevelPending
+  - name: CNetworkGameServerBase_BroadcastMessage
+    alias:
+    - CNetworkGameServerBase::BroadcastMessage
+  - name: CNetworkGameServerBase_BroadcastPrintf
+    alias:
+    - CNetworkGameServerBase::BroadcastPrintf
+  - name: CNetworkGameServerBase_BroadcastEntityVoice
+    alias:
+    - CNetworkGameServerBase::BroadcastEntityVoice
+  - name: CNetworkGameServerBase_WriteDeltaEntities
+    alias:
+    - CNetworkGameServerBase::WriteDeltaEntities
+  - name: CNetworkGameServerBase_ReserveServerForQueuedGame
+    alias:
+    - CNetworkGameServerBase::ReserveServerForQueuedGame
+  - name: CNetworkGameServerBase_FinishChangeLevel
+    alias:
+    - CNetworkGameServerBase::FinishChangeLevel
+  - name: CNetworkGameServerBase_StartChangeLevel
+    alias:
+    - CNetworkGameServerBase::StartChangeLevel
+  - name: CNetworkGameServerBase_SetServerState
+    alias:
+    - CNetworkGameServerBase::SetServerState
+  - name: CNetworkGameServer_GetFreeClient
+    alias:
+    - CNetworkGameServer::GetFreeClient
+    - GetFreeClient
+  - name: CNetworkGameServerBase_CreateFakeClient
+    alias:
+    - CNetworkGameServerBase::CreateFakeClient
+  - name: CNetworkGameServerBase_UserInfoChanged
+    alias:
+    - CNetworkGameServerBase::UserInfoChanged
+  - name: CNetworkGameServerBase_GetPlayerNetworkIDString
+    alias:
+    - CNetworkGameServerBase::GetPlayerNetworkIDString
+  - name: CNetworkGameServerBase_StartHLTVMaster
+    alias:
+    - CNetworkGameServerBase::StartHLTVMaster
+  - name: CNetworkGameServerBase_RegisterLoadingSpawnGroups
+    alias:
+    - CNetworkGameServerBase::RegisterLoadingSpawnGroups
+  - name: CNetworkServerSpawnGroupCreatePrerequisites_Init
+    alias:
+    - CNetworkServerSpawnGroupCreatePrerequisites::Init
+  - name: CNetworkGameServerBase_LoadSpawnGroup
+    alias:
+    - CNetworkGameServerBase::LoadSpawnGroup
+  - name: CNetworkGameServerBase_SpawnGroupThink
+    alias:
+    - CNetworkGameServerBase::SpawnGroupThink
+  - name: CNetworkGameServerBase_PrintSpawnGroupStatus
+    alias:
+    - CNetworkGameServerBase::PrintSpawnGroupStatus
+  - name: CNetworkGameServerBase_AsyncUnloadSpawnGroup
+    alias:
+    - CNetworkGameServerBase::AsyncUnloadSpawnGroup
+  - name: CNetworkGameServerBase_AsyncUnloadSpawnGroupInternal
+    alias:
+    - CNetworkGameServerBase::AsyncUnloadSpawnGroupInternal
+  - name: CNetworkGameServer_PrepareForAssetLoad
+    alias:
+    - CNetworkGameServer::PrepareForAssetLoad
+  - name: CNetworkGameServerBase_IsSaveRestoreAllowed
+    alias:
+    - CNetworkGameServerBase::IsSaveRestoreAllowed
+  - name: CNetworkGameServer_IsPausable
+    alias:
+    - CNetworkGameServer::IsPausable
+  - name: CNetworkGameServerBase_Init
+    alias:
+    - CNetworkGameServerBase::Init
+  - name: CNetworkGameServerBase_Shutdown
+    alias:
+    - CNetworkGameServerBase::Shutdown
+  - name: CNetworkGameServerBase_ShutdownInternal
+    alias:
+    - CNetworkGameServerBase::ShutdownInternal
+  - name: CNetworkGameServer_ActivateServer
+    alias:
+    - CNetworkGameServer::ActivateServer
+  - name: CNetworkGameServer_DirectUpdate
+    alias:
+    - CNetworkGameServer::DirectUpdate
+  - name: CNetworkGameServerBase_ReplyChallenge
+    alias:
+    - CNetworkGameServerBase::ReplyChallenge
+  - name: CNetworkGameServerBase_GetChallengeType
+    alias:
+    - CNetworkGameServerBase::GetChallengeType
+  - name: CNetworkGameServer_Init
+    alias:
+    - CNetworkGameServer::Init
+  - name: CNetworkGameServer_Shutdown
+    alias:
+    - CNetworkGameServer::Shutdown
+  - name: ISource2Server_GetAllServerClasses
+    alias:
+    - ISource2Server::GetAllServerClasses
+  - name: CNetworkGameServer_SpawnServer
+    alias:
+    - CNetworkGameServer::SpawnServer
+  - name: CNetworkGameServerBase_GetMaxClients
+    alias:
+    - CNetworkGameServerBase::GetMaxClients
+  - name: CNetworkGameServerBase_GetClassBaseline
+    alias:
+    - CNetworkGameServerBase::GetClassBaseline
+  - name: CSteam3Server_SendUpdatedServerDetails
+    alias:
+    - CSteam3Server::SendUpdatedServerDetails
+  - name: CNetworkGameServerBase_GetMapName
+    alias:
+    - CNetworkGameServerBase::GetMapName
+  - name: CNetworkGameServerBase_GetHostName
+    alias:
+    - CNetworkGameServerBase::GetHostName
+  - name: CNetworkGameServerBase_SetMaxClients
+    alias:
+    - CNetworkGameServerBase::SetMaxClients
+  - name: CNetworkGameServerBase_FillKV3ServerInfo
+    alias:
+    - CNetworkGameServerBase::FillKV3ServerInfo
+  - name: CNetworkGameServerBase_CheckTimeouts
+    alias:
+    - CNetworkGameServerBase::CheckTimeouts
+  - name: CNetworkGameServerBase_IsHLTV
+    alias:
+    - CNetworkGameServerBase::IsHLTV
+  - name: ISource2Server_ShouldTimeoutClient
+    alias:
+    - ISource2Server::ShouldTimeoutClient
+  - name: CNetworkGameServerBase_GetPassword
+    alias:
+    - CNetworkGameServerBase::GetPassword
+  - name: CNetworkGameServerBase_OnKickById
+    alias:
+    - CNetworkGameServerBase::OnKickById
+  - name: CNetworkGameServerBase_OnKickByName
+    alias:
+    - CNetworkGameServerBase::OnKickByName
+  - name: CNetworkGameClient_SendMovePacket
+    alias:
+    - CNetworkGameClient::SendMovePacket
+    - SendMovePacket
+  - name: CNetworkGameClient_SendMove
+    alias:
+    - CNetworkGameClient::SendMove
+    - SendMove
+  - name: INetworkMessages_Serialize
+    alias:
+    - INetworkMessages::Serialize
+  - name: CDemoPlayer_SkipToTick
+    alias:
+    - CDemoPlayer::SkipToTick
+  - name: CDemoPlayer_PlayDemo
+    alias:
+    - CDemoPlayer::PlayDemo
+  - name: CDemoPlayer_StopPlayback
+    alias:
+    - CDemoPlayer::StopPlayback
+  - name: CDemoPlayer_StartPlayback
+    alias:
+    - CDemoPlayer::StartPlayback
+  - name: CDemoPlayer_SetIgnorePacketsForResourceLoading
+    alias:
+    - CDemoPlayer::SetIgnorePacketsForResourceLoading
+  - name: CDemoPlayer_InternalReadPacket
+    alias:
+    - CDemoPlayer::InternalReadPacket
+  - name: CDemoPlayer_Pause
+    alias:
+    - CDemoPlayer::Pause
+  - name: CDemoPlayer_m_bIsPlaying
+    alias:
+    - CDemoPlayer::m_bIsPlaying
+  - name: CDemoPlayer_m_bIsPaused
+    alias:
+    - CDemoPlayer::m_bIsPaused
+  - name: CDemoRecorder_ParseMessage
+    alias:
+    - CDemoRecorder::ParseMessage
+  - name: CDemoRecorder_WriteSpawnGroups
+    alias:
+    - CDemoRecorder::WriteSpawnGroups
+  - name: CHLTVDemoRecorder_WriteFrameImmediate
+    alias:
+    - CHLTVDemoRecorder::WriteFrameImmediate
+  - name: INetworkMessages_SerializeAbstract
+    alias:
+    - INetworkMessages::SerializeAbstract
+  - name: INetworkMessages_GetNetMessageInfo
+    alias:
+    - INetworkMessages::GetNetMessageInfo
+  - name: INetworkMessages_FindNetworkMessageById
+    alias:
+    - INetworkMessages::FindNetworkMessageById
+  - name: CNetChan_ProcessMessages
+    alias:
+    - CNetChan::ProcessMessages
+  - name: CNetChan_ParseMessagesDemo
+    alias:
+    - CNetChan::ParseMessagesDemo
+  - name: CNetworkGameClient_ProcessPacketEntitiesInternal
+    alias:
+    - CNetworkGameClient::ProcessPacketEntitiesInternal
+  - name: CNetworkGameClient_ProcessPacketEntities
+    alias:
+    - CNetworkGameClient::ProcessPacketEntities
+    - ProcessPacketEntities
+  - name: CNetworkGameClient_RecordEntityBandwidth
+    alias:
+    - CNetworkGameClient::RecordEntityBandwidth
+    - RecordEntityBandwidth
+  - name: CNetworkGameClient_PrintNetStats
+    alias:
+    - CNetworkGameClient::PrintNetStats
+  - name: CMsgSource2NetworkFlowQuality_PrintStats
+    alias:
+    - CMsgSource2NetworkFlowQuality::PrintStats
+  - name: CNetworkGameClient_CreateMove
+    alias:
+    - CNetworkGameClient::CreateMove
+  - name: ISource2Client_CreateMove
+    alias:
+    - ISource2Client::CreateMove
+  - name: CNetworkGameClient_SetSignonState
+    alias:
+    - CNetworkGameClient::SetSignonState
+  - name: CNetworkGameClient_ProcessReadPacketEntitiesWorkItems
+    alias:
+    - CNetworkGameClient::ProcessReadPacketEntitiesWorkItems
+  - name: CNetworkGameClient_OnPreserveEntity
+    alias:
+    - CNetworkGameClient::OnPreserveEntity
+  - name: CNetworkGameClient_GetClientNetworkable
+    alias:
+    - CNetworkGameClient::GetClientNetworkable
+  - name: CNetworkGameClient_CopyNewEntity
+    alias:
+    - CNetworkGameClient::CopyNewEntity
+  - name: CNetworkGameClient_CopyExistingEntity
+    alias:
+    - CNetworkGameClient::CopyExistingEntity
+  - name: CNetworkGameClient_OnReceivedUncompressedPacket
+    alias:
+    - CNetworkGameClient::OnReceivedUncompressedPacket
+  - name: CNetworkGameClient_Clear
+    alias:
+    - CNetworkGameClient::Clear
+  - name: CNetworkGameClient_DisconnectGame
+    alias:
+    - CNetworkGameClient::DisconnectGame
+  - name: INetworkMessages_FindNetworkGroup
+    alias:
+    - INetworkMessages::FindNetworkGroup
+  - name: INetworkClientService_IsActive
+    alias:
+    - INetworkClientService::IsActive
+  - name: INetworkClientService_IsConnected
+    alias:
+    - INetworkClientService::IsConnected
+  - name: INetworkClientService_IsPutInServer
+    alias:
+    - INetworkClientService::IsPutInServer
+  - name: INetworkClientService_IsConnecting
+    alias:
+    - INetworkClientService::IsConnecting
+  - name: CInputService_ProcessConVar
+    alias:
+    - CInputService::ProcessConVar
+  - name: CInputService_ProcessCommand
+    alias:
+    - CInputService::ProcessCommand
+  - name: CInputService_IsClientOnlyCommandAllowed
+    alias:
+    - CInputService::IsClientOnlyCommandAllowed
+  - name: CServerSideClientBase_SetConVarUserInfo
+    alias:
+    - CServerSideClientBase::SetConVarUserInfo
+  - name: CNetworkClientService_RegisterEventMapInternal
+    alias:
+    - CNetworkClientService::RegisterEventMapInternal
+  - name: CNetworkClientService_RegisterEventMap
+    alias:
+    - CNetworkClientService::RegisterEventMap
+  - name: CNetworkClientService_OnClientAdvanceTick
+    alias:
+    - CNetworkClientService::OnClientAdvanceTick
+  - name: CNetworkClientService_OnClientProcessGameInput
+    alias:
+    - CNetworkClientService::OnClientProcessGameInput
+  - name: ISource2Client_ProcessGameInput
+    alias:
+    - ISource2Client::ProcessGameInput
+  - name: CNetworkClientService_OnClientPollNetworking
+    alias:
+    - CNetworkClientService::OnClientPollNetworking
+  - name: CNetworkClientService_OnClientProcessNetworking
+    alias:
+    - CNetworkClientService::OnClientProcessNetworking
+  - name: CNetworkClientService_OnClientSimulate
+    alias:
+    - CNetworkClientService::OnClientSimulate
+  - name: CNetworkClientService_OnClientPauseSimulate
+    alias:
+    - CNetworkClientService::OnClientPauseSimulate
+  - name: CNetworkClientService_OnClientFrameSimulate
+    alias:
+    - CNetworkClientService::OnClientFrameSimulate
+  - name: CNetworkClientService_OnSimpleLoopFrameUpdate
+    alias:
+    - CNetworkClientService::OnSimpleLoopFrameUpdate
+  - name: CNetworkClientService_OnFrameBoundary
+    alias:
+    - CNetworkClientService::OnFrameBoundary
+  - name: CNetworkClientService_OnServerPostSimulate
+    alias:
+    - CNetworkClientService::OnServerPostSimulate
+  - name: CNetworkClientService_OnServerBeginAsyncPostTickWork
+    alias:
+    - CNetworkClientService::OnServerBeginAsyncPostTickWork
+  - name: CNetworkClientService_ReceivedServerInfo
+    alias:
+    - CNetworkClientService::ReceivedServerInfo
+  - name: CNetworkClientService_SplitScreenConnect
+    alias:
+    - CNetworkClientService::SplitScreenConnect
+  - name: CNetworkClientService_SendNetMessage
+    alias:
+    - CNetworkClientService::SendNetMessage
+  - name: CNetworkClientService_SendStringCmd
+    alias:
+    - CNetworkClientService::SendStringCmd
+  - name: CNetworkClientService_StartChangeLevel
+    alias:
+    - CNetworkClientService::StartChangeLevel
+  - name: CNetworkClientService_FinishChangeLevel
+    alias:
+    - CNetworkClientService::FinishChangeLevel
+  - name: CNetworkClientService_PrintConnectionStatus
+    alias:
+    - CNetworkClientService::PrintConnectionStatus
+  - name: CNetworkClientService_OnStatus
+    alias:
+    - CNetworkClientService::OnStatus
+  - name: CNetworkClientService_ServerCmd
+    alias:
+    - CNetworkClientService::ServerCmd
+  - name: CNetworkClientService_GetDisconnectReason
+    alias:
+    - CNetworkClientService::GetDisconnectReason
+  - name: CNetworkClientService_PrintSpawnGroupStatus
+    alias:
+    - CNetworkClientService::PrintSpawnGroupStatus
+  - name: CNetworkClientService_IsActive
+    alias:
+    - CNetworkClientService::IsActive
+  - name: CNetworkClientService_IsConnected
+    alias:
+    - CNetworkClientService::IsConnected
+  - name: CNetworkClientService_IsPutInServer
+    alias:
+    - CNetworkClientService::IsPutInServer
+  - name: CNetworkClientService_IsConnecting
+    alias:
+    - CNetworkClientService::IsConnecting
+  - name: CEngineSoundServices_ShouldSuppressNonUISounds
+    alias:
+    - CEngineSoundServices::ShouldSuppressNonUISounds
+  - name: CNetworkClientService_ClockDriftAdjustFrameTime
+    alias:
+    - CNetworkClientService::ClockDriftAdjustFrameTime
+  - name: CNetworkClientService_Init
+    alias:
+    - CNetworkClientService::Init
+  - name: CNetworkClientService_Shutdown
+    alias:
+    - CNetworkClientService::Shutdown
+  - name: CNetworkClientService_DisconnectGameNow
+    alias:
+    - CNetworkClientService::DisconnectGameNow
+  - name: CGameClientConnectPrerequisite_ctor
+    alias:
+    - CGameClientConnectPrerequisite::CGameClientConnectPrerequisite
+  - name: CNetworkClientSpawnGroupCreatePrerequisites_GetStatus
+    alias:
+    - CNetworkClientSpawnGroupCreatePrerequisites::GetStatus
+  - name: CWaitForInitialSpawnGroupsPrerequisite_GetStatus
+    alias:
+    - CWaitForInitialSpawnGroupsPrerequisite::GetStatus
+  - name: INetworkGameServer_GetSpawnGroupLoadingStatus
+    alias:
+    - INetworkGameServer::GetSpawnGroupLoadingStatus
+  - name: CNetworkClientService_AddClientPrerequisites
+    alias:
+    - CNetworkClientService::AddClientPrerequisites
+  - name: CNetworkClientService_AllocateRemoteConnectionClient
+    alias:
+    - CNetworkClientService::AllocateRemoteConnectionClient
+  - name: CNetworkServerService_Init
+    alias:
+    - CNetworkServerService::Init
+  - name: CNetworkServerService_StartupServer
+    alias:
+    - CNetworkServerService::StartupServer
+  - name: CNetworkServerService_RegisterEventMapInternal
+    alias:
+    - CNetworkServerService::RegisterEventMapInternal
+  - name: CNetworkServerService_OnServerAdvanceTick
+    alias:
+    - CNetworkServerService::OnServerAdvanceTick
+  - name: CNetworkServerService_OnServerPollNetworking
+    alias:
+    - CNetworkServerService::OnServerPollNetworking
+  - name: CNetworkServerService_OnServerProcessNetworking
+    alias:
+    - CNetworkServerService::OnServerProcessNetworking
+  - name: CNetworkServerService_OnServerBeginSimulate
+    alias:
+    - CNetworkServerService::OnServerBeginSimulate
+  - name: CNetworkServerService_OnServerEndSimulate
+    alias:
+    - CNetworkServerService::OnServerEndSimulate
+  - name: CNetworkServerService_OnServerPostSimulate
+    alias:
+    - CNetworkServerService::OnServerPostSimulate
+  - name: CNetworkServerService_OnServerPostAdvanceTick
+    alias:
+    - CNetworkServerService::OnServerPostAdvanceTick
+  - name: CNetworkServerService_OnFrameBoundary
+    alias:
+    - CNetworkServerService::OnFrameBoundary
+  - name: CNetworkServerService_OnClientPollNetworking
+    alias:
+    - CNetworkServerService::OnClientPollNetworking
+  - name: CNetworkServerService_OnSimpleLoopFrameUpdate
+    alias:
+    - CNetworkServerService::OnSimpleLoopFrameUpdate
+  - name: CNetworkServerService_OnKickByIdHLTV
+    alias:
+    - CNetworkServerService::OnKickByIdHLTV
+  - name: CNetworkServerService_DisconnectGameNow
+    alias:
+    - CNetworkServerService::DisconnectGameNow
+  - name: INetworkGameServer_GetMaxClients
+    alias:
+    - INetworkGameServer::GetMaxClients
+  - name: INetworkGameServer_PreWorldUpdate
+    alias:
+    - INetworkGameServer::PreWorldUpdate
+  - name: CNetworkGameServer_PreWorldUpdate
+    alias:
+    - CNetworkGameServer::PreWorldUpdate
+  - name: INetworkGameServer_ServerEndSimulate
+    alias:
+    - INetworkGameServer::ServerEndSimulate
+  - name: CNetworkGameServerBase_ServerEndSimulate
+    alias:
+    - CNetworkGameServerBase::ServerEndSimulate
+  - name: CNetworkGameServerBase_CalculateCPUUsage
+    alias:
+    - CNetworkGameServerBase::CalculateCPUUsage
+  - name: INetworkGameServer_ServerPostSimulate
+    alias:
+    - INetworkGameServer::ServerPostSimulate
+  - name: CNetworkGameServerBase_ServerPostSimulate
+    alias:
+    - CNetworkGameServerBase::ServerPostSimulate
+  - name: CNetworkGameServer_ServerPostSimulate
+    alias:
+    - CNetworkGameServer::ServerPostSimulate
+  - name: INetworkGameServer_ServerAdvanceTick
+    alias:
+    - INetworkGameServer::ServerAdvanceTick
+  - name: CNetworkGameServerBase_ServerAdvanceTick
+    alias:
+    - CNetworkGameServerBase::ServerAdvanceTick
+  - name: INetworkGameServer_GetTime
+    alias:
+    - INetworkGameServer::GetTime
+  - name: INetworkGameServer_ServerProcessNetworking
+    alias:
+    - INetworkGameServer::ServerProcessNetworking
+  - name: CNetworkGameServerBase_ServerProcessNetworking
+    alias:
+    - CNetworkGameServerBase::ServerProcessNetworking
+  - name: INetworkGameServer_GetTimescale
+    alias:
+    - INetworkGameServer::GetTimescale
+  - name: CNetworkGameServerBase_GetTimescale
+    alias:
+    - CNetworkGameServerBase::GetTimescale
+  - name: INetworkGameServer_GetServerNetworkAddress
+    alias:
+    - INetworkGameServer::GetServerNetworkAddress
+  - name: ISource2Server_PreWorldUpdate
+    alias:
+    - ISource2Server::PreWorldUpdate
+  - name: ISource2Server_UpdateWhenNotInGame
+    alias:
+    - ISource2Server::UpdateWhenNotInGame
+  - name: INetworkMessages_SetIsForServer
+    alias:
+    - INetworkMessages::SetIsForServer
+  - name: CRenderingWorldSession_FindOrCreateWorldSession
+    alias:
+    - CRenderingWorldSession::FindOrCreateWorldSession
+  - name: CRenderingWorldSession_GetEntityLumpForTemplate
+    alias:
+    - CRenderingWorldSession::GetEntityLumpForTemplate
+  - name: CEngineClient_GetEntityLumpForTemplate
+    alias:
+    - CEngineClient::GetEntityLumpForTemplate
+  - name: CEngineClient_FindOrCreateWorldSession
+    alias:
+    - CEngineClient::FindOrCreateWorldSession
+  - name: CEngineClient_GetStatsAppID
+    alias:
+    - CEngineClient::GetStatsAppID
+  - name: CEngineClient_DumpNetStats
+    alias:
+    - CEngineClient::DumpNetStats
+  - name: CEngineClient_ExecuteClientCmd
+    alias:
+    - CEngineClient::ExecuteClientCmd
+  - name: CEngineClient_IsPlayingDemo
+    alias:
+    - CEngineClient::IsPlayingDemo
+  - name: CInputService_ProcessCommandBuffer
+    alias:
+    - CInputService::ProcessCommandBuffer
+  - name: CInputService_ProcessCommandBuffers
+    alias:
+    - CInputService::ProcessCommandBuffers
+  - name: CInputService_HandleAnalogValueChange
+    alias:
+    - CInputService::HandleAnalogValueChange
+  - name: CInputService_HandleInputEvent
+    alias:
+    - CInputService::HandleInputEvent
+  - name: CEngineClient_ClientCmd_Unrestricted
+    alias:
+    - CEngineClient::ClientCmd_Unrestricted
+  - name: INetworkGameClient_SendStringCmd
+    alias:
+    - INetworkGameClient::SendStringCmd
+  - name: CEngineServer_DumpNetStats
+    alias:
+    - CEngineServer::DumpNetStats
+  - name: CEngineServer_ClientPrintf
+    alias:
+    - CEngineServer::ClientPrintf
+  - name: CEngineServer_GetFrameTimeAmnesty
+    alias:
+    - CEngineServer::GetFrameTimeAmnesty
+  - name: CEngineServer_ShowFrameTimeReport
+    alias:
+    - CEngineServer::ShowFrameTimeReport
+  - name: CEngineServer_SetFrameTimeAmnesty
+    alias:
+    - CEngineServer::SetFrameTimeAmnesty
+  - name: CEngineServer_GetSteamUniverse
+    alias:
+    - CEngineServer::GetSteamUniverse
+  - name: CEngineServer_ChangeLevel
+    alias:
+    - CEngineServer::ChangeLevel
+  - name: CMapListService_IsMapValid
+    alias:
+    - CMapListService::IsMapValid
+    - IMapListService::IsMapValid
+  - name: CEngineServer_IsMapValid
+    alias:
+    - CEngineServer::IsMapValid
+  - name: CEngineServer_PrecacheGeneric
+    alias:
+    - CEngineServer::PrecacheGeneric
+  - name: CEngineServer_ClientCommand
+    alias:
+    - CEngineServer::ClientCommand
+  - name: CEngineServer_GetClientConVarValue
+    alias:
+    - CEngineServer::GetClientConVarValue
+  - name: CEngineServer_SetFakeClientConVarValue
+    alias:
+    - CEngineServer::SetFakeClientConVarValue
+  - name: CEngineServer_CreateFakeClient
+    alias:
+    - CEngineServer::CreateFakeClient
+  - name: CEngineServer_GetPlayerInfo
+    alias:
+    - CEngineServer::GetPlayerInfo
+  - name: CEngineServer_ClientCommandKeyValues
+    alias:
+    - CEngineServer::ClientCommandKeyValues
+  - name: CLog_Print
+    alias:
+    - CLog::Print
+  - name: CEngineServer_LogPrint
+    alias:
+    - CEngineServer::LogPrint
+  - name: CEngineServer_KickClient
+    alias:
+    - CEngineServer::KickClient
+  - name: CEngineServer_IsDedicatedServer
+    alias:
+    - CEngineServer::IsDedicatedServer
+  - name: CEngineServer_GetServerGlobals
+    alias:
+    - CEngineServer::GetServerGlobals
+  - name: CEngineServer_GetAchievementMgr
+    alias:
+    - CEngineServer::GetAchievementMgr
+  - name: CEngineServer_IsLogEnabled
+    alias:
+    - CEngineServer::IsLogEnabled
+  - name: CEngineServer_ServerCommand
+    alias:
+    - CEngineServer::ServerCommand
+  - name: CLoopTypeClientSimple_ActivateEngineServices
+    alias:
+    - CLoopTypeClientServer::ActivateEngineServices
+  - name: CLoopTypeClientServer_LoopTypeInit
+    alias:
+    - CLoopTypeClientServer::LoopTypeInit
+  - name: CLoopTypeClientServer_AdvanceTime
+    alias:
+    - CLoopTypeClientServer::AdvanceTime
+  - name: CLoopTypeClientServer_Update
+    alias:
+    - CLoopTypeClientServer::Update
+  - name: CLoopTypeClientServer_ActivateLoop
+    alias:
+    - CLoopTypeClientServer::ActivateLoop
+  - name: ISource2Server_GetActiveWorldName
+    alias:
+    - ISource2Server::GetActiveWorldName
+  - name: CLoopTypeClientServer_AllocateLoopMode
+    alias:
+    - CLoopTypeClientServer::AllocateLoopMode
+  - name: CLoopTypeClientServer_WritePerfStats
+    alias:
+    - CLoopTypeClientServer::WritePerfStats
+  - name: CLoopTypeClientServer_DeactivateLoop
+    alias:
+    - CLoopTypeClientServer::DeactivateLoop
+  - name: CLoopTypeClientServer_OutputListeners
+    alias:
+    - CLoopTypeClientServer::OutputListeners
+  - name: CLoopTypeSimple_FrameUpdate
+    alias:
+    - CLoopTypeSimple::FrameUpdate
+  - name: CLoopTypeClientServerService_OnLoopActivate
+    alias:
+    - CLoopTypeClientServerService::OnLoopActivate
+  - name: CLoopTypeSimpleService_OnLoopActivate
+    alias:
+    - CLoopTypeSimpleService::OnLoopActivate
+  - name: CLoopTypeClientServerService_HandleInputEvent
+    alias:
+    - CLoopTypeClientServerService::HandleInputEvent
+  - name: ILoopMode_HandleInputEvent
+    alias:
+    - ILoopMode::HandleInputEvent
+  - name: ILoopType_AddEngineService
+    alias:
+    - ILoopType::AddEngineService
+  - name: CLoopTypeBase_DeallocateLoopMode
+    alias:
+    - CLoopTypeBase::DeallocateLoopMode
+  - name: CLoopTypeBase_EngineLoop
+    alias:
+    - CLoopTypeBase::EngineLoop
+  - name: CLoopTypeBase_FrameUpdate
+    alias:
+    - CLoopTypeBase::FrameUpdate
+  - name: CLoopTypeBase_ActivateLoop
+    alias:
+    - CLoopTypeBase::ActivateLoop
+  - name: CLoopTypeBase_AllocateLoopMode
+    alias:
+    - CLoopTypeBase::AllocateLoopMode
+  - name: CLoopTypeBase_DeactivateLoop
+    alias:
+    - CLoopTypeBase::DeactivateLoop
+  - name: CLoopTypeBase_LoopTypeInit
+    alias:
+    - CLoopTypeBase::LoopTypeInit
+  - name: CLoopTypeBase_LoopTypeShutdown
+    alias:
+    - CLoopTypeBase::LoopTypeShutdown
+  - name: CLoopTypeBase_GetClientServerMode
+    alias:
+    - CLoopTypeBase::GetClientServerMode
+  - name: CLoopTypeBase_GetImplType
+    alias:
+    - CLoopTypeBase::GetImplType
+  - name: CLoopTypeBase_AddDependentServices
+    alias:
+    - CLoopTypeBase::AddDependentServices
+  - name: CLoopTypeBase_GenerateServiceDependencies
+    alias:
+    - CLoopTypeBase::GenerateServiceDependencies
+  - name: CLoopTypeBase_GenerateSecondaryDependencies
+    alias:
+    - CLoopTypeBase::GenerateSecondaryDependencies
+  - name: CLoopTypeBase_LoadDependentServices
+    alias:
+    - CLoopTypeBase::LoadDependentServices
+  - name: IEngineService_GetServiceDependencies
+    alias:
+    - IEngineService::GetServiceDependencies
+  - name: IEngineService_GetName
+    alias:
+    - IEngineService::GetName
+  - name: ILoopModeFactory_GetLoopModeType
+    alias:
+    - ILoopModeFactory::GetLoopModeType
+  - name: ILoopModeFactory_Shutdown
+    alias:
+    - ILoopModeFactory::Shutdown
+  - name: CEngineServiceMgr_RegisterEngineService
+    alias:
+    - CEngineServiceMgr::RegisterEngineService
+  - name: CEngineServiceMgr_RegisterLoopMode
+    alias:
+    - CEngineServiceMgr::RegisterLoopMode
+  - name: CEngineServiceMgr_UnregisterLoopMode
+    alias:
+    - CEngineServiceMgr::UnregisterLoopMode
+  - name: CEngineServiceMgr_UnregisterEngineService
+    alias:
+    - CEngineServiceMgr::UnregisterEngineService
+  - name: CEngineServiceMgr_SwitchToLoop
+    alias:
+    - CEngineServiceMgr::SwitchToLoop
+  - name: CEngineServiceMgr_PrintStatus
+    alias:
+    - CEngineServiceMgr::PrintStatus
+  - name: CEngineServiceMgr__MainLoop
+    alias:
+    - CEngineServiceMgr::_MainLoop
+  - name: CEngineServiceMgr_DeactivateLoop
+    alias:
+    - CEngineServiceMgr::DeactivateLoop
+  - name: CEngineServiceMgr_Shutdown
+    alias:
+    - CEngineServiceMgr::Shutdown
+  - name: CEngineServiceMgr_GetActiveLoopClientServerMode
+    alias:
+    - CEngineServiceMgr::GetActiveLoopClientServerMode
+  - name: CEngineServiceMgr_GetEventDispatcher
+    alias:
+    - CEngineServiceMgr::GetEventDispatcher
+  - name: CEngineGameUI_Shutdown
+    alias:
+    - CEngineGameUI::Shutdown
+  - name: IAppSystem_Shutdown
+    alias:
+    - IAppSystem::Shutdown
+  - name: CSplitScreenService_AddSplitScreenUser
+    alias:
+    - CSplitScreenService::AddSplitScreenUser
+  - name: CSplitScreenService_LoadUserConfiguration
+    alias:
+    - CSplitScreenService::LoadUserConfiguration
+  - name: CHLTVClient_ProcessSetConVar
+    alias:
+    - CHLTVClient::ProcessSetConVar
+  - name: CHLTVBroadcast_RecordSnapshot
+    alias:
+    - CHLTVBroadcast::RecordSnapshot
+  - name: CServerSideClientBase_SendServerInfo
+    alias:
+    - CServerSideClientBase::SendServerInfo
+  - name: CNetworkGameServerBase_FillServerInfo
+    alias:
+    - CNetworkGameServerBase::FillServerInfo
+  - name: CServerSideClientBase_ProcessTick
+    alias:
+    - CServerSideClientBase::ProcessTick
+  - name: CServerSideClientBase_ProcessStringCmd
+    alias:
+    - CServerSideClientBase::ProcessStringCmd
+  - name: CServerSideClientBase_MarkSpawnGroupLoadCompleted
+    alias:
+    - CServerSideClientBase::MarkSpawnGroupLoadCompleted
+  - name: CServerSideClientBase_ProcessSpawnGroup_LoadCompleted
+    alias:
+    - CServerSideClientBase::ProcessSpawnGroup_LoadCompleted
+  - name: CServerSideClientBase_ProcessClientInfo
+    alias:
+    - CServerSideClientBase::ProcessClientInfo
+  - name: CServerSideClientBase_ProcessBaselineAck
+    alias:
+    - CServerSideClientBase::ProcessBaselineAck
+  - name: CServerSideClientBase_ProcessSplitPlayerConnectInternal
+    alias:
+    - CServerSideClientBase::ProcessSplitPlayerConnectInternal
+  - name: CServerSideClientBase_ProcessSplitPlayerConnect
+    alias:
+    - CServerSideClientBase::ProcessSplitPlayerConnect
+  - name: CServerSideClientBase_GetUserIDString
+    alias:
+    - CServerSideClientBase::GetUserIDString
+  - name: CServerSideClientBase_GetNetworkIDString
+    alias:
+    - CServerSideClientBase::GetNetworkIDString
+  - name: CServerSideClientBase_dtor
+    alias:
+    - CServerSideClientBase::~CServerSideClientBase
+  - name: CServerSideClientBase_Connect
+    alias:
+    - CServerSideClientBase::Connect
+  - name: CServerSideClientBase_GetPlayerInfo
+    alias:
+    - CServerSideClientBase::GetPlayerInfo
+  - name: CNetworkGameServer_GetPlayerNetworkIDString
+    alias:
+    - CNetworkGameServer::GetPlayerNetworkIDString
+  - name: CNetworkGameServer_RemoveClientFromGame
+    alias:
+    - CNetworkGameServer::RemoveClientFromGame
+  - name: CEngineServer_GetPlayerNetworkIDString
+    alias:
+    - CEngineServer::GetPlayerNetworkIDString
+  - name: CNetworkGameClientBase_ServerCmd
+    alias:
+    - CNetworkGameClientBase::ServerCmd
+  - name: CNetworkGameClientBase_ProcessSetConVar
+    alias:
+    - CNetworkGameClientBase::ProcessSetConVar
+  - name: CNetworkGameClientBase_SendStringCmd
+    alias:
+    - CNetworkGameClientBase::SendStringCmd
+  - name: CNetworkGameClientBase_StartChangeLevel
+    alias:
+    - CNetworkGameClientBase::StartChangeLevel
+  - name: CNetworkGameClientBase_FinishChangeLevel
+    alias:
+    - CNetworkGameClientBase::FinishChangeLevel
+  - name: CNetworkGameClientBase_DeferActivate
+    alias:
+    - CNetworkGameClientBase::DeferActivate
+  - name: CNetworkGameClientBase_ClockDrift_AdjustFrameTime
+    alias:
+    - CNetworkGameClientBase::ClockDrift_AdjustFrameTime
+  - name: CNetworkGameClientBase_Connect
+    alias:
+    - CNetworkGameClientBase::Connect
+  - name: CNetworkGameClientBase_DisconnectGame
+    alias:
+    - CNetworkGameClientBase::DisconnectGame
+  - name: CNetSupportImpl_Connect
+    alias:
+    - CNetSupportImpl::Connect
+- name: client
+  symbols:
+  - name: CLoopModeGame_RegisterEventMapInternal
+    alias:
+    - CLoopModeGame::RegisterEventMapInternal
+  - name: CLoopModeGame_OnClientPollNetworking
+    alias:
+    - CLoopModeGame::OnClientPollNetworking
+  - name: CLoopModeGame_OnClientAdvanceTick
+    alias:
+    - CLoopModeGame::OnClientAdvanceTick
+  - name: CLoopModeGame_OnClientPostAdvanceTick
+    alias:
+    - CLoopModeGame::OnClientPostAdvanceTick
+  - name: CLoopModeGame_OnClientPreSimulate
+    alias:
+    - CLoopModeGame::OnClientPreSimulate
+  - name: CLoopModeGame_OnClientPreOutput
+    alias:
+    - CLoopModeGame::OnClientPreOutput
+  - name: CLoopModeGame_OnClientPreOutputParallelWithServer
+    alias:
+    - CLoopModeGame::OnClientPreOutputParallelWithServer
+  - name: CLoopModeGame_OnClientPostOutput
+    alias:
+    - CLoopModeGame::OnClientPostOutput
+  - name: CLoopModeGame_OnClientFrameSimulate
+    alias:
+    - CLoopModeGame::OnClientFrameSimulate
+  - name: CLoopModeGame_OnClientAdvanceNonRenderedFrame
+    alias:
+    - CLoopModeGame::OnClientAdvanceNonRenderedFrame
+  - name: CLoopModeGame_OnClientPostSimulate
+    alias:
+    - CLoopModeGame::OnClientPostSimulate
+  - name: CLoopModeGame_OnClientPauseSimulate
+    alias:
+    - CLoopModeGame::OnClientPauseSimulate
+  - name: CLoopModeGame_OnClientSimulate
+    alias:
+    - CLoopModeGame::OnClientSimulate
+  - name: CLoopModeGame_OnPostDataUpdate
+    alias:
+    - CLoopModeGame::OnPostDataUpdate
+  - name: CLoopModeGame_OnPreDataUpdate
+    alias:
+    - CLoopModeGame::OnPreDataUpdate
+  - name: CLoopModeGame_OnFrameBoundary
+    alias:
+    - CLoopModeGame::OnFrameBoundary
+  - name: CLoopModeGame_StaticInit
+    alias:
+    - CLoopModeGame::StaticInit
+  - name: CLoopModeFactory_CLoopModeGame_Init
+    alias:
+    - CLoopModeFactory<CLoopModeGame>::Init
+  - name: CLoopModeFactory_CLoopModeGame_Shutdown
+    alias:
+    - CLoopModeFactory<CLoopModeGame>::Shutdown
+  - name: CLoopModeGame_OnLoopActivate
+    alias:
+    - CLoopModeGame::OnLoopActivate
+  - name: ILoopMode_OnLoopActivate
+    alias:
+    - ILoopMode::OnLoopActivate
+  - name: CLoopModeGame_AddViewsToSceneSystem
+    alias:
+    - CLoopModeGame::AddViewsToSceneSystem
+  - name: ILoopMode_AddViewsToSceneSystem
+    alias:
+    - ILoopMode::AddViewsToSceneSystem
+  - name: CLoopModeGame_LoopInitInternal
+    alias:
+    - CLoopModeGame::LoopInitInternal
+  - name: CLoopModeGame_LoopInit
+    alias:
+    - CLoopModeGame::LoopInit
+  - name: ILoopMode_LoopInit
+    alias:
+    - ILoopMode::LoopInit
+  - name: ILoopMode_LoopShutdown
+    alias:
+    - ILoopMode::LoopShutdown
+  - name: CLoopModeGame_ReceivedServerInfo
+    alias:
+    - CLoopModeGame::ReceivedServerInfo
+  - name: CLoopModeGame_RegisterEventMap
+    alias:
+    - CLoopModeGame::RegisterEventMap
+  - name: ILoopMode_RegisterEventMap
+    alias:
+    - ILoopMode::RegisterEventMap
+  - name: CLoopModeGame_SetWorldSession
+    alias:
+    - CLoopModeGame::SetWorldSession
+  - name: CLoopModeGame_SetGameSystemState
+    alias:
+    - CLoopModeGame::SetGameSystemState
+  - name: CLoopModeGame_LoopShutdown
+    alias:
+    - CLoopModeGame::LoopShutdown
+  - name: IGameSystem_AddByName
+    alias:
+    - IGameSystem::AddByName
+  - name: IGameSystem_Add
+    alias:
+    - IGameSystem::Add
+  - name: IGameSystem_PostInit
+    alias:
+    - IGameSystem::PostInit
+  - name: IGameSystem_InitAllSystems
+    alias:
+    - IGameSystem::InitAllSystems
+  - name: IGameSystem_LoopInitAllSystems
+    alias:
+    - IGameSystem::LoopInitAllSystems
+  - name: IGameSystemFactory_PostInit
+    alias:
+    - IGameSystemFactory::PostInit
+  - name: IGameSystemFactory_GetStaticGameSystem
+    alias:
+    - IGameSystemFactory::GetStaticGameSystem
+  - name: IGameSystemFactory_ShouldAutoAdd
+    alias:
+    - IGameSystemFactory::ShouldAutoAdd
+  - name: IGameSystemFactory_CreateGameSystem
+    alias:
+    - IGameSystemFactory::CreateGameSystem
+  - name: IGameSystemFactory_IsReallocating
+    alias:
+    - IGameSystemFactory::IsReallocating
+  - name: IGameSystem_SetName
+    alias:
+    - IGameSystem::SetName
+  - name: CSpawnGroupMgrGameSystem_DoesGameSystemReallocate
+    alias:
+    - IGameSystem::DoesGameSystemReallocate
+  - name: IGameSystem_DestroyAllGameSystems
+    alias:
+    - IGameSystem::DestroyAllGameSystems
+  - name: IGameSystem_ShutdownAllSystems
+    alias:
+    - IGameSystem::ShutdownAllSystems
+  - name: IGameSystem_LoopDestroyAllSystems
+    alias:
+    - IGameSystem::LoopDestroyAllSystems
+  - name: IGameSystem_LoopPreShutdownAllSystems
+    alias:
+    - IGameSystem::LoopPreShutdownAllSystems
+  - name: IGameSystem_OnClientPollNetworking
+    alias:
+    - IGameSystem::OnClientPollNetworking
+  - name: IGameSystem_OnClientGamePostSimulate
+    alias:
+    - IGameSystem::ClientGamePostSimulate
+  - name: IGameSystem_OnClientPauseSimulate
+    alias:
+    - IGameSystem::OnClientPauseSimulate
+  - name: IGameSystem_OnClientPreUpdate
+    alias:
+    - IGameSystem::OnClientPreUpdate
+  - name: IGameSystem_OnClientPostUpdate
+    alias:
+    - IGameSystem::OnClientPostUpdate
+  - name: IGameSystem_OnClientPostDataUpdate
+    alias:
+    - IGameSystem::OnClientPostDataUpdate
+  - name: IGameSystem_OnGameFrameBoundary
+    alias:
+    - IGameSystem::OnGameFrameBoundary
+  - name: IGameSystem_OnClientAdvanceNonRenderedFrame
+    alias:
+    - IGameSystem::OnClientAdvanceNonRenderedFrame
+  - name: IGameSystem_OnClientFrameSimulate
+    alias:
+    - IGameSystem::OnClientFrameSimulate
+  - name: IGameSystem_OnClientAdvanceTick
+    alias:
+    - IGameSystem::ClientAdvanceTick
+  - name: IGameSystem_OnClientPostAdvanceTick
+    alias:
+    - IGameSystem::ClientPostAdvanceTick
+  - name: IGameSystem_OnClientPostRender
+    alias:
+    - IGameSystem::OnClientPostRender
+  - name: IGameSystem_OnClientPreRender
+    alias:
+    - IGameSystem::OnClientPreRender
+  - name: IGameSystem_OnClientPreRenderAlt
+    alias:
+    - IGameSystem::OnClientPreRenderAlt
+  - name: CSource2Client_CreateMove
+    alias:
+    - CSource2Client::CreateMove
+  - name: CClientInput_CreateMove
+    alias:
+    - CClientInput::CreateMove
+  - name: CClientInput_m_viewangles
+    alias:
+    - CClientInput::m_viewangles
+  - name: CSource2Client_ProcessGameInput
+    alias:
+    - CSource2Client::ProcessGameInput
+  - name: ISource2Client_FrameStageNotify
+    alias:
+    - ISource2Client::FrameStageNotify
+  - name: CSource2Client_FrameStageNotify
+    alias:
+    - CSource2Client::FrameStageNotify
+  - name: IViewRender_OnRenderStart
+    alias:
+    - IViewRender::OnRenderStart
+  - name: CViewRender_OnRenderStart
+    alias:
+    - CViewRender::OnRenderStart
+  - name: CViewRender_Render
+    alias:
+    - CViewRender::Render
+  - name: C_BaseEntity_SetInterpolationPhase
+    alias:
+    - C_BaseEntity::SetInterpolationPhase
+  - name: CSource2Client_SetGlobals
+    alias:
+    - CSource2Client::SetGlobals
+  - name: CSource2Client_Connect
+    alias:
+    - CSource2Client::Connect
+  - name: CBasePlayerController_CheckForLocalPlayer
+    alias:
+    - CBasePlayerController::CheckForLocalPlayer
+  - name: CSource2Client_OnDisconnect
+    alias:
+    - CSource2Client::OnDisconnect
+  - name: IGameSystem_OnClientDisconnect
+    alias:
+    - IGameSystem::OnClientDisconnect
+  - name: IGameSystem_OnClientPreEntityThink
+    alias:
+    - IGameSystem::OnClientPreEntityThink
+  - name: CNetworkGameClient_OnSource1Source1LegacyGameEvent
+    alias:
+    - CNetworkGameClient::OnSource1Source1LegacyGameEvent
+  - name: CMapAnNodeManager_FireGameEvent
+    alias:
+    - CMapAnNodeManager::FireGameEvent
+  - name: C_ServerVoiceHandler_OnServerVoiceData
+    alias:
+    - C_ServerVoiceHandler::OnServerVoiceData
+  - name: IVEngineClient2_IsPlayingDemo
+    alias:
+    - IVEngineClient2::IsPlayingDemo
+  - name: IVEngineClient2_ExecuteClientCmd
+    alias:
+    - IVEngineClient2::ExecuteClientCmd
+  - name: IGameEventManager2_UnserializeEvent
+    alias:
+    - IGameEventManager2::UnserializeEvent
+  - name: IGameEventManager2_FireEventClientSide
+    alias:
+    - IGameEventManager2::FireEventClientSide
+  - name: CGameEventManager_FireEventClientSide
+    alias:
+    - CGameEventManager::FireEventClientSide
+  - name: CGameEventManager_UnserializeEvent
+    alias:
+    - CGameEventManager::UnserializeEvent
+  - name: CSteamworksGameStats_OnReceivedSessionID
+    alias:
+    - CSteamworksGameStats::OnReceivedSessionID
+  - name: IGameSystem_GetName
+    alias:
+    - IGameSystem::GetName
+  - name: IGameSystemFactory_DestroyGameSystem
+    alias:
+    - IGameSystemFactory::DestroyGameSystem
+  - name: IGameSystemFactory_Init
+    alias:
+    - IGameSystemFactory::Init
+  - name: IGameSystemFactory_GetPriority
+    alias:
+    - IGameSystemFactory::GetPriority
+  - name: IGameSystemFactory_Shutdown
+    alias:
+    - IGameSystemFactory::Shutdown
+  - name: IGameSystemFactory_SetGlobalPtr
+    alias:
+    - IGameSystemFactory::SetGlobalPtr
+  - name: CPrediction_PostNetworkDataReceived
+    alias:
+    - CPrediction::PostNetworkDataReceived
+  - name: IEngineServiceMgr_GetActiveLoopClientServerMode
+    alias:
+    - IEngineServiceMgr::GetActiveLoopClientServerMode
+  - name: IEngineServiceMgr_GetEventDispatcher
+    alias:
+    - IEngineServiceMgr::GetEventDispatcher
+  - name: ClientModeCSNormal_Update
+    alias:
+    - ClientModeCSNormal::Update
+  - name: CEntitySystem_ctor
+    alias:
+    - CEntitySystem::CEntitySystem
+  - name: CGameEntitySystem_ctor
+    alias:
+    - CGameEntitySystem::CGameEntitySystem
+  - name: CEntitySystem_Init
+    alias:
+    - CEntitySystem::Init
+  - name: CEntitySystem_PostCreateEntitySystem
+    alias:
+    - CEntitySystem::PostCreateEntitySystem
+  - name: CSource2EntitySystem_StaticInit
+    alias:
+    - CSource2EntitySystem::StaticInit
+  - name: CGameSystemReallocatingFactory_CSource2EntitySystem_Init
+    alias:
+    - CGameSystemReallocatingFactory<CSource2EntitySystem>::Init
+  - name: CGameSystemReallocatingFactory_CSource2EntitySystem_CreateGameSystem
+    alias:
+    - CGameSystemReallocatingFactory<CSource2EntitySystem>::CreateGameSystem
+  - name: CSkeletonInstance_PostDataUpdate
+    alias:
+    - CSkeletonInstance::PostDataUpdate
+  - name: CSkeletonInstance_m_modelState_m_simulationState
+    alias:
+    - CSkeletonInstance::m_modelState.m_simulationState
+  - name: CSkeletonInstance_m_modelState_m_hModel
+    alias:
+    - CSkeletonInstance::m_modelState.m_hModel
+  - name: CSimulationState_SetupJointState
+    alias:
+    - CSimulationState::SetupJointState
+  - name: CSimulationState_m_nTotalTransformCount
+    alias:
+    - CSimulationState::m_nTotalTransformCount
+  - name: CSimulationState_m_nBoneCount
+    alias:
+    - CSimulationState::m_nBoneCount
+  - name: CSimulationState_m_nAttachmentCount
+    alias:
+    - CSimulationState::m_nAttachmentCount
+  - name: IVEngineClient2_GetNetworkClient
+    alias:
+    - IVEngineClient2::GetNetworkClient
+  - name: INetworkClient_GetLocalAddress
+    alias:
+    - INetworkClient::GetLocalAddress
+  - name: INetworkClientService_IsConnected
+    alias:
+    - INetworkClientService::IsConnected
+  - name: INetworkClientService_SendNetMessage
+    alias:
+    - INetworkClientService::SendNetMessage
+  - name: C_GameRules_ctor
+    alias:
+    - C_GameRules::C_GameRules
+  - name: IGameResourceService_SetEntityResourceManifestHandler
+    alias:
+    - IGameResourceService::SetEntityResourceManifestHandler
+  - name: CNetworkSerializerBindingBuildFilter_GetFieldPriority
+    alias:
+    - CNetworkSerializerBindingBuildFilter::GetFieldPriority
+  - name: GameStateAPI_RegisterAPIs
+    alias:
+    - GameStateAPI::RegisterAPIs
+  - name: GameStateAPI_IsLatched
+    alias:
+    - GameStateAPI::IsLatched
+  - name: GameStateAPI_GetPlayerSlot
+    alias:
+    - GameStateAPI::GetPlayerSlot
+  - name: GameStateAPI_GetPlayerName
+    alias:
+    - GameStateAPI::GetPlayerName
+  - name: GameStateAPI_GetPlayerXuidStringFromPlayerSlot
+    alias:
+    - GameStateAPI::GetPlayerXuidStringFromPlayerSlot
+  - name: GameStateAPI_GetLocalPlayerXuid
+    alias:
+    - GameStateAPI::GetLocalPlayerXuid
+  - name: GameStateAPI_GetLocalOrInEyePlayerXuid
+    alias:
+    - GameStateAPI::GetLocalOrInEyePlayerXuid
+  - name: GameStateAPI_GetHudPlayerXuid
+    alias:
+    - GameStateAPI::GetHudPlayerXuid
+  - name: GameStateAPI_GetPlayerTeamName
+    alias:
+    - GameStateAPI::GetPlayerTeamName
+  - name: GameStateAPI_GetPlayerTeamNumber
+    alias:
+    - GameStateAPI::GetPlayerTeamNumber
+  - name: GameStateAPI_GetCoachingTeamNumber
+    alias:
+    - GameStateAPI::GetCoachingTeamNumber
+  - name: GameStateAPI_GetAssociatedTeamNumber
+    alias:
+    - GameStateAPI::GetAssociatedTeamNumber
+  - name: GameStateAPI_IsPlayerConnected
+    alias:
+    - GameStateAPI::IsPlayerConnected
+  - name: GameStateAPI_IsPlayerAlive
+    alias:
+    - GameStateAPI::IsPlayerAlive
+  - name: GameStateAPI_GetPlayerPing
+    alias:
+    - GameStateAPI::GetPlayerPing
+  - name: GameStateAPI_GetPlayerKills
+    alias:
+    - GameStateAPI::GetPlayerKills
+  - name: GameStateAPI_GetPlayerRoundKills
+    alias:
+    - GameStateAPI::GetPlayerRoundKills
+  - name: GameStateAPI_GetPlayerAssists
+    alias:
+    - GameStateAPI::GetPlayerAssists
+  - name: GameStateAPI_GetPlayerDeaths
+    alias:
+    - GameStateAPI::GetPlayerDeaths
+  - name: GameStateAPI_GetPlayerMVPs
+    alias:
+    - GameStateAPI::GetPlayerMVPs
+  - name: GameStateAPI_GetPlayerMoney
+    alias:
+    - GameStateAPI::GetPlayerMoney
+  - name: GameStateAPI_GetPlayerScore
+    alias:
+    - GameStateAPI::GetPlayerScore
+  - name: GameStateAPI_GetPlayerClanTag
+    alias:
+    - GameStateAPI::GetPlayerClanTag
+  - name: GameStateAPI_GetPlayerActiveCoinRank
+    alias:
+    - GameStateAPI::GetPlayerActiveCoinRank
+  - name: GameStateAPI_GetPlayerCompetitiveRankType
+    alias:
+    - GameStateAPI::GetPlayerCompetitiveRankType
+  - name: GameStateAPI_GetPlayerCompetitiveRanking
+    alias:
+    - GameStateAPI::GetPlayerCompetitiveRanking
+  - name: GameStateAPI_GetPlayerCompetitiveWins
+    alias:
+    - GameStateAPI::GetPlayerCompetitiveWins
+  - name: GameStateAPI_GetPlayerPremierRankStatsObject
+    alias:
+    - GameStateAPI::GetPlayerPremierRankStatsObject
+  - name: GameStateAPI_GetPlayerDisplayFlairItem
+    alias:
+    - GameStateAPI::GetPlayerDisplayFlairItem
+  - name: GameStateAPI_GetPlayerStatus
+    alias:
+    - GameStateAPI::GetPlayerStatus
+  - name: GameStateAPI_IsFakePlayer
+    alias:
+    - GameStateAPI::IsFakePlayer
+  - name: GameStateAPI_GetPlayerActiveWeaponItemId
+    alias:
+    - GameStateAPI::GetPlayerActiveWeaponItemId
+  - name: GameStateAPI_IsXuidValid
+    alias:
+    - GameStateAPI::IsXuidValid
+  - name: GameStateAPI_GetPlayerVoiceVolume
+    alias:
+    - GameStateAPI::GetPlayerVoiceVolume
+  - name: GameStateAPI_SetPlayerVoiceVolume
+    alias:
+    - GameStateAPI::SetPlayerVoiceVolume
+  - name: GameStateAPI_GetMapsInMapGroup
+    alias:
+    - GameStateAPI::GetMapsInMapGroup
+  - name: GameStateAPI_GetMapDisplayNameToken
+    alias:
+    - GameStateAPI::GetMapDisplayNameToken
+  - name: GameStateAPI_GetMapsInCurrentMapGroup
+    alias:
+    - GameStateAPI::GetMapsInCurrentMapGroup
+  - name: GameStateAPI_GetPlayerLifetime
+    alias:
+    - GameStateAPI::GetPlayerLifetime
+  - name: GameStateAPI_GetPlayerColor
+    alias:
+    - GameStateAPI::GetPlayerColor
+  - name: GameStateAPI_GetPlayerXpLevel
+    alias:
+    - GameStateAPI::GetPlayerXpLevel
+  - name: GameStateAPI_GetPlayerXpTrailLevel
+    alias:
+    - GameStateAPI::GetPlayerXpTrailLevel
+  - name: GameStateAPI_GetPlayerCommendsLeader
+    alias:
+    - GameStateAPI::GetPlayerCommendsLeader
+  - name: GameStateAPI_GetPlayerCommendsTeacher
+    alias:
+    - GameStateAPI::GetPlayerCommendsTeacher
+  - name: GameStateAPI_GetPlayerCommendsFriendly
+    alias:
+    - GameStateAPI::GetPlayerCommendsFriendly
+  - name: GameStateAPI_HasCommunicationAbuseMute
+    alias:
+    - GameStateAPI::HasCommunicationAbuseMute
+  - name: GameStateAPI_HasCommunicationBan
+    alias:
+    - GameStateAPI::HasCommunicationBan
+  - name: GameStateAPI_ShouldShowHudElements
+    alias:
+    - GameStateAPI::ShouldShowHudElements
+  - name: GameStateAPI_IsQueuedMatchmaking
+    alias:
+    - GameStateAPI::IsQueuedMatchmaking
+  - name: GameStateAPI_GetKickTargets
+    alias:
+    - GameStateAPI::GetKickTargets
+  - name: GameStateAPI_GetPlayerCharacterItemID
+    alias:
+    - GameStateAPI::GetPlayerCharacterItemID
+  - name: GameStateAPI_GetCharacterDefaultCheerByXuid
+    alias:
+    - GameStateAPI::GetCharacterDefaultCheerByXuid
+  - name: GameStateAPI_GetCharacterDefaultDefeatByXuid
+    alias:
+    - GameStateAPI::GetCharacterDefaultDefeatByXuid
+  - name: GameStateAPI_ArePlayersEnemies
+    alias:
+    - GameStateAPI::ArePlayersEnemies
+  - name: GameStateAPI_GetCSGOGameUIStateName
+    alias:
+    - GameStateAPI::GetCSGOGameUIStateName
+  - name: GameStateAPI_IsLocalPlayerPlayingMatch
+    alias:
+    - GameStateAPI::IsLocalPlayerPlayingMatch
+  - name: GameStateAPI_IsConnectedOrConnectingToServer
+    alias:
+    - GameStateAPI::IsConnectedOrConnectingToServer
+  - name: GameStateAPI_AreTeamsPlayingSwitchedSides
+    alias:
+    - GameStateAPI::AreTeamsPlayingSwitchedSides
+  - name: GameStateAPI_AreTeamsPlayingSwitchedSidesInRound
+    alias:
+    - GameStateAPI::AreTeamsPlayingSwitchedSidesInRound
+  - name: GameStateAPI_IsReportCategoryEnabledForSelectedPlayer
+    alias:
+    - GameStateAPI::IsReportCategoryEnabledForSelectedPlayer
+  - name: GameStateAPI_SubmitPlayerReport
+    alias:
+    - GameStateAPI::SubmitPlayerReport
+  - name: GameStateAPI_SubmitServerReport
+    alias:
+    - GameStateAPI::SubmitServerReport
+  - name: GameStateAPI_QueryServersForCommendation
+    alias:
+    - GameStateAPI::QueryServersForCommendation
+  - name: GameStateAPI_GetCommendationTokensAvailable
+    alias:
+    - GameStateAPI::GetCommendationTokensAvailable
+  - name: GameStateAPI_GetMyCommendationsJSOForUser
+    alias:
+    - GameStateAPI::GetMyCommendationsJSOForUser
+  - name: GameStateAPI_SubmitCommendation
+    alias:
+    - GameStateAPI::SubmitCommendation
+  - name: GameStateAPI_IsSelectedPlayerMuted
+    alias:
+    - GameStateAPI::IsSelectedPlayerMuted
+  - name: GameStateAPI_ToggleMute
+    alias:
+    - GameStateAPI::ToggleMute
+  - name: GameStateAPI_GetCrosshairCode
+    alias:
+    - GameStateAPI::GetCrosshairCode
+  - name: GameStateAPI_IsDemoOrHltv
+    alias:
+    - GameStateAPI::IsDemoOrHltv
+  - name: GameStateAPI_IsOverwatch
+    alias:
+    - GameStateAPI::IsOverwatch
+  - name: GameStateAPI_IsLocalPlayerWatchingOwnDemo
+    alias:
+    - GameStateAPI::IsLocalPlayerWatchingOwnDemo
+  - name: GameStateAPI_IsLocalPlayerHLTV
+    alias:
+    - GameStateAPI::IsLocalPlayerHLTV
+  - name: GameStateAPI_IsHLTVAutodirectorOn
+    alias:
+    - GameStateAPI::IsHLTVAutodirectorOn
+  - name: GameStateAPI_SetCasterIsCameraman
+    alias:
+    - GameStateAPI::SetCasterIsCameraman
+  - name: GameStateAPI_SetCasterIsHeard
+    alias:
+    - GameStateAPI::SetCasterIsHeard
+  - name: GameStateAPI_SetCasterControlsXray
+    alias:
+    - GameStateAPI::SetCasterControlsXray
+  - name: GameStateAPI_SetCasterControlsUI
+    alias:
+    - GameStateAPI::SetCasterControlsUI
+  - name: GameStateAPI_GetServerName
+    alias:
+    - GameStateAPI::GetServerName
+  - name: GameStateAPI_GetMapName
+    alias:
+    - GameStateAPI::GetMapName
+  - name: GameStateAPI_GetTournamentEventStage
+    alias:
+    - GameStateAPI::GetTournamentEventStage
+  - name: GameStateAPI_GetGameModeInternalName
+    alias:
+    - GameStateAPI::GetGameModeInternalName
+  - name: GameStateAPI_GetGameModeImagePath
+    alias:
+    - GameStateAPI::GetGameModeImagePath
+  - name: GameStateAPI_GetGameModeName
+    alias:
+    - GameStateAPI::GetGameModeName
+  - name: GameStateAPI_GetViewerCount
+    alias:
+    - GameStateAPI::GetViewerCount
+  - name: GameStateAPI_GetMapBSPName
+    alias:
+    - GameStateAPI::GetMapBSPName
+  - name: GameStateAPI_IsQueuedMatchmakingMode_Team
+    alias:
+    - GameStateAPI::IsQueuedMatchmakingMode_Team
+  - name: GameStateAPI_HasHalfTime
+    alias:
+    - GameStateAPI::HasHalfTime
+  - name: GameStateAPI_GetPlayerModel
+    alias:
+    - GameStateAPI::GetPlayerModel
+  - name: GameStateAPI_GetAllPlayersMatchDataJSO
+    alias:
+    - GameStateAPI::GetAllPlayersMatchDataJSO
+  - name: GameStateAPI_GetPlayerDataJSO
+    alias:
+    - GameStateAPI::GetPlayerDataJSO
+  - name: GameStateAPI_GetTimeDataJSO
+    alias:
+    - GameStateAPI::GetTimeDataJSO
+  - name: GameStateAPI_GetScoreDataJSO
+    alias:
+    - GameStateAPI::GetScoreDataJSO
+  - name: GameStateAPI_GetPlayerStatsJSO
+    alias:
+    - GameStateAPI::GetPlayerStatsJSO
+  - name: GameStateAPI_GetMatchInfoJSO
+    alias:
+    - GameStateAPI::GetMatchInfoJSO
+  - name: GameStateAPI_GetMatchEndWinDataJSO
+    alias:
+    - GameStateAPI::GetMatchEndWinDataJSO
+  - name: GameStateAPI_GetAccoladeLocalizationString
+    alias:
+    - GameStateAPI::GetAccoladeLocalizationString
+  - name: GameStateAPI_GetTeamClanName
+    alias:
+    - GameStateAPI::GetTeamClanName
+  - name: GameStateAPI_GetTeamLogoImagePath
+    alias:
+    - GameStateAPI::GetTeamLogoImagePath
+  - name: GameStateAPI_GetTeamFlagImagePath
+    alias:
+    - GameStateAPI::GetTeamFlagImagePath
+  - name: GameStateAPI_GetTeamTotalPlayerCount
+    alias:
+    - GameStateAPI::GetTeamTotalPlayerCount
+  - name: GameStateAPI_GetTeamLivingPlayerCount
+    alias:
+    - GameStateAPI::GetTeamLivingPlayerCount
+  - name: GameStateAPI_GetTeamNextRoundLossBonus
+    alias:
+    - GameStateAPI::GetTeamNextRoundLossBonus
+  - name: GameStateAPI_GetActiveQuestID
+    alias:
+    - GameStateAPI::GetActiveQuestID
+  - name: GameStateAPI_GetAnnotationsViewingLevel
+    alias:
+    - GameStateAPI::GetAnnotationsViewingLevel
+  - name: GameStateAPI_BIsLocalServerHost
+    alias:
+    - GameStateAPI::BIsLocalServerHost
+- name: server
+  symbols:
+  - name: CSource2Server_GetAllServerClasses
+    alias:
+    - CSource2Server::GetAllServerClasses
+  - name: CSource2Server_GetActiveWorldName
+    alias:
+    - CSource2Server::GetActiveWorldName
+  - name: CSource2Server_ShouldTimeoutClient
+    alias:
+    - CSource2Server::ShouldTimeoutClient
+  - name: CSource2Server_OnStreamEntitiesFromFileCompleted
+    alias:
+    - CSource2Server::OnStreamEntitiesFromFileCompleted
+  - name: CSource2Server_PreWorldUpdate
+    alias:
+    - CSource2Server::PreWorldUpdate
+  - name: CSource2Server_UpdateWhenNotInGame
+    alias:
+    - CSource2Server::UpdateWhenNotInGame
+  - name: CGameSystemReallocatingFactory_CSource2EntitySystem_Init
+    alias:
+    - CGameSystemReallocatingFactory<CSource2EntitySystem>::Init
+  - name: CGameSystemReallocatingFactory_CSource2EntitySystem_CreateGameSystem
+    alias:
+    - CGameSystemReallocatingFactory<CSource2EntitySystem>::CreateGameSystem
+  - name: IGameSystemFactory_Init
+    alias:
+    - IGameSystemFactory::Init
+  - name: IGameSystemFactory_Shutdown
+    alias:
+    - IGameSystemFactory::Shutdown
+  - name: IGameSystemFactory_SetGlobalPtr
+    alias:
+    - IGameSystemFactory::SetGlobalPtr
+  - name: CGameSystemReallocatingFactory_CSpawnGroupMgrGameSystem_DestroyGameSystem
+    alias:
+    - CGameSystemReallocatingFactory<CSpawnGroupMgrGameSystem>::Deallocate
+  - name: IGameSystem_SetGameSystemGlobalPtrs
+    alias:
+    - IGameSystem::SetGameSystemGlobalPtrs
+  - name: IGameSystem_vdtor
+    alias:
+    - IGameSystem::~IGameSystem
+  - name: IGameSystem_OnGameInit
+    alias:
+    - IGameSystem::GameInit
+  - name: CMultiplayRules_ctor
+    alias:
+    - CMultiplayRules::CMultiplayRules
+  - name: CGameMoney_OnMoneySpent
+    alias:
+    - CGameMoney::OnMoneySpent
+  - name: CGameMoney_m_DataMap
+    alias:
+    - CGameMoney::m_DataMap
+  - name: CGameMoney_GetDataDescMap
+    alias:
+    - CGameMoney::GetDataDescMap
+  - name: CCSPlayer_UseServices_OnUseImpl
+    alias:
+    - CCSPlayer_UseServices::OnUseImpl
+  - name: CCSPlayer_UseServices_OnUse
+    alias:
+    - CCSPlayer_UseServices::OnUse
+  - name: CCSPlayer_MovementServices_ProcessMovement
+    alias:
+    - CCSPlayer_MovementServices::ProcessMovement
+    - ProcessMovement
+  - name: CCSPlayer_MovementServices_CheckMovingGround
+    alias:
+    - CCSPlayer_MovementServices::CheckMovingGround
+    - CheckMovingGround
+  - name: CCSPlayer_MovementServices_WalkMove
+    alias:
+    - CCSPlayer_MovementServices::WalkMove
+    - WalkMove
+  - name: CCSPlayer_MovementServices_FullWalkMove
+    alias:
+    - CCSPlayer_MovementServices::FullWalkMove
+    - FullWalkMove
+  - name: CCSPlayer_MovementServices_CheckVelocity
+    alias:
+    - CCSPlayer_MovementServices::CheckVelocity
+    - CheckVelocity
+  - name: CCSPlayer_MovementServices_WaterMove
+    alias:
+    - CCSPlayer_MovementServices::WaterMove
+    - WaterMove
+  - name: CCSPlayer_MovementServices_FullWalkMove_SpeedClamp
+    alias:
+    - ServerMovementUnlock
+  - name: CCSPlayer_MovementServices_CheckJumpButton
+    alias:
+    - CCSPlayer_MovementServices::CheckJumpButton
+  - name: CCSPlayer_MovementServices_CheckJumpButton_WaterPatch
+    alias:
+    - CheckJumpButtonWater
+    - FixWaterFloorJump
+  - name: CPlayer_MovementServices_PlayWaterStepSound
+    alias:
+    - CPlayer_MovementServices::PlayWaterStepSound
+  - name: CPlayer_MovementServices_ForceButtons
+    alias:
+    - CPlayer_MovementServices::ForceButtons
+  - name: CPlayer_MovementServices_ForceButtonState
+    alias:
+    - CPlayer_MovementServices::ForceButtonState
+  - name: CPlayer_MovementServices_s_pRunCommandPawn
+    alias:
+    - CPlayer_MovementServices::s_pRunCommandPawn
+  - name: CEntityInstance_m_pEntity
+    alias:
+    - CEntityInstance::m_pEntity
+  - name: CEntityInstance_m_hPrivateScope
+    alias:
+    - CEntityInstance::m_hPrivateScope
+  - name: CEntityInstance_m_CScriptComponent
+    alias:
+    - CEntityInstance::m_CScriptComponent
+  - name: CEntityInstance_m_pKeyValues
+    alias:
+    - CEntityInstance::m_pKeyValues
+  - name: CEntityInstance_m_iszPrivateVScripts
+    alias:
+    - CEntityInstance::m_iszPrivateVScripts
+  - name: CBaseEntity_OnRestore
+    alias:
+    - CBaseEntity::OnRestore
+  - name: CBaseEntity_UpdateOnRemove
+    alias:
+    - CBaseEntity::UpdateOnRemove
+  - name: CBaseEntity_ModifyOrAppendCriteria
+    alias:
+    - CBaseEntity::ModifyOrAppendCriteria
+  - name: CEntityInstance_OnRestore
+    alias:
+    - CEntityInstance::OnRestore
+  - name: CBaseEntity_ctor
+    alias:
+    - CBaseEntity::CBaseEntity
+  - name: CBaseEntity_dtor
+    alias:
+    - CBaseEntity::~CBaseEntity
+  - name: CBaseEntity_vdtor
+    alias:
+    - CBaseEntity::~CBaseEntity (virtual)
+  - name: CEntityInstance_vdtor
+    alias:
+    - CEntityInstance::~CEntityInstance (virtual)
+  - name: CEntityInstance_dtor
+    alias:
+    - CEntityInstance::~CEntityInstance
+  - name: CEntitySaveRestoreBlockHandler_PreSave
+    alias:
+    - CEntitySaveRestoreBlockHandler::PreSave
+  - name: CEntitySaveRestoreBlockHandler_SaveInternal
+    alias:
+    - CEntitySaveRestoreBlockHandler::SaveInternal
+  - name: CEntitySaveRestoreBlockHandler_Save
+    alias:
+    - CEntitySaveRestoreBlockHandler::Save
+  - name: CEntitySaveRestoreBlockHandler_Restore
+    alias:
+    - CEntitySaveRestoreBlockHandler::Restore
+  - name: CEntitySaveRestoreBlockHandler_DoRestoreEntity
+    alias:
+    - CEntitySaveRestoreBlockHandler::DoRestoreEntity
+  - name: CEntitySaveRestoreBlockHandler_RestoreEntity
+    alias:
+    - CEntitySaveRestoreBlockHandler::RestoreEntity
+  - name: CreateEntityTransitionList
+    alias:
+    - CreateEntityTransitionList
+  - name: CEntitySaveRestoreBlockHandler_WriteSaveHeaders
+    alias:
+    - CEntitySaveRestoreBlockHandler::WriteSaveHeaders
+  - name: CEntitySaveRestoreBlockHandler_ReadRestoreHeaders
+    alias:
+    - CEntitySaveRestoreBlockHandler::ReadRestoreHeaders
+  - name: CEntity2SaveRestore_StreamEntitiesFromFile
+    alias:
+    - CEntity2SaveRestore::StreamEntitiesFromFile
+  - name: CSaveRestoreBlockSet_PreRestore
+    alias:
+    - CSaveRestoreBlockSet::PreRestore
+  - name: CSaveRestoreBlockSet_PostRestore
+    alias:
+    - CSaveRestoreBlockSet::PostRestore
+  - name: CEntitySaveRestoreBlockHandler_PreRestore
+    alias:
+    - CEntitySaveRestoreBlockHandler::PreRestore
+  - name: CEntitySaveRestoreBlockHandler_PostRestore
+    alias:
+    - CEntitySaveRestoreBlockHandler::PostRestore
+  - name: CEntitySystem_ForceSetInPVSCallsIntoQueue
+    alias:
+    - CEntitySystem::ForceSetInPVSCallsIntoQueue
+  - name: CEntitySystem_ExecuteQueuedSetInPVS
+    alias:
+    - CEntitySystem::ExecuteQueuedSetInPVS
+  - name: CEntitySystem_m_nSuppressDormancyChangeCount
+    alias:
+    - CEntitySystem::m_nSuppressDormancyChangeCount
+  - name: CEntitySystem_m_nExecuteQueuedCreationDepth
+    alias:
+    - CEntitySystem::m_nExecuteQueuedCreationDepth
+  - name: CEntitySystem_m_queuedDormancyChanges
+    alias:
+    - CEntitySystem::m_queuedDormancyChanges
+  - name: CEntitySystem_SetInPVS
+    alias:
+    - CEntitySystem::SetInPVS
+  - name: CEntitySystem_OnSetDormant
+    alias:
+    - CEntitySystem::OnSetDormant
+  - name: CEntitySystem_BuildResourceManifestForEntity
+    alias:
+    - CEntitySystem::BuildResourceManifestForEntity
+  - name: CEntityInstance_ObjectCaps
+    alias:
+    - CEntityInstance::ObjectCaps
+  - name: CEntityInstance_Save
+    alias:
+    - CEntityInstance::Save
+  - name: CEntityInstance_Restore
+    alias:
+    - CEntityInstance::Restore
+  - name: CEntitySaveRestoreBlockHandler_SaveInitEntities
+    alias:
+    - CEntitySaveRestoreBlockHandler::SaveInitEntities
+  - name: CEntityInstance_OnSave
+    alias:
+    - CEntityInstance::OnSave
+  - name: CEntityInstance_RequiredEdictIndex
+    alias:
+    - CEntityInstance::RequiredEdictIndex
+  - name: PolymorphicHelper_t__SetPolymorphicPointer
+    alias:
+    - PolymorphicHelper_t::SetPolymorphicPointer
+  - name: CEntityInstance_AddChangeAccessorPathPolymorphic
+    alias:
+    - CEntityInstance::AddChangeAccessorPathPolymorphic
+  - name: CEntityInstance_AssignChangeAccessorPathIdsPolymorphic
+    alias:
+    - CEntityInstance::AssignChangeAccessorPathIdsPolymorphic
+  - name: CEntityInstance_AddChangeAccessorPath
+    alias:
+    - CEntityInstance::AddChangeAccessorPath
+  - name: CBaseEntity_AddChangeAccessorPath
+    alias:
+    - CBaseEntity::AddChangeAccessorPath
+  - name: CEntityInstance_AssignChangeAccessorPathIds
+    alias:
+    - CEntityInstance::AssignChangeAccessorPathIds
+  - name: CEntityInstance_GetChangeAccessorPathInfo_2
+    alias:
+    - CEntityInstance::GetChangeAccessorPathInfo_2
+  - name: CBaseEntity_GetChangeAccessorPathInfo_2
+    alias:
+    - CBaseEntity::GetChangeAccessorPathInfo_2
+  - name: CBaseEntity_GetChangeAccessorPathInfo_1
+    alias:
+    - CBaseEntity::GetChangeAccessorPathInfo_1
+  - name: CMomentaryRotButton_Use
+    alias:
+    - CMomentaryRotButton::Use
+  - name: CBaseEntity_TakeDamageOld
+    alias:
+    - CBaseEntity::TakeDamageOld
+  - name: CBaseEntity_OnTakeDamage
+    alias:
+    - CBasePlayerPawn::OnTakeDamage
+  - name: CBasePlayerPawn_OnTakeDamage_Alive
+    alias:
+    - CBasePlayerPawn::OnTakeDamage_Alive
+  - name: CBasePlayerPawn_OnTakeDamage_Dying
+    alias:
+    - CBasePlayerPawn::OnTakeDamage_Dying
+  - name: CBasePlayerPawn_OnTakeDamage_Dead
+    alias:
+    - CBasePlayerPawn::OnTakeDamage_Dead
+  - name: DecalPlacementInfo_ctor
+    alias:
+    - DecalPlacementInfo::DecalPlacementInfo
+  - name: CBaseModelEntity_GetBoneTransform
+    alias:
+    - CBaseModelEntity::GetBoneTransform
+  - name: CBasePlayerPawn_OnTakeDamage
+    alias:
+    - CBasePlayerPawn::OnTakeDamage
+  - name: CCSPlayerPawn_OnTakeDamage_Alive
+    alias:
+    - CCSPlayerPawn::OnTakeDamage_Alive
+  - name: CCSPlayerPawn_OnTakeDamage_Dying
+    alias:
+    - CCSPlayerPawn::OnTakeDamage_Dying
+  - name: CCSPlayerPawn_OnTakeDamage_Dead
+    alias:
+    - CCSPlayerPawn::OnTakeDamage_Dead
+  - name: CFlashbangProjectile_Spawn
+    alias:
+    - CFlashbangProjectile::Spawn
+  - name: CFlashbangProjectile_Detonate
+    alias:
+    - CFlashbangProjectile::Detonate
+  - name: CSmokeGrenadeProjectile_Detonate
+    alias:
+    - CSmokeGrenadeProjectile::Detonate
+  - name: CSmokeGrenadeProjectile_Create
+    alias:
+    - CSmokeGrenadeProjectile::Create
+  - name: CSmokeGrenadeProjectile_m_SmokeVolume
+    alias:
+    - CSmokeGrenadeProjectile::m_SmokeVolume
+  - name: SmokeVolume_BuildSmokeSimulation
+    alias:
+    - SmokeVolume::BuildSmokeSimulation
+  - name: SmokeVolume_BuildSmokeSimulation_Initialize
+    alias:
+    - sub_1402310
+  - name: SmokeVolume_m_vecCenterOrigin
+    alias:
+    - SmokeVolume::m_vecCenterOrigin
+  - name: SmokeVolume_m_pStorage
+    alias:
+    - SmokeVolume::m_pStorage
+  - name: SmokeVolume_m_flStartTime
+    alias:
+    - SmokeVolume::m_flStartTime
+  - name: SmokeVolume_GetSmokeDensityInLine_Lambda1_operator_call
+    alias:
+    - SmokeVolume::GetSmokeDensityInLine::<lambda_1>::operator()
+  - name: SmokeVolume_m_nFrame
+    alias:
+    - SmokeVolume::m_nFrame
+  - name: CEntitySystem_QueueDestroyEntity
+    alias:
+    - CEntitySystem::QueueDestroyEntity
+  - name: CEntitySystem_ExecuteQueuedDeletion
+    alias:
+    - CEntitySystem::ExecuteQueuedDeletion
+  - name: CEntitySystem_m_nExecuteQueuedDeletionDepth
+    alias:
+    - CEntitySystem::m_nExecuteQueuedDeletionDepth
+  - name: CBaseModelEntity_SetModel
+    alias:
+    - CBaseModelEntity::SetModel
+  - name: CBaseModelEntity_SetRenderAttribute
+    alias:
+    - CBaseModelEntity::SetRenderAttribute
+  - name: CBaseEntity_GetScriptDescInternal
+    alias:
+    - CBaseEntity::GetScriptDescInternal
+  - name: CBaseModelEntity_GetScriptDescInternal
+    alias:
+    - CBaseModelEntity::GetScriptDescInternal
+  - name: CBaseModelEntity_GetModelScale
+    alias:
+    - CBaseModelEntity::GetModelScale
+  - name: CBaseModelEntity_Script_SetModelScale
+    alias:
+    - CBaseModelEntity::Script_SetModelScale
+  - name: CBaseModelEntity_ScriptLookupAttachment
+    alias:
+    - CBaseModelEntity::ScriptLookupAttachment
+  - name: CBaseModelEntity_ScriptGetAttachmentOrigin
+    alias:
+    - CBaseModelEntity::ScriptGetAttachmentOrigin
+  - name: CBaseModelEntity_ScriptGetAttachmentAngles
+    alias:
+    - CBaseModelEntity::ScriptGetAttachmentAngles
+  - name: CBaseModelEntity_ScriptGetAttachmentForward
+    alias:
+    - CBaseModelEntity::ScriptGetAttachmentForward
+  - name: CBaseModelEntity_ScriptSetSize
+    alias:
+    - CBaseModelEntity::ScriptSetSize
+  - name: CBaseModelEntity_ScriptSetModel
+    alias:
+    - CBaseModelEntity::ScriptSetModel
+  - name: ScriptBinding_CBaseModelEntity_SetModel
+    alias:
+    - CS_Script_SetModel
+  - name: CBaseModelEntity_ScriptGetRenderAlpha
+    alias:
+    - CBaseModelEntity::ScriptGetRenderAlpha
+  - name: CBaseModelEntity_ScriptSetRenderAlpha
+    alias:
+    - CBaseModelEntity::ScriptSetRenderAlpha
+  - name: CBaseModelEntity_ScriptSetRenderMode
+    alias:
+    - CBaseModelEntity::ScriptSetRenderMode
+  - name: CBaseModelEntity_ScriptSetRenderColor
+    alias:
+    - CBaseModelEntity::ScriptSetRenderColor
+  - name: CBaseModelEntity_ScriptGetRenderColor
+    alias:
+    - CBaseModelEntity::ScriptGetRenderColor
+  - name: CBaseModelEntity_ScriptSetMaterialGroup
+    alias:
+    - CBaseModelEntity::ScriptSetMaterialGroup
+  - name: CBaseModelEntity_ScriptSetMaterialGroupHash
+    alias:
+    - CBaseModelEntity::ScriptSetMaterialGroupHash
+  - name: CBaseModelEntity_ScriptGetMaterialGroupHash
+    alias:
+    - CBaseModelEntity::ScriptGetMaterialGroupHash
+  - name: CBaseModelEntity_ScriptSetSingleMeshGroup
+    alias:
+    - CBaseModelEntity::ScriptSetSingleMeshGroup
+  - name: CBaseModelEntity_ScriptSetMeshGroupMask
+    alias:
+    - CBaseModelEntity::ScriptSetMeshGroupMask
+  - name: CBaseModelEntity_ScriptGetMeshGroupMask
+    alias:
+    - CBaseModelEntity::ScriptGetMeshGroupMask
+  - name: CBaseModelEntity_ScriptSetBodygroupByName
+    alias:
+    - CBaseModelEntity::ScriptSetBodygroupByName
+  - name: CBaseModelEntity_Script_SetBodygroup
+    alias:
+    - CBaseModelEntity::Script_SetBodygroup
+  - name: CBaseModelEntity_Script_SetSkin
+    alias:
+    - CBaseModelEntity::Script_SetSkin
+  - name: CEntityInstance_NetworkUpdateState_thunk
+    alias:
+    - CEntityInstance::NetworkUpdateState_thunk
+  - name: CBaseEntity_SetGravityScale
+    alias:
+    - CBaseEntity::SetGravityScale
+  - name: CTriggerGravity_GravityTouch
+    alias:
+    - CTriggerGravity::GravityTouch
+  - name: CTriggerGravity_GetTouchFunction
+    alias:
+    - CTriggerGravity::GetTouchFunction
+  - name: CBasePlayerController_HandleCommand_JoinTeam
+    alias:
+    - CBasePlayerController::HandleCommand_JoinTeam
+  - name: CBasePlayerController_SetPlayerName
+    alias:
+    - CBasePlayerController::SetPlayerName
+  - name: CBasePlayerController_ProcessUsercmds
+    alias:
+    - ProcessUsercmds
+  - name: CBasePlayerController_SetPawn
+    alias:
+    - CBasePlayerController::SetPawn
+  - name: CBasePlayerController_GetPawn
+    alias:
+    - CBasePlayerController::GetPawn
+  - name: CBasePlayerController_Connect
+    alias:
+    - CBasePlayerController::Connect
+  - name: CBasePlayerController_SetConnectedState
+    alias:
+    - CBasePlayerController::SetConnectedState
+  - name: CSource2GameClients_ClientSettingsChanged
+    alias:
+    - CSource2GameClients::ClientSettingsChanged
+  - name: CSource2GameClients_ClientSetConVarUserInfoSet
+    alias:
+    - CSource2GameClients::ClientSetConVarUserInfoSet
+  - name: CSource2GameClients_ClientSetupVisibility
+    alias:
+    - CSource2GameClients::ClientSetupVisibility
+  - name: CSource2GameClients_ClientDisconnect
+    alias:
+    - CSource2GameClients::ClientDisconnect
+  - name: CSource2GameClients_ClientPutInServer
+    alias:
+    - CSource2GameClients::ClientPutInServer
+  - name: CSource2GameClients_ClientConnect
+    alias:
+    - CSource2GameClients::ClientConnect
+  - name: CSource2GameClients_ClientActive
+    alias:
+    - CSource2GameClients::ClientActive
+  - name: CSource2GameClients_ClientFullyConnect
+    alias:
+    - CSource2GameClients::ClientFullyConnect
+  - name: CSource2GameClients_ClientCommand
+    alias:
+    - CSource2GameClients::ClientCommand
+  - name: CSource2GameClients_ProcessUsercmds
+    alias:
+    - CSource2GameClients::ProcessUsercmds
+  - name: CSource2GameClients_GetBugReportInfo
+    alias:
+    - CSource2GameClients::GetBugReportInfo
+  - name: CSource2GameClients_ClientDiagnostic
+    alias:
+    - CSource2GameClients::ClientDiagnostic
+  - name: CSource2GameClients_SendHLTVStatusMessage
+    alias:
+    - CSource2GameClients::SendHLTVStatusMessage
+  - name: CSource2GameClients_OnClientConnected
+    alias:
+    - CSource2GameClients::OnClientConnected
+  - name: CGameRules_FindPickerEntity
+    alias:
+    - CGameRules::FindPickerEntity
+  - name: CCSGameRules_FindPickerEntity
+    alias:
+    - CCSGameRules::FindPickerEntity
+  - name: CCSGameRules_TerminateRound
+    alias:
+    - CCSGameRules::TerminateRound
+    - CGameRules::TerminateRound
+    - CGameRules_TerminateRound
+  - name: CCSGameRules_GoToIntermission
+    alias:
+    - CCSGameRules::GoToIntermission
+  - name: CEntityInstance_AcceptInput
+    alias:
+    - CEntityInstance::AcceptInput
+    - AcceptInput
+  - name: CEntityIdentity_AcceptInput
+    alias:
+    - CEntityIdentity::AcceptInput
+  - name: CEntityIdentity_AcceptInputInternal
+    alias:
+    - CEntityIdentity::AcceptInputInternal
+  - name: CEntityInstance_ScriptAcceptInput
+    alias:
+    - CEntityInstance::ScriptAcceptInput
+  - name: CEntityIdentity_SetEntityName
+    alias:
+    - CEntityIdentity::SetEntityName
+  - name: CEntitySystem_RemoveEntityFromNameMap
+    alias:
+    - CEntitySystem::RemoveEntityFromNameMap
+  - name: CEntitySystem_AddEntityToNameMap
+    alias:
+    - CEntitySystem::AddEntityToNameMap
+  - name: ScriptBinding_Entity_SetEntityName
+    alias:
+    - Entity::SetEntityName
+  - name: CBtActionCoordinatedBuy_Update
+    alias:
+    - CBtActionCoordinatedBuy::Update
+  - name: CCSPlayer_ItemServices_CanAcquire
+    alias:
+    - CCSPlayer_ItemServices::CanAcquire
+  - name: CCSPlayer_ItemServices_GiveDefaultItems
+    alias:
+    - CCSPlayer_ItemServices::GiveDefaultItems
+  - name: CCSPlayer_ItemServices_GiveNamedItem
+    alias:
+    - CCSPlayer_ItemServices::GiveNamedItem
+  - name: CCSPlayer_ItemServices_GiveNamedItemBool
+    alias:
+    - CCSPlayer_ItemServices::GiveNamedItemBool
+  - name: CCSPlayer_WeaponServices_CanUse
+    alias:
+    - CCSPlayer_WeaponServices::CanUse
+  - name: CCSPlayer_WeaponServices_PickupItem
+    alias:
+    - CCSPlayer_WeaponServices::PickupItem
+  - name: CCSPlayer_WeaponServices_EquipWeapon
+    alias:
+    - CCSPlayer_WeaponServices::EquipWeapon
+  - name: CCSPlayer_WeaponServices_Weapon_GetSlot
+    alias:
+    - CCSPlayer_WeaponServices_Weapon_GetSlot
+  - name: CCSPlayerController_ChangeTeam
+    alias:
+    - CCSPlayerController::ChangeTeam
+  - name: CCSPlayerController_GetThinkFunction
+    alias:
+    - CCSPlayerController::GetThinkFunction
+  - name: CCSPlayerController_PlayerForceTeamThink
+    alias:
+    - PlayerForceTeamThink
+    - CCSPlayerController::PlayerForceTeamThink
+  - name: CCSPlayerController_ResetForceTeamThink
+    alias:
+    - ResetForceTeamThink
+    - CCSPlayerController::ResetForceTeamThink
+  - name: CCSPlayerController_ResourceDataThink
+    alias:
+    - ResourceDataThink
+    - CCSPlayerController::ResourceDataThink
+  - name: CCSPlayerController_InventoryUpdateThink
+    alias:
+    - InventoryUpdateThink
+    - CCSPlayerController::InventoryUpdateThink
+  - name: g_CCSPlayerController_PlayerForceTeamThink
+    alias:
+    - g_CCSPlayerController::PlayerForceTeamThink
+  - name: g_CCSPlayerController_ResetForceTeamThink
+    alias:
+    - g_CCSPlayerController::ResetForceTeamThink
+  - name: g_CCSPlayerController_ResourceDataThink
+    alias:
+    - g_CCSPlayerController::ResourceDataThink
+  - name: g_CCSPlayerController_InventoryUpdateThink
+    alias:
+    - g_CCSPlayerController::InventoryUpdateThink
+  - name: CCSGameRules__sm_mapGcBanInformation
+    alias:
+    - CCSGameRules::sm_mapGcBanInformation
+  - name: CCSGameRules_BeginRound
+    alias:
+    - CCSGameRules::BeginRound
+  - name: CCSGameRules_PlayerSpawn
+    alias:
+    - CCSGameRules::PlayerSpawn
+  - name: CCSPlayerController_Respawn
+    alias:
+    - CCSPlayerController::Respawn
+  - name: CCSPlayerController_Connect
+    alias:
+    - CCSPlayerController::Connect
+  - name: CCSPlayerController_Disconnect
+    alias:
+    - CCSPlayerController::Disconnect
+  - name: CCSPlayerController_SwitchTeam
+    alias:
+    - CCSPlayerController::SwitchTeam
+  - name: CCSPlayerPawnBase_OnSetDormant
+    alias:
+    - CCSPlayerPawnBase::OnSetDormant
+  - name: CCSPlayerPawnBase_CheckForIdle
+    alias:
+    - CCSPlayerPawnBase::CheckForIdle
+  - name: CCSPlayerPawnBase_CheckForIdleInternal
+    alias:
+    - CCSPlayerPawnBase::CheckForIdleInternal
+  - name: CCSPlayerPawn_PostThink
+    alias:
+    - CCSPlayerPawnBase::PostThink
+    - CCSPlayerPawn::PostThink
+    - CCSPlayerPawnBase_PostThink
+    - CCSPlayerPawn_PostThink
+    - PostThink
+  - name: CCSPlayerPawn_OnSwitchWeapons
+    alias:
+    - CCSPlayerPawn::OnSwitchWeapons
+  - name: CCSPlayerPawn_ProcessSuicideAsKillReward
+    alias:
+    - CCSPlayerPawn::ProcessSuicideAsKillReward
+  - name: CGameRules_ClientSettingsChanged
+    alias:
+    - CGameRules::ClientSettingsChanged
+  - name: CGameRulesGameSystem_OnGameInit
+    alias:
+    - CGameRulesGameSystem::GameInit
+  - name: CGameRulesGameSystem_OnGameShutdown
+    alias:
+    - CGameRulesGameSystem::GameShutdown
+  - name: IGameSystem_OnGameShutdown
+    alias:
+    - IGameSystem::GameShutdown
+  - name: IGameSystem_OnGamePostInit
+    alias:
+    - IGameSystem::GamePostInit
+  - name: IGameSystem_OnGamePreShutdown
+    alias:
+    - IGameSystem::GamePreShutdown
+  - name: CMultiplayRules_ClientDisconnected
+    alias:
+    - CMultiplayRules::ClientDisconnected
+  - name: CSource2Server_Init
+    alias:
+    - CSource2Server::Init
+  - name: CSource2Server_ApplyGameSettings
+    alias:
+    - CSource2Server::ApplyGameSettings
+  - name: CSource2Server_GetEntityReport
+    alias:
+    - CSource2Server::GetEntityReport
+  - name: CSource2Server_BroadcastServerFrameTime
+    alias:
+    - CSource2Server::BroadcastServerFrameTime
+  - name: CSource2Server_WriteSignonMessages
+    alias:
+    - CSource2Server::WriteSignonMessages
+  - name: CSource2Server_GameCreateNetworkStringTables
+    alias:
+    - CSource2Server::GameCreateNetworkStringTables
+  - name: CSource2Server_GetMatchmakingGameData
+    alias:
+    - CSource2Server::GetMatchmakingGameData
+  - name: CSource2Server_GameServerSteamAPIActivated
+    alias:
+    - CSource2Server::GameServerSteamAPIActivated
+  - name: CSource2Server_GameServerSteamAPIDeactivated
+    alias:
+    - CSource2Server::GameServerSteamAPIDeactivated
+  - name: CSource2Server_OnHostNameChanged
+    alias:
+    - CSource2Server::OnHostNameChanged
+  - name: CSource2Server_GetLevelsFromSaveFile
+    alias:
+    - CSource2Server::GetLevelsFromSaveFile
+  - name: CSource2Server_ServerConVarChanged
+    alias:
+    - CSource2Server::ServerConVarChanged
+  - name: CSource2Server_Save
+    alias:
+    - CSource2Server::Save
+  - name: CSource2Server_Connect
+    alias:
+    - CSource2Server::Connect
+  - name: CSource2Server_PreShutdown
+    alias:
+    - CSource2Server::PreShutdown
+  - name: IAppSystem_Connect
+    alias:
+    - IAppSystem::Connect
+  - name: IAppSystem_PreShutdown
+    alias:
+    - IAppSystem::PreShutdown
+  - name: IVEngineServer2_ServerCommand
+    alias:
+    - IVEngineServer2::ServerCommand
+  - name: IVEngineServer2_IsDedicatedServer
+    alias:
+    - IVEngineServer2::IsDedicatedServer
+  - name: IVEngineServer2_GetServerGlobals
+    alias:
+    - IVEngineServer2::GetServerGlobals
+  - name: IVEngineServer2_GetAchievementMgr
+    alias:
+    - IVEngineServer2::GetAchievementMgr
+  - name: IVEngineServer2_IsLogEnabled
+    alias:
+    - IVEngineServer2::IsLogEnabled
+  - name: CSource2Server_Shutdown
+    alias:
+    - CSource2Server::Shutdown
+  - name: CGameEventManager_Shutdown
+    alias:
+    - CGameEventManager::Shutdown
+  - name: CLoopModeRegistry_UnregisterLoopModes
+    alias:
+    - CLoopModeRegistry::UnregisterLoopModes
+  - name: CEngineServiceRegistry_UnregisterEngineServices
+    alias:
+    - CEngineServiceRegistry::UnregisterEngineServices
+  - name: IEngineServiceMgr_UnregisterLoopMode
+    alias:
+    - IEngineServiceMgr::UnregisterLoopMode
+  - name: IEngineServiceMgr_UnregisterEngineService
+    alias:
+    - IEngineServiceMgr::UnregisterEngineService
+  - name: CSource2Server_GameFrame
+    alias:
+    - CSource2Server::GameFrame
+  - name: CGameEventManager_Init
+    alias:
+    - CGameEventManager::Init
+  - name: CTakeDamageInfo_HitGroupInfo
+    alias:
+    - CTakeDamageInfo::HitGroupInfo
+    - CTakeDamageInfo::HitGroup
+    - CTakeDamageInfo_HitGroup
+  - name: CEntitySystem_RegisterEntityClass
+    alias:
+    - CEntitySystem::RegisterEntityClass
+  - name: CEntitySystem_CreateEntityByName
+    alias:
+    - CEntitySystem::CreateEntityByName
+  - name: CEntitySystem_CreateEntity
+    alias:
+    - CEntitySystem::CreateEntity
+  - name: CEntitySystem_AddEntityToEntityDataBase
+    alias:
+    - CEntitySystem::AddEntityToEntityDataBase
+  - name: CEntitySystem_OnAddEntity
+    alias:
+    - CEntitySystem::OnAddEntity
+  - name: CEntitySystem_OnEntityParentChanged
+    alias:
+    - CEntitySystem::OnEntityParentChanged
+  - name: CEntitySystem_PrecacheEntity
+    alias:
+    - CEntitySystem::PrecacheEntity
+  - name: CEntitySystem_InvokePrecacheCallback
+    alias:
+    - CEntitySystem::InvokePrecacheCallback
+  - name: CEntitySystem_DestroyEntity
+    alias:
+    - CEntitySystem::DestroyEntity
+  - name: CConcreteEntityList_AllocEntity
+    alias:
+    - CConcreteEntityList::AllocEntity
+  - name: CEntitySystem_ConstructEntity
+    alias:
+    - CEntitySystem::ConstructEntity
+  - name: CEntitySystem_DoConstructEntity
+    alias:
+    - CEntitySystem::DoConstructEntity
+  - name: CEntitySystem_GetSpawnGroupWorldId
+    alias:
+    - CEntitySystem::GetSpawnGroupWorldId
+  - name: CEntitySystem_FindClassByDesignName
+    alias:
+    - CEntitySystem::FindClassByDesignName
+  - name: CEntitySystem_m_EntityList
+    alias:
+    - CEntitySystem::m_EntityList
+  - name: CEntitySystem_m_entityNames
+    alias:
+    - CEntitySystem::m_entityNames
+  - name: CEntitySystem_m_entityComponentHelpers
+    alias:
+    - CEntitySystem::m_entityComponentHelpers
+  - name: CEntitySystem_m_DataDescKeyUnserializers
+    alias:
+    - CEntitySystem::m_DataDescKeyUnserializers
+  - name: CEntitySystem_m_EntityPostSpawnCallback
+    alias:
+    - CEntitySystem::m_EntityPostSpawnCallback
+  - name: CEntityIdentity_FreeAttributes
+    alias:
+    - CEntityIdentity::FreeAttributes
+  - name: CConcreteEntityList_FreeEntity
+    alias:
+    - CConcreteEntityList::FreeEntity
+  - name: UTIL_CreateEntityByName
+    alias:
+    - CreateEntityByName
+  - name: CBaseEntity_DispatchSpawn
+    alias:
+    - CBaseEntity::DispatchSpawn
+    - DispatchSpawn
+  - name: CEntitySystem_QueueSpawnEntity
+    alias:
+    - CEntitySystem::QueueSpawnEntity
+  - name: CEntitySystem_HelperExecuteQueuedSpawn
+    alias:
+    - CEntitySystem::HelperExecuteQueuedSpawn
+  - name: CEntitySystem_SortEntities
+    alias:
+    - CEntitySystem::SortEntities
+  - name: CGameEntitySystem_SortEntities
+    alias:
+    - CGameEntitySystem::SortEntities
+  - name: CEntitySystem_InstallCreationWrapperCallbacks
+    alias:
+    - CEntitySystem::InstallCreationWrapperCallbacks
+  - name: CEntitySystem_ExecuteQueuedCreation
+    alias:
+    - CEntitySystem::ExecuteQueuedCreation
+  - name: CEntitySystem_ExecuteQueuedActivates
+    alias:
+    - CEntitySystem::ExecuteQueuedActivates
+  - name: CEntitySystem_ExecuteQueuedPostDataUpdateAndActivates
+    alias:
+    - CEntitySystem::ExecuteQueuedPostDataUpdateAndActivates
+  - name: CEntitySystem_Activate
+    alias:
+    - CEntitySystem::Activate
+  - name: CEntitySystem_PostDataUpdate
+    alias:
+    - CEntitySystem::PostDataUpdate
+  - name: CBaseEntity_NetworkStateChangedLog
+    alias:
+    - CBaseEntity::NetworkStateChangedLog
+  - name: CBaseEntity_NetworkStateChanged
+    alias:
+    - CBaseEntity::NetworkStateChanged
+  - name: CBaseEntity_FullEdictChanged
+    alias:
+    - CBaseEntity::FullEdictChanged
+  - name: CBaseEntity_m_NetworkTransmitComponent
+    alias:
+    - CBaseEntity::m_NetworkTransmitComponent
+  - name: CNetworkTransmitComponent_StateChanged
+    alias:
+    - CNetworkTransmitComponent::StateChanged
+  - name: CNetworkTransmitComponent_m_nStateFlags
+    alias:
+    - CNetworkTransmitComponent::m_nStateFlags
+  - name: CInferno_InfernoThink
+    alias:
+    - CInferno::InfernoThink
+  - name: CPhysExplosion_Activate
+    alias:
+    - CPhysExplosion::Activate
+  - name: CPhysExplosion_Explode
+    alias:
+    - CPhysExplosion::Explode
+  - name: UTIL_SayTextFilter2
+    alias:
+    - UTIL_SayText2Filter
+  - name: CCSWeaponBase_ItemPostFrame_ProcessReloadAction
+    alias:
+    - CCSWeaponBase::ItemPostFrame::ProcessReloadAction
+  - name: CCSPlayer_WeaponServices_HandleDropWeapon
+    alias:
+    - CCSPlayer_WeaponServices::HandleDropWeapon
+  - name: CCSPlayer_UseServices_BumpWeapon
+    alias:
+    - CCSPlayer_UseServices::BumpWeapon
+  - name: CCSPlayerPawn_HandleDropWeapon
+    alias:
+    - CCSPlayerPawn::HandleDropWeapon
+  - name: CCSPlayerPawn_ClientCommand
+    alias:
+    - CCSPlayerPawn::ClientCommand
+  - name: CCSPlayerPawn_SprayPaint
+    alias:
+    - CCSPlayerPawn::SprayPaint
+  - name: CEntitySpawner_CPlayerSprayDecal_Spawn
+    alias:
+    - CEntitySpawner<CPlayerSprayDecal>::Spawn
+  - name: CEntityKeyValuesAllocator_GetTempBuffer
+    alias:
+    - CEntityKeyValuesAllocator::GetTempBuffer
+  - name: CEntityKeyValues_LoadFromContext
+    alias:
+    - CEntityKeyValues::LoadFromContext
+  - name: CEntityKeyValues_Initialized
+    alias:
+    - CEntityKeyValues::Initialized
+  - name: CEntitySystem_m_nEntityKeyValuesAllocatorRefCount
+    alias:
+    - CEntitySystem::m_nEntityKeyValuesAllocatorRefCount
+  - name: CEntitySystem_AddRefKeyValues
+    alias:
+    - CEntitySystem::AddRefKeyValues
+  - name: CEntitySystem_ReleaseKeyValues
+    alias:
+    - CEntitySystem::ReleaseKeyValues
+  - name: CCSPlayerController_HandleCommandDrop
+    alias:
+    - CCSPlayerController::HandleCommandDrop
+  - name: IGameSystem_InitAllSystems
+    alias:
+    - IGameSystem::InitAllSystems
+  - name: IGameSystem_LoopInitAllSystems
+    alias:
+    - IGameSystem::LoopInitAllSystems
+  - name: IGameSystem_LoopPostInitAllSystems
+    alias:
+    - IGameSystem::LoopPostInitAllSystems
+  - name: IGameSystem_PostInit
+    alias:
+    - IGameSystem::PostInit
+  - name: IGameSystemFactory_PostInit
+    alias:
+    - IGameSystemFactory::PostInit
+  - name: IGameSystemFactory_GetStaticGameSystem
+    alias:
+    - IGameSystemFactory::GetStaticGameSystem
+  - name: IGameSystem_InitAllSystems_pFirst
+    alias:
+    - IGameSystem::InitAllSystems::pFirst
+    - IGameSystem::InitAllSystems->pFirst
+  - name: IGameSystem_LoopPostInitAllSystems_pEventDispatcher
+    alias:
+    - IGameSystem::LoopPostInitAllSystems::pEventDispatcher
+    - IGameSystem::LoopPostInitAllSystems->pEventDispatcher
+  - name: IGameSystem_LoopDestroyAllSystems_s_GameSystems
+    alias:
+    - IGameSystem::LoopDestroyAllSystems::s_GameSystems
+    - IGameSystem::LoopDestroyAllSystems->s_GameSystems
+  - name: CSource2GameEntities_CheckTransmit
+    alias:
+    - CSource2GameEntities::CheckTransmit
+    - ISource2GameEntities::CheckTransmit
+    - ISource2GameEntities_CheckTransmit
+    - CheckTransmit
+  - name: CSource2GameEntities_ShouldClientReceiveStringTableUserData
+    alias:
+    - CSource2GameEntities::ShouldClientReceiveStringTableUserData
+    - ISource2GameEntities::ShouldClientReceiveStringTableUserData
+    - ISource2GameEntities_ShouldClientReceiveStringTableUserData
+    - ShouldClientReceiveStringTableUserData
+  - name: INetworkGameServer_IsBackgroundMap
+    alias:
+    - INetworkGameServer::IsBackgroundMap
+  - name: ILoopModeGameSharedState_IsBackgroundMap
+    alias:
+    - ILoopModeGameSharedState::IsBackgroundMap
+  - name: CNetworkGameServerBase_IsBackgroundMap
+    alias:
+    - CNetworkGameServerBase::IsBackgroundMap
+  - name: CBaseEntity_EmitSoundFilter
+    alias:
+    - CBaseEntity::EmitSoundFilter
+  - name: CBaseEntity_ScriptInputKill
+    alias:
+    - CBaseEntity::ScriptInputKill
+  - name: CBaseEntity_ScriptGetForward
+    alias:
+    - CBaseEntity::ScriptGetForward
+  - name: CBaseEntity_ScriptGetRight
+    alias:
+    - CBaseEntity::ScriptGetRight
+  - name: CBaseEntity_ScriptGetLeft
+    alias:
+    - CBaseEntity::ScriptGetLeft
+  - name: CBaseEntity_ScriptGetUp
+    alias:
+    - CBaseEntity::ScriptGetUp
+  - name: CBaseEntity_ScriptGetModelName
+    alias:
+    - CBaseEntity::ScriptGetModelName
+  - name: CBaseEntity_ScriptGetMoveParent
+    alias:
+    - CBaseEntity::ScriptGetMoveParent
+  - name: CBaseEntity_ScriptGetRootMoveParent
+    alias:
+    - CBaseEntity::ScriptGetRootMoveParent
+  - name: CBaseEntity_ScriptFirstMoveChild
+    alias:
+    - CBaseEntity::ScriptFirstMoveChild
+  - name: CBaseEntity_ScriptNextMovePeer
+    alias:
+    - CBaseEntity::ScriptNextMovePeer
+  - name: CBaseEntity_ScriptGetOwnerEntity
+    alias:
+    - CBaseEntity::ScriptGetOwnerEntity
+  - name: CBaseEntity_Script_GetChildren
+    alias:
+    - CBaseEntity::Script_GetChildren
+  - name: CBaseEntity_ScriptSetParent
+    alias:
+    - CBaseEntity::ScriptSetParent
+  - name: CBaseEntity_ScriptEyePosition
+    alias:
+    - CBaseEntity::ScriptEyePosition
+  - name: CBaseEntity_ScriptSetAngles
+    alias:
+    - CBaseEntity::ScriptSetAngles
+  - name: CBaseEntity_ScriptSetAbsAngles
+    alias:
+    - CBaseEntity::ScriptSetAbsAngles
+  - name: CBaseEntity_ScriptGetAngles
+    alias:
+    - CBaseEntity::ScriptGetAngles
+  - name: CBaseEntity_ScriptEyeAngles
+    alias:
+    - CBaseEntity::ScriptEyeAngles
+  - name: CBaseEntity_ScriptSetOrigin
+    alias:
+    - CBaseEntity::ScriptSetOrigin
+  - name: CBaseEntity_ScriptSetLocalAngles
+    alias:
+    - CBaseEntity::ScriptSetLocalAngles
+  - name: CBaseEntity_ScriptGetLocalAngles
+    alias:
+    - CBaseEntity::ScriptGetLocalAngles
+  - name: CBaseEntity_ScriptSetLocalOrigin
+    alias:
+    - CBaseEntity::ScriptSetLocalOrigin
+  - name: CBaseEntity_ScriptGetLocalOrigin
+    alias:
+    - CBaseEntity::ScriptGetLocalOrigin
+  - name: CBaseEntity_ScriptTransformPointEntityToWorld
+    alias:
+    - CBaseEntity::ScriptTransformPointEntityToWorld
+  - name: CBaseEntity_ScriptTransformPointWorldToEntity
+    alias:
+    - CBaseEntity::ScriptTransformPointWorldToEntity
+  - name: CBaseEntity_ScriptSetForward
+    alias:
+    - CBaseEntity::ScriptSetForward
+  - name: CBaseEntity_ScriptGetBoundingMins
+    alias:
+    - CBaseEntity::ScriptGetBoundingMins
+  - name: CBaseEntity_ScriptGetBoundingMaxs
+    alias:
+    - CBaseEntity::ScriptGetBoundingMaxs
+  - name: CBaseEntity_ScriptGetBounds
+    alias:
+    - CBaseEntity::ScriptGetBounds
+  - name: CBaseEntity_ScriptGetLocalAngularVelocity_OBSOLETE
+    alias:
+    - CBaseEntity::ScriptGetLocalAngularVelocity_OBSOLETE
+  - name: CBaseEntity_ScriptSetLocalAngularVelocity_OBSOLETE
+    alias:
+    - CBaseEntity::ScriptSetLocalAngularVelocity_OBSOLETE
+  - name: CBaseEntity_ScriptAddEffects
+    alias:
+    - CBaseEntity::ScriptAddEffects
+  - name: CBaseEntity_ScriptRemoveEffects
+    alias:
+    - CBaseEntity::ScriptRemoveEffects
+  - name: CBaseEntity_ScriptSetAttributeFloatValue
+    alias:
+    - CBaseEntity::ScriptSetAttributeFloatValue
+  - name: CBaseEntity_ScriptGetAttributeFloatValue
+    alias:
+    - CBaseEntity::ScriptGetAttributeFloatValue
+  - name: CBaseEntity_ScriptSetAttributeIntValue
+    alias:
+    - CBaseEntity::ScriptSetAttributeIntValue
+  - name: CBaseEntity_ScriptGetAttributeIntValue
+    alias:
+    - CBaseEntity::ScriptGetAttributeIntValue
+  - name: CBaseEntity_ScriptHasAttribute
+    alias:
+    - CBaseEntity::ScriptHasAttribute
+  - name: CBaseEntity_ScriptDeleteAttribute
+    alias:
+    - CBaseEntity::ScriptDeleteAttribute
+  - name: CBaseEntity_GetScriptOwnerEntity
+    alias:
+    - CBaseEntity::GetScriptOwnerEntity
+  - name: CBaseEntity_SetScriptOwnerEntity
+    alias:
+    - CBaseEntity::SetScriptOwnerEntity
+  - name: CBaseEntity_ScriptSetEntityName
+    alias:
+    - CBaseEntity::ScriptSetEntityName
+  - name: CBaseEntity_ScriptGetMass
+    alias:
+    - CBaseEntity::ScriptGetMass
+  - name: CBaseEntity_ScriptSetMass
+    alias:
+    - CBaseEntity::ScriptSetMass
+  - name: CBaseEntity_ScriptGetSpawnGroupHandle
+    alias:
+    - CBaseEntity::ScriptGetSpawnGroupHandle
+  - name: CBaseEntity_GetAbsAngles
+    alias:
+    - CBaseEntity::GetAbsAngles
+  - name: CBaseEntity_Script_GetTeamNumber
+    alias:
+    - CBaseEntity::Script_GetTeamNumber
+  - name: CBaseEntity_Script_FollowEntity
+    alias:
+    - CBaseEntity::Script_FollowEntity
+  - name: CBaseEntity_Script_FollowEntityMerge
+    alias:
+    - CBaseEntity::Script_FollowEntityMerge
+  - name: CBaseEntity_Script_Trigger
+    alias:
+    - CBaseEntity::Script_Trigger
+  - name: CBaseEntity_Script_SetContextThink
+    alias:
+    - CBaseEntity::Script_SetContextThink
+  - name: CBaseEntity_AddContextForScript
+    alias:
+    - CBaseEntity::AddContextForScript
+  - name: CBaseEntity_AddContextForScriptNumeric
+    alias:
+    - CBaseEntity::AddContextForScriptNumeric
+  - name: CBaseEntity_GetContextForScript
+    alias:
+    - CBaseEntity::GetContextForScript
+  - name: CBaseEntity_ScriptGatherCriteria
+    alias:
+    - CBaseEntity::ScriptGatherCriteria
+  - name: CBaseEntity_Script_TakeDamage
+    alias:
+    - CBaseEntity::Script_TakeDamage
+  - name: CBaseEntity_SetAbsVelocity
+    alias:
+    - CBaseEntity::SetAbsVelocity
+  - name: CBaseEntity_GetAbsVelocity
+    alias:
+    - CBaseEntity::GetAbsVelocity
+  - name: CBaseEntity_Script_ApplyLocalAngularVelocityImpulse
+    alias:
+    - CBaseEntity::Script_ApplyLocalAngularVelocityImpulse
+  - name: CBaseEntity_GetLocalAngularVelocity_OBSOLETE
+    alias:
+    - CBaseEntity::GetLocalAngularVelocity_OBSOLETE
+  - name: CBaseEntity_ScriptEmitSoundParams
+    alias:
+    - CBaseEntity::ScriptEmitSoundParams
+    - CBaseEntity::EmitSoundParams
+    - CBaseEntity_EmitSoundParams
+  - name: CBaseEntity_ScriptStopSound
+    alias:
+    - CBaseEntity::ScriptStopSound
+  - name: CBaseEntity_ScriptSoundDuration
+    alias:
+    - CBaseEntity::ScriptSoundDuration
+  - name: CBaseEntity_ScriptGetAbsOrigin
+    alias:
+    - CBaseEntity::ScriptGetAbsOrigin
+  - name: CBaseEntity_OnSetDormant
+    alias:
+    - CBaseEntity::OnSetDormant
+  - name: CBaseEntity_Precache
+    alias:
+    - CBaseEntity::Precache
+    - Precache
+  - name: CCSPlayerController_AddedToEntityDatabase
+    alias:
+    - CCSPlayerController::AddedToEntityDatabase
+  - name: CEnvEntityIgniter_Precache
+    alias:
+    - CEnvEntityIgniter::Precache
+  - name: CEnvShake_Spawn
+    alias:
+    - CEnvShake::Spawn
+  - name: CBaseEntity_SetMoveType
+    alias:
+    - CBaseEntity::SetMoveType
+  - name: CBasePlayerPawn_CommitSuicide
+    alias:
+    - CBasePlayerPawn::CommitSuicide
+    - CommitSuicide
+  - name: CBaseCombatCharacter_OnKilled
+    alias:
+    - CBaseCombatCharacter::OnKilled
+  - name: CCSPlayerPawn_Event_KilledOther
+    alias:
+    - CCSPlayerPawn::Event_KilledOther
+  - name: CCSPlayerPawn_Event_Killed
+    alias:
+    - CCSPlayerPawn::Event_Killed
+  - name: CBasePlayerPawn_Event_Killed
+    alias:
+    - CBasePlayerPawn::Event_Killed
+  - name: ScriptBinding_CSPlayerPawn_DestroyWeapon
+    alias:
+    - CSPlayerPawn::DestroyWeapon
+  - name: CBasePlayerPawn_RemovePlayerItem
+    alias:
+    - CBasePlayerPawn::RemovePlayerItem
+  - name: CBasePlayerPawn_DropActivePlayerWeapon
+    alias:
+    - CBasePlayerPawn::DropActivePlayerWeapon
+  - name: CBasePlayerPawn_GetEyePosition
+    alias:
+    - CBasePlayerPawn::GetEyePosition
+  - name: CBaseEntity_GetEyePosition
+    alias:
+    - CBaseEntity::GetEyePosition
+  - name: CCSBotManager_BotPlaceCommand
+    alias:
+    - CCSBotManager::BotPlace
+  - name: CBasePlayerPawn_EyeVectors
+    alias:
+    - CBasePlayerPawn::EyeVectors
+  - name: CBasePlayerPawn_GetEyeAngles
+    alias:
+    - CBasePlayerPawn::GetEyeAngles
+  - name: CBaseEntity_GetEyeAngles
+    alias:
+    - CBaseEntity::GetEyeAngles
+  - name: CCSBot_Upkeep
+    alias:
+    - CCSBot::Upkeep
+  - name: CCSBot_SetState
+    alias:
+    - CCSBot::SetState
+  - name: CCSBot_UpdatePathMovement
+    alias:
+    - CCSBot::UpdatePathMovement
+  - name: CCSBot_PrintIfWatched
+    alias:
+    - CCSBot::PrintIfWatched
+  - name: CHostage_Follow
+    alias:
+    - CHostage::Follow
+  - name: CHostage_DropHostage
+    alias:
+    - CHostage::DropHostage
+  - name: HideState_OnUpdate
+    alias:
+    - HideState::OnUpdate
+  - name: CCSBot_Attack
+    alias:
+    - CCSBot::Attack
+  - name: CCSBot_MoveTo
+    alias:
+    - CCSBot::MoveTo
+  - name: CCSBot_InhibitLookAround
+    alias:
+    - CCSBot::InhibitLookAround
+  - name: CCSBot_SetDisposition
+    alias:
+    - CCSBot::SetDisposition
+  - name: CCSBot_Idle
+    alias:
+    - CCSBot::Idle
+  - name: CCSBot_ComputePath
+    alias:
+    - CCSBot::ComputePath
+  - name: CBaseEntity_IsAlive
+    alias:
+    - CBaseEntity::IsAlive
+  - name: CBaseEntity_SetOwner
+    alias:
+    - CBaseEntity::SetOwner
+  - name: CBaseEntity_CollisionRulesChanged
+    alias:
+    - CBaseEntity::CollisionRulesChanged
+    - CollisionRulesChanged
+  - name: CBaseEntity_Use
+    alias:
+    - CBaseEntity::Use
+  - name: CGameSceneNode_PostSpawnKeyValues
+    alias:
+    - CGameSceneNode::PostSpawnKeyValues
+  - name: CBaseEntity_Spawn
+    alias:
+    - CBaseEntity::Spawn
+    - Spawn
+  - name: CBaseEntity_SpawnRadius
+    alias:
+    - CBaseEntity::SpawnRadius
+  - name: CCSPlayer_ItemServices_DropActivePlayerWeapon
+    alias:
+    - CCSPlayer_ItemServices::DropActivePlayerWeapon
+  - name: CCSPlayer_WeaponServices_DropWeapon
+    alias:
+    - CCSPlayer_WeaponServices::DropWeapon
+  - name: CBasePlayerWeapon_Shoot_Secondary
+    alias:
+    - CBasePlayerWeapon::Shoot_Secondary
+  - name: CCSPlayer_ItemServices_RemoveWeapons
+    alias:
+    - CCSPlayer_ItemServices::RemoveWeapons
+  - name: CCSPlayer_WeaponServices_SelectItem
+    alias:
+    - CCSPlayer_WeaponServices::SelectItem
+  - name: CEntFireOutputAutoCompletionFunctor_FireOutput
+    alias:
+    - CEntFireOutputAutoCompletionFunctor::FireOutput
+  - name: CEntityInstance_FindOutputsByName
+    alias:
+    - CEntityInstance::FindOutputsByName
+  - name: CEntityInstance_ScriptEntityIO
+    alias:
+    - CEntityInstance::ScriptEntityIO
+  - name: CEntityIOOutput_FireOutputInternal
+    alias:
+    - CEntityIOOutput::FireOutputInternal
+  - name: CEntitySystem_AddEntityIOEvent
+    alias:
+    - CEntitySystem::AddEntityIOEvent
+  - name: CEntitySystem_AddEntityIOEvent2
+    alias:
+    - CEntitySystem::AddEntityIOEvent2
+  - name: CEntitySystem_AddEntityIOEventBuildStruct
+    alias:
+    - CEntitySystem::AddEntityIOEventBuildStruct
+  - name: CEntitySystem_AddEntityIOEventToQueue
+    alias:
+    - CEntitySystem::AddEntityIOEventToQueue
+  - name: CEntitySystem_m_EventQueue
+    alias:
+    - CEntitySystem::m_EventQueue
+  - name: CGameEntitySystem_FindEntityByClassName
+    alias:
+    - CGameEntitySystem::FindEntityByClassName
+  - name: CGameEntitySystem_FindEntityByName
+    alias:
+    - CGameEntitySystem::FindEntityByName
+  - name: CChicken_Event_Killed
+    alias:
+    - CChicken::Event_Killed
+  - name: CBaseEntity_EmitSound
+    alias:
+    - CBaseEntity::EmitSound
+  - name: CBaseModelEntity_FindBone
+    alias:
+    - CBaseModelEntity::FindBone
+  - name: CGameEntitySystem_OnAddEntity
+    alias:
+    - CGameEntitySystem::OnAddEntity
+  - name: CGameEntitySystem_BuildResourceManifest_ManifestNameOrGroupName
+    alias:
+    - CGameEntitySystem::BuildResourceManifest_ManifestNameOrGroupName
+  - name: CGameEntitySystem_BuildResourceManifest_KeyValuesVectors
+    alias:
+    - CGameEntitySystem::BuildResourceManifest_KeyValuesVectors
+  - name: CGameEntitySystem_FindEntityProcedural
+    alias:
+    - CGameEntitySystem::FindEntityProcedural
+  - name: CGameEntitySystem_Spawn
+    alias:
+    - CGameEntitySystem::Spawn
+  - name: CEntitySystem_Spawn
+    alias:
+    - CEntitySystem::Spawn
+  - name: CBodyGameSystem_SpawnDependencyIsland
+    alias:
+    - CBodyGameSystem::SpawnDependencyIsland
+  - name: CGameEntitySystem_CheckGlobalState
+    alias:
+    - CGameEntitySystem::CheckGlobalState
+  - name: IGameSystem_OnBuildGameSessionManifest
+    alias:
+    - IGameSystem::BuildGameSessionManifest
+  - name: IGameSystem_OnServerPreEntityThink
+    alias:
+    - IGameSystem::OnServerPreEntityThink
+  - name: IGameSystem_OnServerPostEntityThink
+    alias:
+    - IGameSystem::OnServerPostEntityThink
+  - name: IGameSystem_OnServerPreClientUpdate
+    alias:
+    - IGameSystem::ServerPreClientUpdate
+  - name: IGameSystem_OnServerAdvanceTick
+    alias:
+    - IGameSystem::ServerAdvanceTick
+  - name: IGameSystem_OnServerGamePostSimulate
+    alias:
+    - IGameSystem::ServerGamePostSimulate
+  - name: IGameSystem_OnServerPostAdvanceTick
+    alias:
+    - IGameSystem::ServerPostAdvanceTick
+  - name: IGameSystem_OnServerPreBeginAsyncPostTickWork
+    alias:
+    - IGameSystem::OnServerPreBeginAsyncPostTickWork
+  - name: IGameSystem_OnServerBeginAsyncPostTickWork
+    alias:
+    - IGameSystem::OnServerBeginAsyncPostTickWork
+  - name: IGameSystem_OnServerPreEndAsyncPostTickWork
+    alias:
+    - IGameSystem::OnServerPreEndAsyncPostTickWork
+  - name: IGameSystem_OnServerPostEndAsyncPostTickWork
+    alias:
+    - IGameSystem::OnServerPostEndAsyncPostTickWork
+  - name: IGameSystem_OnSaveGame
+    alias:
+    - IGameSystem::OnSaveGame
+  - name: IGameSystem_OnRestoreGame
+    alias:
+    - IGameSystem::OnRestoreGame
+  - name: IGameSystem_OnOutOfGameFrameBoundary
+    alias:
+    - IGameSystem::OnOutOfGameFrameBoundary
+  - name: CSource2GameClients_StartHLTVServer
+    alias:
+    - CSource2GameClients::StartHLTVServer
+  - name: LegacyGameEventListener
+    alias:
+    - GetLegacyGameEventListener
+  - name: CPhysicsGameSystem_ProcessContactEvents
+    alias:
+    - CPhysicsGameSystem::ProcessContactEvents
+  - name: CBaseEntity_VPhysicsStartTouch
+    alias:
+    - CBaseEntity::VPhysicsStartTouch
+  - name: CBaseEntity_PhysicsTouch
+    alias:
+    - CBaseEntity::PhysicsTouch
+  - name: CBaseEntity_VPhysicsEndTouch
+    alias:
+    - CBaseEntity::VPhysicsEndTouch
+  - name: CBaseEntity_StartTouch
+    alias:
+    - CBaseEntity::StartTouch
+    - StartTouch
+  - name: CBaseEntity_Touch
+    alias:
+    - CBaseEntity::Touch
+    - Touch
+  - name: CBaseEntity_EndTouch
+    alias:
+    - CBaseEntity::EndTouch
+    - EndTouch
+  - name: IVPhys2World_GetTouchingList
+    alias:
+    - IVPhys2World::GetTouchingList
+    - CVPhys2World::GetTouchingList
+  - name: CTriggerPush_Touch
+    alias:
+    - CTriggerPush::Touch
+    - TriggerPush_Touch
+  - name: CPhysBox_Use
+    alias:
+    - CPhysBox::Use
+  - name: CBaseEntity_SetGroundEntity
+    alias:
+    - SetGroundEntity
+  - name: CBaseEntity_GetHammerUniqueId
+    alias:
+    - CBaseEntity::GetHammerUniqueId
+    - GetHammerUniqueId
+  - name: CBaseEntity_IsPlayerPawn
+    alias:
+    - CBaseEntity::IsPlayerPawn
+    - IsEntityPawn
+    - IsPlayerPawn
+  - name: CBaseEntity_IsPlayerController
+    alias:
+    - CBaseEntity::IsPlayerController
+    - IsEntityController
+    - IsPlayerController
+  - name: CBaseTrigger_StartTouch
+    alias:
+    - CBaseTrigger::StartTouch
+  - name: CBaseTrigger_EndTouch
+    alias:
+    - CBaseTrigger::EndTouch
+  - name: CBaseTrigger_PassesTriggerFilters
+    alias:
+    - CBaseTrigger::PassesTriggerFilters
+    - PassesTriggerFilters
+  - name: CBaseAnimGraph_GetAnimationController
+    alias:
+    - CBaseAnimGraph::GetAnimationController
+  - name: CBaseAnimGraph_m_skeletonInstance
+    alias:
+    - CBaseAnimGraph::m_skeletonInstance
+  - name: CGameSceneNode_PreInstanceSpawn
+    alias:
+    - CGameSceneNode::PreInstanceSpawn
+  - name: CGameSceneNode_GetSkeletonInstance
+    alias:
+    - CGameSceneNode::GetSkeletonInstance
+  - name: CSkeletonInstance_m_animationController
+    alias:
+    - CSkeletonInstance::m_animationController
+  - name: CSkeletonInstance_PostDataUpdate
+    alias:
+    - CSkeletonInstance::PostDataUpdate
+  - name: CGameSceneNode_PostDataUpdate
+    alias:
+    - CGameSceneNode::PostDataUpdate
+  - name: CGameSceneNode_UpdateEntityForHierarchyChange
+    alias:
+    - CGameSceneNode::UpdateEntityForHierarchyChange
+  - name: CPointTeleportAPI_TeleportEntityInternal
+    alias:
+    - CPointTeleportAPI::TeleportEntityInternal
+  - name: CBaseEntity_Teleport
+    alias:
+    - CBaseEntity::Teleport
+  - name: CPointTeleport_Activate
+    alias:
+    - CPointTeleport::Activate
+  - name: CBaseEntity_Activate
+    alias:
+    - CBaseEntity::Activate
+    - Activate
+  - name: CBaseEntity_DrawDebugTextOverlays
+    alias:
+    - CBaseEntity::DrawDebugTextOverlays
+  - name: CRagdollProp_DrawEntityDebugOverlays
+    alias:
+    - CRagdollProp::DrawEntityDebugOverlays
+  - name: CBaseEntity_ReloadPrivateScripts
+    alias:
+    - CBaseEntity::ReloadPrivateScripts
+  - name: CCheckTransmitInfo_m_nPlayerSlot
+    alias:
+    - CCheckTransmitInfo::m_nPlayerSlot
+    - CheckTransmitPlayerSlot
+  - name: CCheckTransmitInfo_m_bFullUpdate
+    alias:
+    - CCheckTransmitInfo::m_bFullUpdate
+  - name: CDedicatedServerWorkshopManager_SwitchToWorkshopMapGroup
+    alias:
+    - CDedicatedServerWorkshopManager::SwitchToWorkshopMapGroup
+  - name: IGameTypes_CreateWorkshopMapGroup
+    alias:
+    - IGameTypes::CreateWorkshopMapGroup
+  - name: CEngineServer_UnloadSpawnGroup
+    alias:
+    - CEngineServer::UnloadSpawnGroup
+  - name: CNetworkServerService_SetGameSpawnGroupMgr
+    alias:
+    - CNetworkServerService::SetGameSpawnGroupMgr
+  - name: CNetworkServerService_AddServerPrerequisites
+    alias:
+    - CNetworkServerService::AddServerPrerequisites
+  - name: CNetworkServerService_SetFinalSimulationTickThisFrame
+    alias:
+    - CNetworkServerService::SetFinalSimulationTickThisFrame
+  - name: CSpawnGroupMgrGameSystem_GetSpawnGroups
+    alias:
+    - CSpawnGroupMgrGameSystem::GetSpawnGroups
+    - GetSpawnGroups
+  - name: CSpawnGroupMgrGameSystem_DumpSpawnGroups
+    alias:
+    - CSpawnGroupMgrGameSystem::DumpSpawnGroups
+    - DumpSpawnGroups
+  - name: CSpawnGroupMgrGameSystem_SpawnGroupSpawnEntitiesInternal
+    alias:
+    - CSpawnGroupMgrGameSystem::SpawnGroupSpawnEntitiesInternal
+    - SpawnGroupSpawnEntitiesInternal
+  - name: IGameSystem_OnPreSpawnGroupLoad
+    alias:
+    - IGameSystem::OnPreSpawnGroupLoad
+  - name: IGameSystem_OnPostSpawnGroupLoad
+    alias:
+    - IGameSystem::OnPostSpawnGroupLoad
+  - name: CSpawnGroupMgrGameSystem_SpawnGroupShutdown
+    alias:
+    - CSpawnGroupMgrGameSystem::SpawnGroupShutdown
+    - SpawnGroupShutdown
+  - name: CSpawnGroupMgrGameSystem_SpawnGroupActuallyShutdown
+    alias:
+    - CSpawnGroupMgrGameSystem::SpawnGroupActuallyShutdown
+    - SpawnGroupActuallyShutdown
+  - name: IGameSystem_OnPreSpawnGroupUnload
+    alias:
+    - IGameSystem::OnPreSpawnGroupUnload
+  - name: IGameSystem_OnPostSpawnGroupUnload
+    alias:
+    - IGameSystem::OnPostSpawnGroupUnload
+  - name: CLoadingSpawnGroup_CreateEntityToSpawn
+    alias:
+    - CLoadingSpawnGroup::CreateEntityToSpawn
+  - name: CSpawnGroupMgrGameSystem_OnSpawnGroupPrecache
+    alias:
+    - CSpawnGroupMgrGameSystem::OnSpawnGroupPrecache
+    - SpawnGroupPrecache
+  - name: CSpawnGroupMgrGameSystem_AllocateSpawnGroup
+    alias:
+    - CSpawnGroupMgrGameSystem::AllocateSpawnGroup
+  - name: CSpawnGroupMgrGameSystem_ReleaseSpawnGroup
+    alias:
+    - CSpawnGroupMgrGameSystem::ReleaseSpawnGroup
+  - name: CSpawnGroupMgrGameSystem_SpawnGroupInit
+    alias:
+    - CSpawnGroupMgrGameSystem::SpawnGroupInit
+  - name: CSpawnGroupMgrGameSystem_CreateLoadingSpawnGroup
+    alias:
+    - CSpawnGroupMgrGameSystem::CreateLoadingSpawnGroup
+  - name: CSpawnGroupMgrGameSystem_CreateLoadingSpawnGroupForSaveFile
+    alias:
+    - CSpawnGroupMgrGameSystem::CreateLoadingSpawnGroupForSaveFile
+  - name: CSpawnGroupMgrGameSystem_SpawnGroupSpawnEntities
+    alias:
+    - CSpawnGroupMgrGameSystem::SpawnGroupSpawnEntities
+  - name: CSpawnGroupMgrGameSystem_SetActiveSpawnGroup
+    alias:
+    - CSpawnGroupMgrGameSystem::SetActiveSpawnGroup
+  - name: IVEngineServer2_MakeSpawnGroupActive
+    alias:
+    - IVEngineServer2::MakeSpawnGroupActive
+  - name: CSpawnGroupMgrGameSystem_UnloadSpawnGroup
+    alias:
+    - CSpawnGroupMgrGameSystem::UnloadSpawnGroup
+  - name: CSpawnGroupMgrGameSystem_SaveGame_Start
+    alias:
+    - CSpawnGroupMgrGameSystem::SaveGame_Start
+  - name: IGameSystem_OnSpawnGroupPrecache
+    alias:
+    - IGameSystem::OnSpawnGroupPrecache
+  - name: IGameSystem_OnSpawnGroupUncache
+    alias:
+    - IGameSystem::OnSpawnGroupUncache
+  - name: CBaseFilter_InputTestActivator
+    alias:
+    - CBaseFilter::InputTestActivator
+  - name: CGamePlayerEquip_InputTriggerForAllPlayers
+    alias:
+    - CGamePlayerEquip::InputTriggerForAllPlayers
+  - name: CGamePlayerEquip_InputTriggerForActivatedPlayer
+    alias:
+    - CGamePlayerEquip::InputTriggerForActivatedPlayer
+  - name: CNavMesh_GetNearestNavArea
+    alias:
+    - CNavMesh::GetNearestNavArea
+  - name: CCSBotManager_AddBot
+    alias:
+    - CCSBotManager::AddBot
+  - name: BotAdd_CommandHandler
+    alias:
+    - CCSBotManager::BotAddCommand
+  - name: BotKill_CommandHandler
+    alias:
+    - CCSBotManager::BotKillCommand
+  - name: EntInfo_CommandHandler
+    alias:
+    - CC_Ent_Info
+  - name: CEntitySystem_DestroyEntityImmediate
+    alias:
+    - CEntitySystem::DestroyEntityImmediate
+  - name: CEntitySystem_OnRemoveEntityFromDatabase
+    alias:
+    - CEntitySystem::OnRemoveEntityFromDatabase
+  - name: CEntitySystem_DoDestructEntity
+    alias:
+    - CEntitySystem::DoDestructEntity
+  - name: CEntitySystem_UpdateOnRemove
+    alias:
+    - CEntitySystem::UpdateOnRemove
+  - name: ClientPrintToController
+    alias:
+    - ClientPrint
+  - name: CCSBotManager_AddBot_BotNavIgnore
+    alias:
+    - BotNavIgnore
+  - name: CEnvHudHint_API_ShowHudHint
+    alias:
+    - CEnvHudHint_API::ShowHudHint
+  - name: UTIL_GetPlayerControllerForEntity
+    alias:
+    - UTIL_GetPlayerControllerForEntity
+  - name: CEntitySystem_ctor
+    alias:
+    - CEntitySystem::CEntitySystem
+  - name: CGameEntitySystem_ctor
+    alias:
+    - CGameEntitySystem::CGameEntitySystem
+  - name: CEntitySystem_RegisterAccessor
+    alias:
+    - CEntitySystem::RegisterAccessor
+  - name: CEntitySystem_Init
+    alias:
+    - CEntitySystem::Init
+  - name: CEntitySystem_ProcessEntityRegistration
+    alias:
+    - CEntitySystem::ProcessEntityRegistration
+  - name: CEntitySystem_PostCreateEntitySystem
+    alias:
+    - CEntitySystem::PostCreateEntitySystem
+  - name: CSource2EntitySystem_StaticInit
+    alias:
+    - CSource2EntitySystem::StaticInit
+  - name: CSpawnGroupEntityFilterRegistrar_RegisterSpawnGroupEntityFilters
+    alias:
+    - CSpawnGroupEntityFilterRegistrar::RegisterSpawnGroupEntityFilters
+  - name: CGameEntitySystem_m_spawnGroupEntityFilters
+    alias:
+    - CGameEntitySystem::m_spawnGroupEntityFilters
+  - name: CGameEntitySystem_m_pEntity2Networkables
+    alias:
+    - CGameEntitySystem::m_pEntity2Networkables
+  - name: CEntity2NetworkClasses_ServerClass_InitEntity2NetworkClasses
+    alias:
+    - CEntity2NetworkClasses<ServerClass>::InitEntity2NetworkClasses
+  - name: CEntitySystem_m_Symbols
+    alias:
+    - CEntitySystem::m_Symbols
+  - name: CEntitySystem_m_pNetworkFieldChangedEventQueue
+    alias:
+    - CEntitySystem::m_pNetworkFieldChangedEventQueue
+  - name: CEntitySystem_m_pNetworkFieldScratchData
+    alias:
+    - CEntitySystem::m_pNetworkFieldScratchData
+  - name: CEntitySystem_m_pFieldChangeLimitSpew
+    alias:
+    - CEntitySystem::m_pFieldChangeLimitSpew
+  - name: CEntitySystem_m_ComponentUnserializerInfoAllocator
+    alias:
+    - CEntitySystem::m_ComponentUnserializerInfoAllocator
+  - name: CEntitySystem_m_EntityMaterialAttributes
+    alias:
+    - CEntitySystem::m_EntityMaterialAttributes
+  - name: CEntitySystem_m_flChangeCallbackSpewThreshold
+    alias:
+    - CEntitySystem::m_flChangeCallbackSpewThreshold
+  - name: CEntitySystem_ClearEntityDatabase
+    alias:
+    - CEntitySystem::ClearEntityDatabase
+  - name: INetworkMessages_SetNetworkSerializationContextData
+    alias:
+    - INetworkMessages::SetNetworkSerializationContextData
+  - name: CFlattenedSerializers_CreateFieldChangedEventQueue
+    alias:
+    - CFlattenedSerializers::CreateFieldChangedEventQueue
+  - name: INetworkMessages_RegisterSchemaTypeOverride
+    alias:
+    - INetworkMessages::RegisterSchemaTypeOverride
+  - name: CSceneEntity_GetScriptDesc
+    alias:
+    - CSceneEntity::GetScriptDesc
+  - name: CEntityInstance_GetScriptDesc
+    alias:
+    - CEntityInstance::GetScriptDesc
+  - name: CEntityInstance_Spawn
+    alias:
+    - CEntityInstance::Spawn
+  - name: CEntityInstance_Activate
+    alias:
+    - CEntityInstance::Activate
+  - name: CEntityInstance_Precache
+    alias:
+    - CEntityInstance::Precache
+  - name: CEntityInstance_GetDataDescMap
+    alias:
+    - CEntityInstance::GetDataDescMap
+  - name: CEntityInstance_ReloadPrivateScripts
+    alias:
+    - CEntityInstance::ReloadPrivateScripts
+  - name: CEntityInstance_ValidatePrivateScriptScope
+    alias:
+    - CEntityInstance::ValidatePrivateScriptScope
+  - name: CEntityInstance_NetworkStateChanged
+    alias:
+    - CEntityInstance::NetworkStateChanged
+  - name: CEntityInstance_FullEdictChanged
+    alias:
+    - CEntityInstance::FullEdictChanged
+  - name: CEntityInstance_NetworkUpdateState
+    alias:
+    - CEntityInstance::NetworkUpdateState
+  - name: CEntityInstance_NetworkStateChangedLog
+    alias:
+    - CEntityInstance::NetworkStateChangedLog
+  - name: CEntityInstance_DrawDebugTextOverlays
+    alias:
+    - CEntityInstance::DrawDebugTextOverlays
+  - name: CEntityInstance_DrawEntityDebugOverlays
+    alias:
+    - CEntityInstance::DrawEntityDebugOverlays
+  - name: CEntityInstance_PostDataUpdateDelta
+    alias:
+    - CEntityInstance::PostDataUpdateDelta
+  - name: CEntityInstance_PreDataUpdate
+    alias:
+    - CEntityInstance::PreDataUpdate
+  - name: CEntityInstance_PostDataUpdate
+    alias:
+    - CEntityInstance::PostDataUpdate
+  - name: CEntityInstance_PostDataUpdatePreserve
+    alias:
+    - CEntityInstance::PostDataUpdatePreserve
+  - name: CEntityInstance_Connect
+    alias:
+    - CEntityInstance::Connect
+  - name: CEntityInstance_UpdateOnRemove
+    alias:
+    - CEntityInstance::UpdateOnRemove
+  - name: CEntityInstance_Disconnect
+    alias:
+    - CEntityInstance::Disconnect
+  - name: CEntityInstance_AddedToEntityDatabase
+    alias:
+    - CEntityInstance::AddedToEntityDatabase
+  - name: CEntityInstance_OnSetDormant
+    alias:
+    - CEntityInstance::OnSetDormant
+  - name: CEntityInstance_Schema_DynamicBinding
+    alias:
+    - CEntityInstance::Schema_DynamicBinding
+  - name: CEntitySystem_OnRemoveEntity
+    alias:
+    - CEntitySystem::OnRemoveEntity
+  - name: CEntityComponentHelperT_Free
+    alias:
+    - CEntityComponentHelperT::Free
+  - name: CScriptedSequence_SynchronizeSequence
+    alias:
+    - CScriptedSequence::SynchronizeSequence
+  - name: CNetworkUtlVectorEmbedded_NetworkStateChanged_m_vecRenderAttributes
+    alias:
+    - CNetworkUtlVectorEmbedded<CRenderAttribute>::NetworkStateChanged_m_vecRenderAttributes
+  - name: CNetworkUtlVectorEmbedded_NetworkStateChanged_m_perRoundStats
+    alias:
+    - CNetworkUtlVectorEmbedded<CSPerRoundStats_t>::NetworkStateChanged_m_perRoundStats
+  - name: CUtlVectorEmbeddedNetworkVar_CSPerRoundStats_t_NetworkVar_m_perRoundStats_SetCount
+    alias:
+    - CUtlVectorEmbeddedNetworkVar<CSPerRoundStats_t, NetworkVar>::SetCount
+  - name: CNetworkUtlVectorEmbedded_TryLateResolve_m_vecRenderAttributes
+    alias:
+    - CNetworkUtlVectorEmbedded<CRenderAttribute>::TryLateResolve
+  - name: INetworkMessages_GetLoggingChannel
+    alias:
+    - INetworkMessages::GetLoggingChannel
+  - name: CPhysicsEntitySolver_PhysEnableEntityCollisions
+    alias:
+    - CPhysicsEntitySolver::PhysEnableEntityCollisions
+  - name: CLoopModeGame_StaticInit
+    alias:
+    - CLoopModeGame::StaticInit
+  - name: CLoopModeGame_ctor
+    alias:
+    - CLoopModeGame::CLoopModeGame
+  - name: CLoopModeFactory_CLoopModeGame_Init
+    alias:
+    - CLoopModeFactory<CLoopModeGame>::Init
+  - name: CLoopModeFactory_CLoopModeGame_CreateLoopMode
+    alias:
+    - CLoopModeFactory<CLoopModeGame>::CreateLoopMode
+  - name: CLoopModeFactory_CLoopModeGame_Shutdown
+    alias:
+    - CLoopModeFactory<CLoopModeGame>::Shutdown
+  - name: CLoopModeGame_OnLoopActivate
+    alias:
+    - CLoopModeGame::OnLoopActivate
+  - name: ILoopMode_OnLoopActivate
+    alias:
+    - ILoopMode::OnLoopActivate
+  - name: CLoopModeGame_AddViewsToSceneSystem
+    alias:
+    - CLoopModeGame::AddViewsToSceneSystem
+  - name: ILoopMode_AddViewsToSceneSystem
+    alias:
+    - ILoopMode::AddViewsToSceneSystem
+  - name: CLoopModeGame_LoopInitInternal
+    alias:
+    - CLoopModeGame::LoopInitInternal
+  - name: CLoopModeGame_LoopInit
+    alias:
+    - CLoopModeGame::LoopInit
+  - name: ILoopMode_LoopInit
+    alias:
+    - ILoopMode::LoopInit
+  - name: ILoopMode_LoopShutdown
+    alias:
+    - ILoopMode::LoopShutdown
+  - name: CLoopModeGame_RegisterEventMapInternal
+    alias:
+    - CLoopModeGame::RegisterEventMapInternal
+  - name: CLoopModeGame_OnServerAdvanceTick
+    alias:
+    - CLoopModeGame::OnServerAdvanceTick
+  - name: CLoopModeGame_OnServerBeginSimulate
+    alias:
+    - CLoopModeGame::OnServerBeginSimulate
+  - name: CLoopModeGame_OnServerPostSimulate
+    alias:
+    - CLoopModeGame::OnServerPostSimulate
+  - name: CLoopModeGame_OnServerPostAdvanceTick
+    alias:
+    - CLoopModeGame::OnServerPostAdvanceTick
+  - name: CLoopModeGame_OnServerBeginAsyncPostTickWork
+    alias:
+    - CLoopModeGame::OnServerBeginAsyncPostTickWork
+  - name: CLoopModeGame_OnServerEndAsyncPostTickWork
+    alias:
+    - CLoopModeGame::OnServerEndAsyncPostTickWork
+  - name: CLoopModeGame_OnFrameBoundary
+    alias:
+    - CLoopModeGame::OnFrameBoundary
+  - name: CLoopModeGame_ReceivedServerInfo
+    alias:
+    - CLoopModeGame::ReceivedServerInfo
+  - name: CLoopModeGame_SetWorldSession
+    alias:
+    - CLoopModeGame::SetWorldSession
+  - name: CLoopModeGame_SetGameSystemState
+    alias:
+    - CLoopModeGame::SetGameSystemState
+  - name: IGameSystem_DestroyAllGameSystems
+    alias:
+    - IGameSystem::DestroyAllGameSystems
+  - name: IGameSystem_ShutdownAllSystems
+    alias:
+    - IGameSystem::ShutdownAllSystems
+  - name: IGameSystem_LoopDestroyAllSystems
+    alias:
+    - IGameSystem::LoopDestroyAllSystems
+  - name: IGameSystem_LoopPreShutdownAllSystems
+    alias:
+    - IGameSystem::LoopPreShutdownAllSystems
+  - name: CLoopModeGame_Shutdown
+    alias:
+    - CLoopModeGame::Shutdown
+  - name: CLoopModeGame_LoopShutdown
+    alias:
+    - CLoopModeGame::LoopShutdown
+  - name: CLoopModeGame_ShutdownServer
+    alias:
+    - CLoopModeGame::ShutdownServer
+  - name: CLoopModeGame_OnLoopDeactivate
+    alias:
+    - CLoopModeGame::OnLoopDeactivate
+  - name: ILoopMode_OnLoopDeactivate
+    alias:
+    - ILoopMode::OnLoopDeactivate
+  - name: CPlayerCommandQueue_ctor
+    alias:
+    - CPlayerCommandQueue::CPlayerCommandQueue
+  - name: CBasePlayerController_IsFakeClient
+    alias:
+    - CBasePlayerController::IsFakeClient
+    - IsFakeClient
+  - name: INetworkGameServer_GetClientConnectionType
+    alias:
+    - INetworkGameServer::GetClientConnectionType
+  - name: IGameResourceService_SetEntityResourceManifestHandler
+    alias:
+    - IGameResourceService::SetEntityResourceManifestHandler
+  - name: CNetworkSerializerBindingBuildFilter_GetFieldPriority
+    alias:
+    - CNetworkSerializerBindingBuildFilter::GetFieldPriority
+  - name: CEntitySystem_FindComponentTypeByName
+    alias:
+    - CEntitySystem::FindComponentTypeByName
+- name: networksystem
+  symbols:
+  - name: INetworkMessages_GetFieldChangeCallbackOrderCount
+    alias:
+    - INetworkMessages::GetFieldChangeCallbackOrderCount
+  - name: INetworkMessages_GetFieldChangeCallbackPriorities
+    alias:
+    - INetworkMessages::GetFieldChangeCallbackPriorities

--- a/gamesymbols/14175.metadata.yaml
+++ b/gamesymbols/14175.metadata.yaml
@@ -1,0 +1,3791 @@
+modules:
+- name: scenesystem
+  symbols:
+  - name: ISceneSystem_GetWorldsInfo
+    alias:
+    - ISceneSystem::GetWorldsInfo
+  - name: ISceneWorld_GetObjectsInfo
+    alias:
+    - ISceneWorld::GetObjectsInfo
+  - name: ISceneWorld_GetWorldName
+    alias:
+    - ISceneWorld::GetWorldName
+  - name: ISceneSystem_GetObjectBounds
+    alias:
+    - ISceneSystem::GetObjectBounds
+  - name: ISceneSystem_GetObjectClassName
+    alias:
+    - ISceneSystem::GetObjectClassName
+  - name: CSceneObject_pDesc
+    alias:
+    - CSceneObject::pDesc
+  - name: CSceneObject_nFlags
+    alias:
+    - CSceneObject::nFlags
+  - name: CSceneObject_fOriginX
+    alias:
+    - CSceneObject::fOriginX
+  - name: CSceneObject_fOriginY
+    alias:
+    - CSceneObject::fOriginY
+  - name: CSceneObject_fOriginZ
+    alias:
+    - CSceneObject::fOriginZ
+  - name: CSceneObject_nClassIndex
+    alias:
+    - CSceneObject::nClassIndex
+- name: networksystem
+  symbols:
+  - name: CNetworkMessages_RegisterNetworkCategory
+    alias:
+    - CNetworkMessages::RegisterNetworkCategory
+  - name: CNetworkMessages_AssociateNetMessageWithChannelCategoryAbstract
+    alias:
+    - CNetworkMessages::AssociateNetMessageWithChannelCategoryAbstract
+  - name: CNetworkMessages_FindOrCreateNetMessage
+    alias:
+    - CNetworkMessages::FindOrCreateNetMessage
+  - name: CNetworkMessages_SerializeInternal
+    alias:
+    - CNetworkMessages::SerializeInternal
+  - name: CNetworkMessages_UnserializeMessageInternal
+    alias:
+    - CNetworkMessages::UnserializeMessageInternal
+  - name: CNetworkMessages_SerializeMessageInternal
+    alias:
+    - CNetworkMessages::SerializeMessageInternal
+  - name: CNetworkMessages_UnserializeFromStream
+    alias:
+    - CNetworkMessages::UnserializeFromStream
+  - name: CNetworkMessages_AllocateAndCopyConstructNetMessageAbstract
+    alias:
+    - CNetworkMessages::AllocateAndCopyConstructNetMessageAbstract
+  - name: CNetworkMessages_DeallocateNetMessageAbstract
+    alias:
+    - CNetworkMessages::DeallocateNetMessageAbstract
+  - name: CNetworkMessages_RegisterNetworkFieldSerializer
+    alias:
+    - CNetworkMessages::RegisterNetworkFieldSerializer
+  - name: CNetworkMessages_RegisterNetworkArrayFieldSerializer
+    alias:
+    - CNetworkMessages::RegisterNetworkArrayFieldSerializer
+  - name: CNetworkMessages_AssociateNetMessageGroupIdWithChannelCategory
+    alias:
+    - CNetworkMessages::AssociateNetMessageGroupIdWithChannelCategory
+  - name: CNetworkMessages_RegisterNetworkFieldChangeCallbackInternal
+    alias:
+    - CNetworkMessages::RegisterNetworkFieldChangeCallbackInternal
+  - name: CNetworkMessages_AllowAdditionalMessageRegistration
+    alias:
+    - CNetworkMessages::AllowAdditionalMessageRegistration
+  - name: CNetworkMessages_IsAdditionalMessageRegistrationAllowed
+    alias:
+    - CNetworkMessages::IsAdditionalMessageRegistrationAllowed
+  - name: CNetworkMessages_RegisterFieldChangeCallbackPriority
+    alias:
+    - CNetworkMessages::RegisterFieldChangeCallbackPriority
+  - name: CNetworkMessages_ComputeOrderForPriority
+    alias:
+    - CNetworkMessages::ComputeOrderForPriority
+  - name: CNetworkMessages_dtor
+    alias:
+    - CNetworkMessages::~CNetworkMessages
+  - name: CNetworkMessages_GetIsForServer
+    alias:
+    - CNetworkMessages::GetIsForServer
+  - name: CNetworkMessages_GetNetworkSerializationContextData
+    alias:
+    - CNetworkMessages::GetNetworkSerializationContextData
+  - name: CNetChan_ParseMessagesDemoInternal
+    alias:
+    - CNetChan::ParseMessagesDemoInternal
+  - name: CNetChan_ParseNetMessageShowFilter
+    alias:
+    - CNetChan::ParseNetMessageShowFilter
+  - name: CNetworkMessages_FindNetworkMessagePartial
+    alias:
+    - CNetworkMessages::FindNetworkMessagePartial
+  - name: CNetworkMessages_FindNetworkMessage
+    alias:
+    - CNetworkMessages::FindNetworkMessage
+  - name: CNetworkMessages_FindNetworkGroup
+    alias:
+    - CNetworkMessages::FindNetworkGroup
+  - name: CNetworkSystem_SendNetworkStats
+    alias:
+    - CNetworkSystem::SendNetworkStats
+  - name: CNetworkMessages_GetNetworkGroupCount
+    alias:
+    - CNetworkMessages::GetNetworkGroupCount
+  - name: CNetworkMessages_GetNetworkGroupName
+    alias:
+    - CNetworkMessages::GetNetworkGroupName
+  - name: CNetworkMessages_GetNetworkGroupColor
+    alias:
+    - CNetworkMessages::GetNetworkGroupColor
+  - name: CNetworkMessages_ConfirmAllMessageHandlersInstalled
+    alias:
+    - CNetworkMessages::ConfirmAllMessageHandlersInstalled
+- name: engine
+  symbols:
+  - name: CServerSideClient_ctor
+    alias:
+    - CServerSideClient::CServerSideClient
+  - name: CNetworkGameServer_CreateNewClient
+    alias:
+    - CNetworkGameServer::CreateNewClient
+  - name: CServerSideClient_IsHearingClient
+    alias:
+    - IsHearingClient
+  - name: CServerSideClient_ExecuteStringCommand
+    alias:
+    - CServerSideClient::ExecuteStringCommand
+  - name: CServerSideClient_ActivatePlayer
+    alias:
+    - CServerSideClient::ActivatePlayer
+  - name: ISource2GameClients_ClientSettingsChanged
+    alias:
+    - ISource2GameClients::ClientSettingsChanged
+  - name: CGameResourceService_BuildResourceManifest
+    alias:
+    - CGameResourceService::BuildResourceManifest
+    - BuildResourceManifest
+  - name: CGameResourceService_m_pEntitySystem
+    alias:
+    - GameEntitySystem
+  - name: CGameResourceService_LoadGameResourceManifestNamed
+    alias:
+    - CGameResourceService::LoadGameResourceManifestNamed
+  - name: CGameResourceService_LoadGameResourceManifestGroup
+    alias:
+    - CGameResourceService::LoadGameResourceManifestGroup
+  - name: CGameResourceService_GetResourceManifestDebugName
+    alias:
+    - CGameResourceService::GetResourceManifestDebugName
+  - name: CGameResourceService_PrecacheEntitiesAndConfirmResourcesAreLoaded
+    alias:
+    - CGameResourceService::PrecacheEntitiesAndConfirmResourcesAreLoaded
+  - name: CGameResourceService_LoadGameResourceManifest_IEntityResourceManifest
+    alias:
+    - CGameResourceService::LoadGameResourceManifest
+  - name: CGameResourceService_DescribeContents
+    alias:
+    - CGameResourceService::DescribeContents
+  - name: CGameResourceService_AppendToGameResourceManifest
+    alias:
+    - CGameResourceService::AppendToGameResourceManifest
+  - name: CGameResourceService_RegisterEventMap
+    alias:
+    - CGameResourceService::RegisterEventMap
+  - name: IEntityResourceManifestBuilder_BuildResourceManifest_ManifestNameOrGroupName
+    alias:
+    - IEntityResourceManifestBuilder::BuildResourceManifest
+  - name: CServerSideClientBase_ClientPrintf
+    alias:
+    - CServerSideClientBase::ClientPrintf
+    - ClientPrintf
+  - name: CNetworkGameServer_ClientList
+    alias:
+    - CNetworkGameServer::ClientList
+  - name: CNetworkGameServerBase_SendPeerList
+    alias:
+    - CNetworkGameServerBase::SendPeerList
+  - name: CNetworkGameServerBase_ConnectClient
+    alias:
+    - CNetworkGameServerBase::ConnectClient
+  - name: CNetworkGameServerBase_CheckPassword
+    alias:
+    - CNetworkGameServerBase::CheckPassword
+  - name: CNetworkGameServerBase_GetClientConnectionType
+    alias:
+    - CNetworkGameServerBase::GetClientConnectionType
+  - name: CNetworkGameServerBase_ServerSimulateInternal
+    alias:
+    - CNetworkGameServerBase::ServerSimulateInternal
+  - name: CNetworkGameServerBase_ServerSimulate
+    alias:
+    - CNetworkGameServerBase::ServerSimulate
+  - name: CNetworkGameServerBase_ServerPollNetworking
+    alias:
+    - CNetworkGameServerBase::ServerPollNetworking
+  - name: INetworkGameServer_IsChangelevelPending
+    alias:
+    - INetworkGameServer::IsChangelevelPending
+  - name: CNetworkGameServerBase_IsChangelevelPending
+    alias:
+    - CNetworkGameServerBase::IsChangelevelPending
+  - name: CNetworkGameServerBase_BroadcastMessage
+    alias:
+    - CNetworkGameServerBase::BroadcastMessage
+  - name: CNetworkGameServerBase_BroadcastPrintf
+    alias:
+    - CNetworkGameServerBase::BroadcastPrintf
+  - name: CNetworkGameServerBase_BroadcastEntityVoice
+    alias:
+    - CNetworkGameServerBase::BroadcastEntityVoice
+  - name: CNetworkGameServerBase_WriteDeltaEntities
+    alias:
+    - CNetworkGameServerBase::WriteDeltaEntities
+  - name: CNetworkGameServerBase_ReserveServerForQueuedGame
+    alias:
+    - CNetworkGameServerBase::ReserveServerForQueuedGame
+  - name: CNetworkGameServerBase_FinishChangeLevel
+    alias:
+    - CNetworkGameServerBase::FinishChangeLevel
+  - name: CNetworkGameServerBase_StartChangeLevel
+    alias:
+    - CNetworkGameServerBase::StartChangeLevel
+  - name: CNetworkGameServerBase_SetServerState
+    alias:
+    - CNetworkGameServerBase::SetServerState
+  - name: CNetworkGameServer_GetFreeClient
+    alias:
+    - CNetworkGameServer::GetFreeClient
+    - GetFreeClient
+  - name: CNetworkGameServerBase_CreateFakeClient
+    alias:
+    - CNetworkGameServerBase::CreateFakeClient
+  - name: CNetworkGameServerBase_UserInfoChanged
+    alias:
+    - CNetworkGameServerBase::UserInfoChanged
+  - name: CNetworkGameServerBase_GetPlayerNetworkIDString
+    alias:
+    - CNetworkGameServerBase::GetPlayerNetworkIDString
+  - name: CNetworkGameServerBase_StartHLTVMaster
+    alias:
+    - CNetworkGameServerBase::StartHLTVMaster
+  - name: CNetworkGameServerBase_RegisterLoadingSpawnGroups
+    alias:
+    - CNetworkGameServerBase::RegisterLoadingSpawnGroups
+  - name: CNetworkServerSpawnGroupCreatePrerequisites_Init
+    alias:
+    - CNetworkServerSpawnGroupCreatePrerequisites::Init
+  - name: CNetworkGameServerBase_LoadSpawnGroup
+    alias:
+    - CNetworkGameServerBase::LoadSpawnGroup
+  - name: CNetworkGameServerBase_SpawnGroupThink
+    alias:
+    - CNetworkGameServerBase::SpawnGroupThink
+  - name: CNetworkGameServerBase_PrintSpawnGroupStatus
+    alias:
+    - CNetworkGameServerBase::PrintSpawnGroupStatus
+  - name: CNetworkGameServerBase_AsyncUnloadSpawnGroup
+    alias:
+    - CNetworkGameServerBase::AsyncUnloadSpawnGroup
+  - name: CNetworkGameServerBase_AsyncUnloadSpawnGroupInternal
+    alias:
+    - CNetworkGameServerBase::AsyncUnloadSpawnGroupInternal
+  - name: CNetworkGameServer_PrepareForAssetLoad
+    alias:
+    - CNetworkGameServer::PrepareForAssetLoad
+  - name: CNetworkGameServerBase_IsSaveRestoreAllowed
+    alias:
+    - CNetworkGameServerBase::IsSaveRestoreAllowed
+  - name: CNetworkGameServer_IsPausable
+    alias:
+    - CNetworkGameServer::IsPausable
+  - name: CNetworkGameServerBase_Init
+    alias:
+    - CNetworkGameServerBase::Init
+  - name: CNetworkGameServerBase_Shutdown
+    alias:
+    - CNetworkGameServerBase::Shutdown
+  - name: CNetworkGameServerBase_ShutdownInternal
+    alias:
+    - CNetworkGameServerBase::ShutdownInternal
+  - name: CNetworkGameServer_ActivateServer
+    alias:
+    - CNetworkGameServer::ActivateServer
+  - name: CNetworkGameServer_DirectUpdate
+    alias:
+    - CNetworkGameServer::DirectUpdate
+  - name: CNetworkGameServerBase_ReplyChallenge
+    alias:
+    - CNetworkGameServerBase::ReplyChallenge
+  - name: CNetworkGameServerBase_GetChallengeType
+    alias:
+    - CNetworkGameServerBase::GetChallengeType
+  - name: CNetworkGameServer_Init
+    alias:
+    - CNetworkGameServer::Init
+  - name: CNetworkGameServer_Shutdown
+    alias:
+    - CNetworkGameServer::Shutdown
+  - name: ISource2Server_GetAllServerClasses
+    alias:
+    - ISource2Server::GetAllServerClasses
+  - name: CNetworkGameServer_SpawnServer
+    alias:
+    - CNetworkGameServer::SpawnServer
+  - name: CNetworkGameServerBase_GetMaxClients
+    alias:
+    - CNetworkGameServerBase::GetMaxClients
+  - name: CNetworkGameServerBase_GetClassBaseline
+    alias:
+    - CNetworkGameServerBase::GetClassBaseline
+  - name: CSteam3Server_SendUpdatedServerDetails
+    alias:
+    - CSteam3Server::SendUpdatedServerDetails
+  - name: CNetworkGameServerBase_GetMapName
+    alias:
+    - CNetworkGameServerBase::GetMapName
+  - name: CNetworkGameServerBase_GetHostName
+    alias:
+    - CNetworkGameServerBase::GetHostName
+  - name: CNetworkGameServerBase_SetMaxClients
+    alias:
+    - CNetworkGameServerBase::SetMaxClients
+  - name: CNetworkGameServerBase_FillKV3ServerInfo
+    alias:
+    - CNetworkGameServerBase::FillKV3ServerInfo
+  - name: CNetworkGameServerBase_CheckTimeouts
+    alias:
+    - CNetworkGameServerBase::CheckTimeouts
+  - name: CNetworkGameServerBase_IsHLTV
+    alias:
+    - CNetworkGameServerBase::IsHLTV
+  - name: ISource2Server_ShouldTimeoutClient
+    alias:
+    - ISource2Server::ShouldTimeoutClient
+  - name: CNetworkGameServerBase_GetPassword
+    alias:
+    - CNetworkGameServerBase::GetPassword
+  - name: CNetworkGameServerBase_OnKickById
+    alias:
+    - CNetworkGameServerBase::OnKickById
+  - name: CNetworkGameServerBase_OnKickByName
+    alias:
+    - CNetworkGameServerBase::OnKickByName
+  - name: CNetworkGameClient_SendMovePacket
+    alias:
+    - CNetworkGameClient::SendMovePacket
+    - SendMovePacket
+  - name: CNetworkGameClient_SendMove
+    alias:
+    - CNetworkGameClient::SendMove
+    - SendMove
+  - name: INetworkMessages_Serialize
+    alias:
+    - INetworkMessages::Serialize
+  - name: CDemoPlayer_SkipToTick
+    alias:
+    - CDemoPlayer::SkipToTick
+  - name: CDemoPlayer_PlayDemo
+    alias:
+    - CDemoPlayer::PlayDemo
+  - name: CDemoPlayer_StopPlayback
+    alias:
+    - CDemoPlayer::StopPlayback
+  - name: CDemoPlayer_StartPlayback
+    alias:
+    - CDemoPlayer::StartPlayback
+  - name: CDemoPlayer_SetIgnorePacketsForResourceLoading
+    alias:
+    - CDemoPlayer::SetIgnorePacketsForResourceLoading
+  - name: CDemoPlayer_InternalReadPacket
+    alias:
+    - CDemoPlayer::InternalReadPacket
+  - name: CDemoPlayer_Pause
+    alias:
+    - CDemoPlayer::Pause
+  - name: CDemoPlayer_m_bIsPlaying
+    alias:
+    - CDemoPlayer::m_bIsPlaying
+  - name: CDemoPlayer_m_bIsPaused
+    alias:
+    - CDemoPlayer::m_bIsPaused
+  - name: CDemoRecorder_ParseMessage
+    alias:
+    - CDemoRecorder::ParseMessage
+  - name: CDemoRecorder_WriteSpawnGroups
+    alias:
+    - CDemoRecorder::WriteSpawnGroups
+  - name: CHLTVDemoRecorder_WriteFrameImmediate
+    alias:
+    - CHLTVDemoRecorder::WriteFrameImmediate
+  - name: INetworkMessages_SerializeAbstract
+    alias:
+    - INetworkMessages::SerializeAbstract
+  - name: INetworkMessages_GetNetMessageInfo
+    alias:
+    - INetworkMessages::GetNetMessageInfo
+  - name: INetworkMessages_FindNetworkMessageById
+    alias:
+    - INetworkMessages::FindNetworkMessageById
+  - name: CNetChan_ProcessMessages
+    alias:
+    - CNetChan::ProcessMessages
+  - name: CNetChan_ParseMessagesDemo
+    alias:
+    - CNetChan::ParseMessagesDemo
+  - name: CNetworkGameClient_ProcessPacketEntitiesInternal
+    alias:
+    - CNetworkGameClient::ProcessPacketEntitiesInternal
+  - name: CNetworkGameClient_ProcessPacketEntities
+    alias:
+    - CNetworkGameClient::ProcessPacketEntities
+    - ProcessPacketEntities
+  - name: CNetworkGameClient_RecordEntityBandwidth
+    alias:
+    - CNetworkGameClient::RecordEntityBandwidth
+    - RecordEntityBandwidth
+  - name: CNetworkGameClient_PrintNetStats
+    alias:
+    - CNetworkGameClient::PrintNetStats
+  - name: CMsgSource2NetworkFlowQuality_PrintStats
+    alias:
+    - CMsgSource2NetworkFlowQuality::PrintStats
+  - name: CNetworkGameClientBase__ProcessNetworking
+    alias:
+    - CNetworkGameClientBase::ProcessNetworking
+  - name: CNetworkGameClient_CreateMove
+    alias:
+    - CNetworkGameClient::CreateMove
+  - name: ISource2Client_CreateMove
+    alias:
+    - ISource2Client::CreateMove
+  - name: CNetworkGameClient_SetSignonState
+    alias:
+    - CNetworkGameClient::SetSignonState
+  - name: CNetworkGameClient_ProcessReadPacketEntitiesWorkItems
+    alias:
+    - CNetworkGameClient::ProcessReadPacketEntitiesWorkItems
+  - name: CNetworkGameClient_OnPreserveEntity
+    alias:
+    - CNetworkGameClient::OnPreserveEntity
+  - name: CNetworkGameClient_GetClientNetworkable
+    alias:
+    - CNetworkGameClient::GetClientNetworkable
+  - name: CNetworkGameClient_CopyNewEntity
+    alias:
+    - CNetworkGameClient::CopyNewEntity
+  - name: CNetworkGameClient_CopyExistingEntity
+    alias:
+    - CNetworkGameClient::CopyExistingEntity
+  - name: CNetworkGameClient_OnReceivedUncompressedPacket
+    alias:
+    - CNetworkGameClient::OnReceivedUncompressedPacket
+  - name: CNetworkGameClient_Clear
+    alias:
+    - CNetworkGameClient::Clear
+  - name: CNetworkGameClient_DisconnectGame
+    alias:
+    - CNetworkGameClient::DisconnectGame
+  - name: INetworkMessages_FindNetworkGroup
+    alias:
+    - INetworkMessages::FindNetworkGroup
+  - name: INetworkClientService_IsActive
+    alias:
+    - INetworkClientService::IsActive
+  - name: INetworkClientService_IsConnected
+    alias:
+    - INetworkClientService::IsConnected
+  - name: INetworkClientService_IsPutInServer
+    alias:
+    - INetworkClientService::IsPutInServer
+  - name: INetworkClientService_IsConnecting
+    alias:
+    - INetworkClientService::IsConnecting
+  - name: CInputService_ProcessConVar
+    alias:
+    - CInputService::ProcessConVar
+  - name: CInputService_ProcessCommand
+    alias:
+    - CInputService::ProcessCommand
+  - name: CInputService_IsClientOnlyCommandAllowed
+    alias:
+    - CInputService::IsClientOnlyCommandAllowed
+  - name: CServerSideClientBase_SetConVarUserInfo
+    alias:
+    - CServerSideClientBase::SetConVarUserInfo
+  - name: CNetworkClientService_RegisterEventMapInternal
+    alias:
+    - CNetworkClientService::RegisterEventMapInternal
+  - name: CNetworkClientService_RegisterEventMap
+    alias:
+    - CNetworkClientService::RegisterEventMap
+  - name: CNetworkClientService_OnClientAdvanceTick
+    alias:
+    - CNetworkClientService::OnClientAdvanceTick
+  - name: CNetworkClientService_OnClientProcessGameInput
+    alias:
+    - CNetworkClientService::OnClientProcessGameInput
+  - name: ISource2Client_ProcessGameInput
+    alias:
+    - ISource2Client::ProcessGameInput
+  - name: CNetworkClientService_OnClientPollNetworking
+    alias:
+    - CNetworkClientService::OnClientPollNetworking
+  - name: CNetworkClientService_OnClientProcessNetworking
+    alias:
+    - CNetworkClientService::OnClientProcessNetworking
+  - name: CNetworkClientService_OnClientSimulate
+    alias:
+    - CNetworkClientService::OnClientSimulate
+  - name: CNetworkClientService_OnClientPauseSimulate
+    alias:
+    - CNetworkClientService::OnClientPauseSimulate
+  - name: CNetworkClientService_OnClientFrameSimulate
+    alias:
+    - CNetworkClientService::OnClientFrameSimulate
+  - name: CNetworkClientService_OnSimpleLoopFrameUpdate
+    alias:
+    - CNetworkClientService::OnSimpleLoopFrameUpdate
+  - name: CNetworkClientService_OnFrameBoundary
+    alias:
+    - CNetworkClientService::OnFrameBoundary
+  - name: CNetworkClientService_OnServerPostSimulate
+    alias:
+    - CNetworkClientService::OnServerPostSimulate
+  - name: CNetworkClientService_OnServerBeginAsyncPostTickWork
+    alias:
+    - CNetworkClientService::OnServerBeginAsyncPostTickWork
+  - name: CNetworkClientService_ReceivedServerInfo
+    alias:
+    - CNetworkClientService::ReceivedServerInfo
+  - name: CNetworkClientService_SplitScreenConnect
+    alias:
+    - CNetworkClientService::SplitScreenConnect
+  - name: CNetworkClientService_SendNetMessage
+    alias:
+    - CNetworkClientService::SendNetMessage
+  - name: CNetworkClientService_SendStringCmd
+    alias:
+    - CNetworkClientService::SendStringCmd
+  - name: CNetworkClientService_StartChangeLevel
+    alias:
+    - CNetworkClientService::StartChangeLevel
+  - name: CNetworkClientService_FinishChangeLevel
+    alias:
+    - CNetworkClientService::FinishChangeLevel
+  - name: CNetworkClientService_PrintConnectionStatus
+    alias:
+    - CNetworkClientService::PrintConnectionStatus
+  - name: CNetworkClientService_OnStatus
+    alias:
+    - CNetworkClientService::OnStatus
+  - name: CNetworkClientService_ServerCmd
+    alias:
+    - CNetworkClientService::ServerCmd
+  - name: CNetworkClientService_GetDisconnectReason
+    alias:
+    - CNetworkClientService::GetDisconnectReason
+  - name: CNetworkClientService_PrintSpawnGroupStatus
+    alias:
+    - CNetworkClientService::PrintSpawnGroupStatus
+  - name: CNetworkClientService_IsActive
+    alias:
+    - CNetworkClientService::IsActive
+  - name: CNetworkClientService_IsConnected
+    alias:
+    - CNetworkClientService::IsConnected
+  - name: CNetworkClientService_IsPutInServer
+    alias:
+    - CNetworkClientService::IsPutInServer
+  - name: CNetworkClientService_IsConnecting
+    alias:
+    - CNetworkClientService::IsConnecting
+  - name: CEngineSoundServices_ShouldSuppressNonUISounds
+    alias:
+    - CEngineSoundServices::ShouldSuppressNonUISounds
+  - name: CNetworkClientService_ClockDriftAdjustFrameTime
+    alias:
+    - CNetworkClientService::ClockDriftAdjustFrameTime
+  - name: CNetworkClientService_Init
+    alias:
+    - CNetworkClientService::Init
+  - name: CNetworkClientService_Shutdown
+    alias:
+    - CNetworkClientService::Shutdown
+  - name: CNetworkClientService_DisconnectGameNow
+    alias:
+    - CNetworkClientService::DisconnectGameNow
+  - name: CGameClientConnectPrerequisite_ctor
+    alias:
+    - CGameClientConnectPrerequisite::CGameClientConnectPrerequisite
+  - name: CNetworkClientSpawnGroupCreatePrerequisites_GetStatus
+    alias:
+    - CNetworkClientSpawnGroupCreatePrerequisites::GetStatus
+  - name: CWaitForInitialSpawnGroupsPrerequisite_GetStatus
+    alias:
+    - CWaitForInitialSpawnGroupsPrerequisite::GetStatus
+  - name: INetworkGameServer_GetSpawnGroupLoadingStatus
+    alias:
+    - INetworkGameServer::GetSpawnGroupLoadingStatus
+  - name: CNetworkClientService_AddClientPrerequisites
+    alias:
+    - CNetworkClientService::AddClientPrerequisites
+  - name: CNetworkClientService_AllocateRemoteConnectionClient
+    alias:
+    - CNetworkClientService::AllocateRemoteConnectionClient
+  - name: CNetworkGameServer_WriteClassInfosAndSerializesToBuffer
+    alias:
+    - CNetworkGameServer::WriteClassInfosAndSerializesToBuffer
+  - name: INetworkServerService_GetServerSerializersCRC
+    alias:
+    - INetworkServerService::GetServerSerializersCRC
+  - name: CNetworkServerService_GetServerSerializersCRC
+    alias:
+    - CNetworkServerService::GetServerSerializersCRC
+  - name: CSteam3ServerS1_InitGameServer
+    alias:
+    - CSteam3ServerS1::InitGameServer
+  - name: INetworkServerService_IsActiveInGame
+    alias:
+    - INetworkServerService::IsActiveInGame
+  - name: INetworkServerService_IsServerRunning
+    alias:
+    - INetworkServerService::IsServerRunning
+  - name: CNetworkServerService_SetGameSpawnGroupMgr
+    alias:
+    - CNetworkServerService::SetGameSpawnGroupMgr
+  - name: CNetworkServerService_AddServerPrerequisites
+    alias:
+    - CNetworkServerService::AddServerPrerequisites
+  - name: CNetworkServerService_SetFinalSimulationTickThisFrame
+    alias:
+    - CNetworkServerService::SetFinalSimulationTickThisFrame
+  - name: CNetworkServerService_Init
+    alias:
+    - CNetworkServerService::Init
+  - name: CNetworkServerService_StartupServer
+    alias:
+    - CNetworkServerService::StartupServer
+  - name: CNetworkServerService_RegisterEventMapInternal
+    alias:
+    - CNetworkServerService::RegisterEventMapInternal
+  - name: CNetworkServerService_OnServerAdvanceTick
+    alias:
+    - CNetworkServerService::OnServerAdvanceTick
+  - name: CNetworkServerService_OnServerPollNetworking
+    alias:
+    - CNetworkServerService::OnServerPollNetworking
+  - name: CNetworkServerService_OnServerProcessNetworking
+    alias:
+    - CNetworkServerService::OnServerProcessNetworking
+  - name: CNetworkServerService_OnServerBeginSimulate
+    alias:
+    - CNetworkServerService::OnServerBeginSimulate
+  - name: CNetworkServerService_OnServerEndSimulate
+    alias:
+    - CNetworkServerService::OnServerEndSimulate
+  - name: CNetworkServerService_OnServerPostSimulate
+    alias:
+    - CNetworkServerService::OnServerPostSimulate
+  - name: CNetworkServerService_OnServerPostAdvanceTick
+    alias:
+    - CNetworkServerService::OnServerPostAdvanceTick
+  - name: CNetworkServerService_OnFrameBoundary
+    alias:
+    - CNetworkServerService::OnFrameBoundary
+  - name: CNetworkServerService_OnClientPollNetworking
+    alias:
+    - CNetworkServerService::OnClientPollNetworking
+  - name: CNetworkServerService_OnSimpleLoopFrameUpdate
+    alias:
+    - CNetworkServerService::OnSimpleLoopFrameUpdate
+  - name: CNetworkServerService_OnKickByIdHLTV
+    alias:
+    - CNetworkServerService::OnKickByIdHLTV
+  - name: CNetworkServerService_DisconnectGameNow
+    alias:
+    - CNetworkServerService::DisconnectGameNow
+  - name: INetworkGameServer_GetMaxClients
+    alias:
+    - INetworkGameServer::GetMaxClients
+  - name: INetworkGameServer_PreWorldUpdate
+    alias:
+    - INetworkGameServer::PreWorldUpdate
+  - name: CNetworkGameServer_PreWorldUpdate
+    alias:
+    - CNetworkGameServer::PreWorldUpdate
+  - name: INetworkGameServer_ServerEndSimulate
+    alias:
+    - INetworkGameServer::ServerEndSimulate
+  - name: CNetworkGameServerBase_ServerEndSimulate
+    alias:
+    - CNetworkGameServerBase::ServerEndSimulate
+  - name: CNetworkGameServerBase_CalculateCPUUsage
+    alias:
+    - CNetworkGameServerBase::CalculateCPUUsage
+  - name: INetworkGameServer_ServerPostSimulate
+    alias:
+    - INetworkGameServer::ServerPostSimulate
+  - name: CNetworkGameServerBase_ServerPostSimulate
+    alias:
+    - CNetworkGameServerBase::ServerPostSimulate
+  - name: CNetworkGameServer_ServerPostSimulate
+    alias:
+    - CNetworkGameServer::ServerPostSimulate
+  - name: INetworkGameServer_ServerAdvanceTick
+    alias:
+    - INetworkGameServer::ServerAdvanceTick
+  - name: CNetworkGameServerBase_ServerAdvanceTick
+    alias:
+    - CNetworkGameServerBase::ServerAdvanceTick
+  - name: INetworkGameServer_GetTime
+    alias:
+    - INetworkGameServer::GetTime
+  - name: INetworkGameServer_ServerProcessNetworking
+    alias:
+    - INetworkGameServer::ServerProcessNetworking
+  - name: CNetworkGameServerBase_ServerProcessNetworking
+    alias:
+    - CNetworkGameServerBase::ServerProcessNetworking
+  - name: INetworkGameServer_GetTimescale
+    alias:
+    - INetworkGameServer::GetTimescale
+  - name: CNetworkGameServerBase_GetTimescale
+    alias:
+    - CNetworkGameServerBase::GetTimescale
+  - name: INetworkGameServer_GetServerNetworkAddress
+    alias:
+    - INetworkGameServer::GetServerNetworkAddress
+  - name: ISource2Server_PreWorldUpdate
+    alias:
+    - ISource2Server::PreWorldUpdate
+  - name: ISource2Server_UpdateWhenNotInGame
+    alias:
+    - ISource2Server::UpdateWhenNotInGame
+  - name: INetworkMessages_SetIsForServer
+    alias:
+    - INetworkMessages::SetIsForServer
+  - name: CRenderingWorldSession_FindOrCreateWorldSession
+    alias:
+    - CRenderingWorldSession::FindOrCreateWorldSession
+  - name: CRenderingWorldSession_GetEntityLumpForTemplate
+    alias:
+    - CRenderingWorldSession::GetEntityLumpForTemplate
+  - name: CEngineClient_GetEntityLumpForTemplate
+    alias:
+    - CEngineClient::GetEntityLumpForTemplate
+  - name: CEngineClient_FindOrCreateWorldSession
+    alias:
+    - CEngineClient::FindOrCreateWorldSession
+  - name: CEngineClient_GetStatsAppID
+    alias:
+    - CEngineClient::GetStatsAppID
+  - name: CEngineClient_DumpNetStats
+    alias:
+    - CEngineClient::DumpNetStats
+  - name: CEngineClient_ExecuteClientCmd
+    alias:
+    - CEngineClient::ExecuteClientCmd
+  - name: CEngineClient_IsPlayingDemo
+    alias:
+    - CEngineClient::IsPlayingDemo
+  - name: CInputService_ProcessCommandBuffer
+    alias:
+    - CInputService::ProcessCommandBuffer
+  - name: CInputService_ProcessCommandBuffers
+    alias:
+    - CInputService::ProcessCommandBuffers
+  - name: CInputService_HandleAnalogValueChange
+    alias:
+    - CInputService::HandleAnalogValueChange
+  - name: CInputService_HandleInputEvent
+    alias:
+    - CInputService::HandleInputEvent
+  - name: CEngineClient_ClientCmd_Unrestricted
+    alias:
+    - CEngineClient::ClientCmd_Unrestricted
+  - name: INetworkGameClient_SendStringCmd
+    alias:
+    - INetworkGameClient::SendStringCmd
+  - name: CEngineServer_DumpNetStats
+    alias:
+    - CEngineServer::DumpNetStats
+  - name: CEngineServer_ClientPrintf
+    alias:
+    - CEngineServer::ClientPrintf
+  - name: CEngineServer_GetFrameTimeAmnesty
+    alias:
+    - CEngineServer::GetFrameTimeAmnesty
+  - name: CEngineServer_ShowFrameTimeReport
+    alias:
+    - CEngineServer::ShowFrameTimeReport
+  - name: CEngineServer_SetFrameTimeAmnesty
+    alias:
+    - CEngineServer::SetFrameTimeAmnesty
+  - name: CEngineServer_GetSteamUniverse
+    alias:
+    - CEngineServer::GetSteamUniverse
+  - name: CEngineServer_ChangeLevel
+    alias:
+    - CEngineServer::ChangeLevel
+  - name: CMapListService_IsMapValid
+    alias:
+    - CMapListService::IsMapValid
+    - IMapListService::IsMapValid
+  - name: CEngineServer_IsMapValid
+    alias:
+    - CEngineServer::IsMapValid
+  - name: CEngineServer_PrecacheGeneric
+    alias:
+    - CEngineServer::PrecacheGeneric
+  - name: CEngineServer_ClientCommand
+    alias:
+    - CEngineServer::ClientCommand
+  - name: CEngineServer_GetClientConVarValue
+    alias:
+    - CEngineServer::GetClientConVarValue
+  - name: CEngineServer_SetFakeClientConVarValue
+    alias:
+    - CEngineServer::SetFakeClientConVarValue
+  - name: CEngineServer_CreateFakeClient
+    alias:
+    - CEngineServer::CreateFakeClient
+  - name: CEngineServer_GetPlayerInfo
+    alias:
+    - CEngineServer::GetPlayerInfo
+  - name: CEngineServer_ClientCommandKeyValues
+    alias:
+    - CEngineServer::ClientCommandKeyValues
+  - name: CLog_Print
+    alias:
+    - CLog::Print
+  - name: CEngineServer_LogPrint
+    alias:
+    - CEngineServer::LogPrint
+  - name: CEngineServer_KickClient
+    alias:
+    - CEngineServer::KickClient
+  - name: CEngineServer_IsDedicatedServer
+    alias:
+    - CEngineServer::IsDedicatedServer
+  - name: CEngineServer_GetServerGlobals
+    alias:
+    - CEngineServer::GetServerGlobals
+  - name: CEngineServer_GetAchievementMgr
+    alias:
+    - CEngineServer::GetAchievementMgr
+  - name: CEngineServer_IsLogEnabled
+    alias:
+    - CEngineServer::IsLogEnabled
+  - name: CEngineServer_ServerCommand
+    alias:
+    - CEngineServer::ServerCommand
+  - name: CLoopTypeClientSimple_ActivateEngineServices
+    alias:
+    - CLoopTypeClientServer::ActivateEngineServices
+  - name: CLoopTypeClientServer_LoopTypeInit
+    alias:
+    - CLoopTypeClientServer::LoopTypeInit
+  - name: CLoopTypeClientServer_AdvanceTime
+    alias:
+    - CLoopTypeClientServer::AdvanceTime
+  - name: CLoopTypeClientServer_Update
+    alias:
+    - CLoopTypeClientServer::Update
+  - name: CLoopTypeClientServer_ActivateLoop
+    alias:
+    - CLoopTypeClientServer::ActivateLoop
+  - name: ISource2Server_GetActiveWorldName
+    alias:
+    - ISource2Server::GetActiveWorldName
+  - name: CLoopTypeClientServer_AllocateLoopMode
+    alias:
+    - CLoopTypeClientServer::AllocateLoopMode
+  - name: CLoopTypeClientServer_WritePerfStats
+    alias:
+    - CLoopTypeClientServer::WritePerfStats
+  - name: CLoopTypeClientServer_DeactivateLoop
+    alias:
+    - CLoopTypeClientServer::DeactivateLoop
+  - name: CLoopTypeClientServer_OutputListeners
+    alias:
+    - CLoopTypeClientServer::OutputListeners
+  - name: CLoopTypeSimple_FrameUpdate
+    alias:
+    - CLoopTypeSimple::FrameUpdate
+  - name: CLoopTypeClientServerService_OnLoopActivate
+    alias:
+    - CLoopTypeClientServerService::OnLoopActivate
+  - name: CLoopTypeSimpleService_OnLoopActivate
+    alias:
+    - CLoopTypeSimpleService::OnLoopActivate
+  - name: CLoopTypeClientServerService_HandleInputEvent
+    alias:
+    - CLoopTypeClientServerService::HandleInputEvent
+  - name: ILoopMode_HandleInputEvent
+    alias:
+    - ILoopMode::HandleInputEvent
+  - name: ILoopType_AddEngineService
+    alias:
+    - ILoopType::AddEngineService
+  - name: CLoopTypeBase_DeallocateLoopMode
+    alias:
+    - CLoopTypeBase::DeallocateLoopMode
+  - name: CLoopTypeBase_EngineLoop
+    alias:
+    - CLoopTypeBase::EngineLoop
+  - name: CLoopTypeBase_FrameUpdate
+    alias:
+    - CLoopTypeBase::FrameUpdate
+  - name: CLoopTypeBase_ActivateLoop
+    alias:
+    - CLoopTypeBase::ActivateLoop
+  - name: CLoopTypeBase_AllocateLoopMode
+    alias:
+    - CLoopTypeBase::AllocateLoopMode
+  - name: CLoopTypeBase_DeactivateLoop
+    alias:
+    - CLoopTypeBase::DeactivateLoop
+  - name: CLoopTypeBase_LoopTypeInit
+    alias:
+    - CLoopTypeBase::LoopTypeInit
+  - name: CLoopTypeBase_LoopTypeShutdown
+    alias:
+    - CLoopTypeBase::LoopTypeShutdown
+  - name: CLoopTypeBase_GetClientServerMode
+    alias:
+    - CLoopTypeBase::GetClientServerMode
+  - name: CLoopTypeBase_GetImplType
+    alias:
+    - CLoopTypeBase::GetImplType
+  - name: CLoopTypeBase_AddDependentServices
+    alias:
+    - CLoopTypeBase::AddDependentServices
+  - name: CLoopTypeBase_GenerateServiceDependencies
+    alias:
+    - CLoopTypeBase::GenerateServiceDependencies
+  - name: CLoopTypeBase_GenerateSecondaryDependencies
+    alias:
+    - CLoopTypeBase::GenerateSecondaryDependencies
+  - name: CLoopTypeBase_LoadDependentServices
+    alias:
+    - CLoopTypeBase::LoadDependentServices
+  - name: IEngineService_GetServiceDependencies
+    alias:
+    - IEngineService::GetServiceDependencies
+  - name: IEngineService_GetName
+    alias:
+    - IEngineService::GetName
+  - name: ILoopModeFactory_GetLoopModeType
+    alias:
+    - ILoopModeFactory::GetLoopModeType
+  - name: ILoopModeFactory_Shutdown
+    alias:
+    - ILoopModeFactory::Shutdown
+  - name: CEngineServiceMgr_RegisterEngineService
+    alias:
+    - CEngineServiceMgr::RegisterEngineService
+  - name: CEngineServiceMgr_RegisterLoopMode
+    alias:
+    - CEngineServiceMgr::RegisterLoopMode
+  - name: CEngineServiceMgr_UnregisterLoopMode
+    alias:
+    - CEngineServiceMgr::UnregisterLoopMode
+  - name: CEngineServiceMgr_UnregisterEngineService
+    alias:
+    - CEngineServiceMgr::UnregisterEngineService
+  - name: CEngineServiceMgr_SwitchToLoop
+    alias:
+    - CEngineServiceMgr::SwitchToLoop
+  - name: CEngineServiceMgr_PrintStatus
+    alias:
+    - CEngineServiceMgr::PrintStatus
+  - name: CEngineServiceMgr__MainLoop
+    alias:
+    - CEngineServiceMgr::_MainLoop
+  - name: CEngineServiceMgr_DeactivateLoop
+    alias:
+    - CEngineServiceMgr::DeactivateLoop
+  - name: CEngineServiceMgr_Shutdown
+    alias:
+    - CEngineServiceMgr::Shutdown
+  - name: CEngineServiceMgr_GetActiveLoopClientServerMode
+    alias:
+    - CEngineServiceMgr::GetActiveLoopClientServerMode
+  - name: CEngineServiceMgr_GetEventDispatcher
+    alias:
+    - CEngineServiceMgr::GetEventDispatcher
+  - name: CEngineGameUI_Shutdown
+    alias:
+    - CEngineGameUI::Shutdown
+  - name: IAppSystem_Shutdown
+    alias:
+    - IAppSystem::Shutdown
+  - name: CSplitScreenService_AddSplitScreenUser
+    alias:
+    - CSplitScreenService::AddSplitScreenUser
+  - name: CSplitScreenService_LoadUserConfiguration
+    alias:
+    - CSplitScreenService::LoadUserConfiguration
+  - name: CHLTVClient_ProcessSetConVar
+    alias:
+    - CHLTVClient::ProcessSetConVar
+  - name: CHLTVBroadcast_RecordSnapshot
+    alias:
+    - CHLTVBroadcast::RecordSnapshot
+  - name: CServerSideClientBase_SendServerInfo
+    alias:
+    - CServerSideClientBase::SendServerInfo
+  - name: CNetworkGameServerBase_FillServerInfo
+    alias:
+    - CNetworkGameServerBase::FillServerInfo
+  - name: CServerSideClientBase_ProcessTick
+    alias:
+    - CServerSideClientBase::ProcessTick
+  - name: CServerSideClientBase_ProcessStringCmd
+    alias:
+    - CServerSideClientBase::ProcessStringCmd
+  - name: CServerSideClientBase_MarkSpawnGroupLoadCompleted
+    alias:
+    - CServerSideClientBase::MarkSpawnGroupLoadCompleted
+  - name: CServerSideClientBase_ProcessSpawnGroup_LoadCompleted
+    alias:
+    - CServerSideClientBase::ProcessSpawnGroup_LoadCompleted
+  - name: CServerSideClientBase_ProcessClientInfo
+    alias:
+    - CServerSideClientBase::ProcessClientInfo
+  - name: CServerSideClientBase_ProcessBaselineAck
+    alias:
+    - CServerSideClientBase::ProcessBaselineAck
+  - name: CServerSideClientBase_ProcessSplitPlayerConnectInternal
+    alias:
+    - CServerSideClientBase::ProcessSplitPlayerConnectInternal
+  - name: CServerSideClientBase_ProcessSplitPlayerConnect
+    alias:
+    - CServerSideClientBase::ProcessSplitPlayerConnect
+  - name: CServerSideClientBase_GetUserIDString
+    alias:
+    - CServerSideClientBase::GetUserIDString
+  - name: CServerSideClientBase_GetNetworkIDString
+    alias:
+    - CServerSideClientBase::GetNetworkIDString
+  - name: CServerSideClientBase_dtor
+    alias:
+    - CServerSideClientBase::~CServerSideClientBase
+  - name: CServerSideClientBase_Connect
+    alias:
+    - CServerSideClientBase::Connect
+  - name: CServerSideClientBase_GetPlayerInfo
+    alias:
+    - CServerSideClientBase::GetPlayerInfo
+  - name: CNetworkGameServer_GetPlayerNetworkIDString
+    alias:
+    - CNetworkGameServer::GetPlayerNetworkIDString
+  - name: CNetworkGameServer_RemoveClientFromGame
+    alias:
+    - CNetworkGameServer::RemoveClientFromGame
+  - name: CEngineServer_GetPlayerNetworkIDString
+    alias:
+    - CEngineServer::GetPlayerNetworkIDString
+  - name: CNetworkGameClientBase_ServerCmd
+    alias:
+    - CNetworkGameClientBase::ServerCmd
+  - name: CNetworkGameClientBase_ProcessSetConVar
+    alias:
+    - CNetworkGameClientBase::ProcessSetConVar
+  - name: CNetworkGameClientBase_SendStringCmd
+    alias:
+    - CNetworkGameClientBase::SendStringCmd
+  - name: CNetworkGameClientBase_StartChangeLevel
+    alias:
+    - CNetworkGameClientBase::StartChangeLevel
+  - name: CNetworkGameClientBase_FinishChangeLevel
+    alias:
+    - CNetworkGameClientBase::FinishChangeLevel
+  - name: CNetworkGameClientBase_DeferActivate
+    alias:
+    - CNetworkGameClientBase::DeferActivate
+  - name: CNetworkGameClientBase_ClockDrift_AdjustFrameTime
+    alias:
+    - CNetworkGameClientBase::ClockDrift_AdjustFrameTime
+  - name: CNetworkGameClientBase_Connect
+    alias:
+    - CNetworkGameClientBase::Connect
+  - name: CNetworkGameClientBase_DisconnectGame
+    alias:
+    - CNetworkGameClientBase::DisconnectGame
+  - name: CNetSupportImpl_Connect
+    alias:
+    - CNetSupportImpl::Connect
+- name: client
+  symbols:
+  - name: CLoopModeGame_RegisterEventMapInternal
+    alias:
+    - CLoopModeGame::RegisterEventMapInternal
+  - name: CLoopModeGame_OnClientPollNetworking
+    alias:
+    - CLoopModeGame::OnClientPollNetworking
+  - name: CLoopModeGame_OnClientAdvanceTick
+    alias:
+    - CLoopModeGame::OnClientAdvanceTick
+  - name: CLoopModeGame_OnClientPostAdvanceTick
+    alias:
+    - CLoopModeGame::OnClientPostAdvanceTick
+  - name: CLoopModeGame_OnClientPreSimulate
+    alias:
+    - CLoopModeGame::OnClientPreSimulate
+  - name: CLoopModeGame_OnClientPreOutput
+    alias:
+    - CLoopModeGame::OnClientPreOutput
+  - name: CLoopModeGame_OnClientPreOutputParallelWithServer
+    alias:
+    - CLoopModeGame::OnClientPreOutputParallelWithServer
+  - name: CLoopModeGame_OnClientPostOutput
+    alias:
+    - CLoopModeGame::OnClientPostOutput
+  - name: CLoopModeGame_OnClientFrameSimulate
+    alias:
+    - CLoopModeGame::OnClientFrameSimulate
+  - name: CLoopModeGame_OnClientAdvanceNonRenderedFrame
+    alias:
+    - CLoopModeGame::OnClientAdvanceNonRenderedFrame
+  - name: CLoopModeGame_OnClientPostSimulate
+    alias:
+    - CLoopModeGame::OnClientPostSimulate
+  - name: CLoopModeGame_OnClientPauseSimulate
+    alias:
+    - CLoopModeGame::OnClientPauseSimulate
+  - name: CLoopModeGame_OnClientSimulate
+    alias:
+    - CLoopModeGame::OnClientSimulate
+  - name: CLoopModeGame_OnPostDataUpdate
+    alias:
+    - CLoopModeGame::OnPostDataUpdate
+  - name: CLoopModeGame_OnPreDataUpdate
+    alias:
+    - CLoopModeGame::OnPreDataUpdate
+  - name: CLoopModeGame_OnFrameBoundary
+    alias:
+    - CLoopModeGame::OnFrameBoundary
+  - name: CLoopModeGame_StaticInit
+    alias:
+    - CLoopModeGame::StaticInit
+  - name: CLoopModeFactory_CLoopModeGame_Init
+    alias:
+    - CLoopModeFactory<CLoopModeGame>::Init
+  - name: CLoopModeFactory_CLoopModeGame_Shutdown
+    alias:
+    - CLoopModeFactory<CLoopModeGame>::Shutdown
+  - name: CLoopModeGame_OnLoopActivate
+    alias:
+    - CLoopModeGame::OnLoopActivate
+  - name: ILoopMode_OnLoopActivate
+    alias:
+    - ILoopMode::OnLoopActivate
+  - name: CLoopModeGame_AddViewsToSceneSystem
+    alias:
+    - CLoopModeGame::AddViewsToSceneSystem
+  - name: ILoopMode_AddViewsToSceneSystem
+    alias:
+    - ILoopMode::AddViewsToSceneSystem
+  - name: CLoopModeGame_LoopInitInternal
+    alias:
+    - CLoopModeGame::LoopInitInternal
+  - name: CLoopModeGame_LoopInit
+    alias:
+    - CLoopModeGame::LoopInit
+  - name: ILoopMode_LoopInit
+    alias:
+    - ILoopMode::LoopInit
+  - name: ILoopMode_LoopShutdown
+    alias:
+    - ILoopMode::LoopShutdown
+  - name: CLoopModeGame_ReceivedServerInfo
+    alias:
+    - CLoopModeGame::ReceivedServerInfo
+  - name: CLoopModeGame_RegisterEventMap
+    alias:
+    - CLoopModeGame::RegisterEventMap
+  - name: ILoopMode_RegisterEventMap
+    alias:
+    - ILoopMode::RegisterEventMap
+  - name: CLoopModeGame_SetWorldSession
+    alias:
+    - CLoopModeGame::SetWorldSession
+  - name: CLoopModeGame_SetGameSystemState
+    alias:
+    - CLoopModeGame::SetGameSystemState
+  - name: CLoopModeGame_LoopShutdown
+    alias:
+    - CLoopModeGame::LoopShutdown
+  - name: IGameSystem_AddByName
+    alias:
+    - IGameSystem::AddByName
+  - name: IGameSystem_Add
+    alias:
+    - IGameSystem::Add
+  - name: IGameSystem_PostInit
+    alias:
+    - IGameSystem::PostInit
+  - name: IGameSystem_InitAllSystems
+    alias:
+    - IGameSystem::InitAllSystems
+  - name: IGameSystem_LoopInitAllSystems
+    alias:
+    - IGameSystem::LoopInitAllSystems
+  - name: IGameSystemFactory_PostInit
+    alias:
+    - IGameSystemFactory::PostInit
+  - name: IGameSystemFactory_GetStaticGameSystem
+    alias:
+    - IGameSystemFactory::GetStaticGameSystem
+  - name: IGameSystemFactory_ShouldAutoAdd
+    alias:
+    - IGameSystemFactory::ShouldAutoAdd
+  - name: IGameSystemFactory_CreateGameSystem
+    alias:
+    - IGameSystemFactory::CreateGameSystem
+  - name: IGameSystemFactory_IsReallocating
+    alias:
+    - IGameSystemFactory::IsReallocating
+  - name: IGameSystem_SetName
+    alias:
+    - IGameSystem::SetName
+  - name: CSpawnGroupMgrGameSystem_DoesGameSystemReallocate
+    alias:
+    - IGameSystem::DoesGameSystemReallocate
+  - name: IGameSystem_DestroyAllGameSystems
+    alias:
+    - IGameSystem::DestroyAllGameSystems
+  - name: IGameSystem_ShutdownAllSystems
+    alias:
+    - IGameSystem::ShutdownAllSystems
+  - name: IGameSystem_LoopDestroyAllSystems
+    alias:
+    - IGameSystem::LoopDestroyAllSystems
+  - name: IGameSystem_LoopPreShutdownAllSystems
+    alias:
+    - IGameSystem::LoopPreShutdownAllSystems
+  - name: IGameSystem_OnClientPollNetworking
+    alias:
+    - IGameSystem::OnClientPollNetworking
+  - name: IGameSystem_OnClientGamePostSimulate
+    alias:
+    - IGameSystem::ClientGamePostSimulate
+  - name: IGameSystem_OnClientPauseSimulate
+    alias:
+    - IGameSystem::OnClientPauseSimulate
+  - name: IGameSystem_OnClientPreUpdate
+    alias:
+    - IGameSystem::OnClientPreUpdate
+  - name: IGameSystem_OnClientPostUpdate
+    alias:
+    - IGameSystem::OnClientPostUpdate
+  - name: IGameSystem_OnClientPostDataUpdate
+    alias:
+    - IGameSystem::OnClientPostDataUpdate
+  - name: IGameSystem_OnGameFrameBoundary
+    alias:
+    - IGameSystem::OnGameFrameBoundary
+  - name: IGameSystem_OnClientAdvanceNonRenderedFrame
+    alias:
+    - IGameSystem::OnClientAdvanceNonRenderedFrame
+  - name: IGameSystem_OnClientFrameSimulate
+    alias:
+    - IGameSystem::OnClientFrameSimulate
+  - name: IGameSystem_OnClientAdvanceTick
+    alias:
+    - IGameSystem::ClientAdvanceTick
+  - name: IGameSystem_OnClientPostAdvanceTick
+    alias:
+    - IGameSystem::ClientPostAdvanceTick
+  - name: IGameSystem_OnClientPostRender
+    alias:
+    - IGameSystem::OnClientPostRender
+  - name: IGameSystem_OnClientPreRender
+    alias:
+    - IGameSystem::OnClientPreRender
+  - name: IGameSystem_OnClientPreRenderAlt
+    alias:
+    - IGameSystem::OnClientPreRenderAlt
+  - name: CSource2Client_CreateMove
+    alias:
+    - CSource2Client::CreateMove
+  - name: CClientInput_CreateMove
+    alias:
+    - CClientInput::CreateMove
+  - name: CClientInput_m_viewangles
+    alias:
+    - CClientInput::m_viewangles
+  - name: CSource2Client_ProcessGameInput
+    alias:
+    - CSource2Client::ProcessGameInput
+  - name: ISource2Client_FrameStageNotify
+    alias:
+    - ISource2Client::FrameStageNotify
+  - name: CSource2Client_FrameStageNotify
+    alias:
+    - CSource2Client::FrameStageNotify
+  - name: IViewRender_OnRenderStart
+    alias:
+    - IViewRender::OnRenderStart
+  - name: CViewRender_OnRenderStart
+    alias:
+    - CViewRender::OnRenderStart
+  - name: CViewRender_Render
+    alias:
+    - CViewRender::Render
+  - name: C_BaseEntity_SetInterpolationPhase
+    alias:
+    - C_BaseEntity::SetInterpolationPhase
+  - name: CSource2Client_SetGlobals
+    alias:
+    - CSource2Client::SetGlobals
+  - name: CSource2Client_Connect
+    alias:
+    - CSource2Client::Connect
+  - name: CBasePlayerController_CheckForLocalPlayer
+    alias:
+    - CBasePlayerController::CheckForLocalPlayer
+  - name: CSource2Client_OnDisconnect
+    alias:
+    - CSource2Client::OnDisconnect
+  - name: IGameSystem_OnClientDisconnect
+    alias:
+    - IGameSystem::OnClientDisconnect
+  - name: IGameSystem_OnClientPreEntityThink
+    alias:
+    - IGameSystem::OnClientPreEntityThink
+  - name: CNetworkGameClient_OnSource1Source1LegacyGameEvent
+    alias:
+    - CNetworkGameClient::OnSource1Source1LegacyGameEvent
+  - name: CMapAnNodeManager_FireGameEvent
+    alias:
+    - CMapAnNodeManager::FireGameEvent
+  - name: C_ServerVoiceHandler_OnServerVoiceData
+    alias:
+    - C_ServerVoiceHandler::OnServerVoiceData
+  - name: IVEngineClient2_IsPlayingDemo
+    alias:
+    - IVEngineClient2::IsPlayingDemo
+  - name: IVEngineClient2_ExecuteClientCmd
+    alias:
+    - IVEngineClient2::ExecuteClientCmd
+  - name: IGameEventManager2_UnserializeEvent
+    alias:
+    - IGameEventManager2::UnserializeEvent
+  - name: IGameEventManager2_FireEventClientSide
+    alias:
+    - IGameEventManager2::FireEventClientSide
+  - name: CGameEventManager_FireEventClientSide
+    alias:
+    - CGameEventManager::FireEventClientSide
+  - name: CGameEventManager_UnserializeEvent
+    alias:
+    - CGameEventManager::UnserializeEvent
+  - name: CSteamworksGameStats_OnReceivedSessionID
+    alias:
+    - CSteamworksGameStats::OnReceivedSessionID
+  - name: IGameSystem_GetName
+    alias:
+    - IGameSystem::GetName
+  - name: IGameSystemFactory_DestroyGameSystem
+    alias:
+    - IGameSystemFactory::DestroyGameSystem
+  - name: IGameSystemFactory_Init
+    alias:
+    - IGameSystemFactory::Init
+  - name: IGameSystemFactory_GetPriority
+    alias:
+    - IGameSystemFactory::GetPriority
+  - name: IGameSystemFactory_Shutdown
+    alias:
+    - IGameSystemFactory::Shutdown
+  - name: IGameSystemFactory_SetGlobalPtr
+    alias:
+    - IGameSystemFactory::SetGlobalPtr
+  - name: CPrediction_PostNetworkDataReceived
+    alias:
+    - CPrediction::PostNetworkDataReceived
+  - name: IEngineServiceMgr_GetActiveLoopClientServerMode
+    alias:
+    - IEngineServiceMgr::GetActiveLoopClientServerMode
+  - name: IEngineServiceMgr_GetEventDispatcher
+    alias:
+    - IEngineServiceMgr::GetEventDispatcher
+  - name: ClientModeCSNormal_Update
+    alias:
+    - ClientModeCSNormal::Update
+  - name: CEntitySystem_ctor
+    alias:
+    - CEntitySystem::CEntitySystem
+  - name: CGameEntitySystem_ctor
+    alias:
+    - CGameEntitySystem::CGameEntitySystem
+  - name: CEntitySystem_Init
+    alias:
+    - CEntitySystem::Init
+  - name: CEntitySystem_PostCreateEntitySystem
+    alias:
+    - CEntitySystem::PostCreateEntitySystem
+  - name: CSource2EntitySystem_StaticInit
+    alias:
+    - CSource2EntitySystem::StaticInit
+  - name: CGameSystemReallocatingFactory_CSource2EntitySystem_Init
+    alias:
+    - CGameSystemReallocatingFactory<CSource2EntitySystem>::Init
+  - name: CGameSystemReallocatingFactory_CSource2EntitySystem_CreateGameSystem
+    alias:
+    - CGameSystemReallocatingFactory<CSource2EntitySystem>::CreateGameSystem
+  - name: CSkeletonInstance_PostDataUpdate
+    alias:
+    - CSkeletonInstance::PostDataUpdate
+  - name: CSkeletonInstance_m_modelState_m_simulationState
+    alias:
+    - CSkeletonInstance::m_modelState.m_simulationState
+  - name: CSkeletonInstance_m_modelState_m_hModel
+    alias:
+    - CSkeletonInstance::m_modelState.m_hModel
+  - name: CSimulationState_SetupJointState
+    alias:
+    - CSimulationState::SetupJointState
+  - name: CSimulationState_m_nTotalTransformCount
+    alias:
+    - CSimulationState::m_nTotalTransformCount
+  - name: CSimulationState_m_nBoneCount
+    alias:
+    - CSimulationState::m_nBoneCount
+  - name: CSimulationState_m_nAttachmentCount
+    alias:
+    - CSimulationState::m_nAttachmentCount
+  - name: IVEngineClient2_GetNetworkClient
+    alias:
+    - IVEngineClient2::GetNetworkClient
+  - name: INetworkClient_GetLocalAddress
+    alias:
+    - INetworkClient::GetLocalAddress
+  - name: INetworkClientService_IsConnected
+    alias:
+    - INetworkClientService::IsConnected
+  - name: INetworkClientService_SendNetMessage
+    alias:
+    - INetworkClientService::SendNetMessage
+  - name: C_GameRules_ctor
+    alias:
+    - C_GameRules::C_GameRules
+  - name: IGameResourceService_SetEntityResourceManifestHandler
+    alias:
+    - IGameResourceService::SetEntityResourceManifestHandler
+  - name: CNetworkSerializerBindingBuildFilter_GetFieldPriority
+    alias:
+    - CNetworkSerializerBindingBuildFilter::GetFieldPriority
+  - name: GameStateAPI_RegisterAPIs
+    alias:
+    - GameStateAPI::RegisterAPIs
+  - name: GameStateAPI_IsLatched
+    alias:
+    - GameStateAPI::IsLatched
+  - name: GameStateAPI_GetPlayerSlot
+    alias:
+    - GameStateAPI::GetPlayerSlot
+  - name: GameStateAPI_GetPlayerName
+    alias:
+    - GameStateAPI::GetPlayerName
+  - name: GameStateAPI_GetPlayerXuidStringFromPlayerSlot
+    alias:
+    - GameStateAPI::GetPlayerXuidStringFromPlayerSlot
+  - name: GameStateAPI_GetLocalPlayerXuid
+    alias:
+    - GameStateAPI::GetLocalPlayerXuid
+  - name: GameStateAPI_GetLocalOrInEyePlayerXuid
+    alias:
+    - GameStateAPI::GetLocalOrInEyePlayerXuid
+  - name: GameStateAPI_GetHudPlayerXuid
+    alias:
+    - GameStateAPI::GetHudPlayerXuid
+  - name: GameStateAPI_GetPlayerTeamName
+    alias:
+    - GameStateAPI::GetPlayerTeamName
+  - name: GameStateAPI_GetPlayerTeamNumber
+    alias:
+    - GameStateAPI::GetPlayerTeamNumber
+  - name: GameStateAPI_GetCoachingTeamNumber
+    alias:
+    - GameStateAPI::GetCoachingTeamNumber
+  - name: GameStateAPI_GetAssociatedTeamNumber
+    alias:
+    - GameStateAPI::GetAssociatedTeamNumber
+  - name: GameStateAPI_IsPlayerConnected
+    alias:
+    - GameStateAPI::IsPlayerConnected
+  - name: GameStateAPI_IsPlayerAlive
+    alias:
+    - GameStateAPI::IsPlayerAlive
+  - name: GameStateAPI_GetPlayerPing
+    alias:
+    - GameStateAPI::GetPlayerPing
+  - name: GameStateAPI_GetPlayerKills
+    alias:
+    - GameStateAPI::GetPlayerKills
+  - name: GameStateAPI_GetPlayerRoundKills
+    alias:
+    - GameStateAPI::GetPlayerRoundKills
+  - name: GameStateAPI_GetPlayerAssists
+    alias:
+    - GameStateAPI::GetPlayerAssists
+  - name: GameStateAPI_GetPlayerDeaths
+    alias:
+    - GameStateAPI::GetPlayerDeaths
+  - name: GameStateAPI_GetPlayerMVPs
+    alias:
+    - GameStateAPI::GetPlayerMVPs
+  - name: GameStateAPI_GetPlayerMoney
+    alias:
+    - GameStateAPI::GetPlayerMoney
+  - name: GameStateAPI_GetPlayerScore
+    alias:
+    - GameStateAPI::GetPlayerScore
+  - name: GameStateAPI_GetPlayerClanTag
+    alias:
+    - GameStateAPI::GetPlayerClanTag
+  - name: GameStateAPI_GetPlayerActiveCoinRank
+    alias:
+    - GameStateAPI::GetPlayerActiveCoinRank
+  - name: GameStateAPI_GetPlayerCompetitiveRankType
+    alias:
+    - GameStateAPI::GetPlayerCompetitiveRankType
+  - name: GameStateAPI_GetPlayerCompetitiveRanking
+    alias:
+    - GameStateAPI::GetPlayerCompetitiveRanking
+  - name: GameStateAPI_GetPlayerCompetitiveWins
+    alias:
+    - GameStateAPI::GetPlayerCompetitiveWins
+  - name: GameStateAPI_GetPlayerPremierRankStatsObject
+    alias:
+    - GameStateAPI::GetPlayerPremierRankStatsObject
+  - name: GameStateAPI_GetPlayerDisplayFlairItem
+    alias:
+    - GameStateAPI::GetPlayerDisplayFlairItem
+  - name: GameStateAPI_GetPlayerStatus
+    alias:
+    - GameStateAPI::GetPlayerStatus
+  - name: GameStateAPI_IsFakePlayer
+    alias:
+    - GameStateAPI::IsFakePlayer
+  - name: GameStateAPI_GetPlayerActiveWeaponItemId
+    alias:
+    - GameStateAPI::GetPlayerActiveWeaponItemId
+  - name: GameStateAPI_IsXuidValid
+    alias:
+    - GameStateAPI::IsXuidValid
+  - name: GameStateAPI_GetPlayerVoiceVolume
+    alias:
+    - GameStateAPI::GetPlayerVoiceVolume
+  - name: GameStateAPI_SetPlayerVoiceVolume
+    alias:
+    - GameStateAPI::SetPlayerVoiceVolume
+  - name: GameStateAPI_GetMapsInMapGroup
+    alias:
+    - GameStateAPI::GetMapsInMapGroup
+  - name: GameStateAPI_GetMapDisplayNameToken
+    alias:
+    - GameStateAPI::GetMapDisplayNameToken
+  - name: GameStateAPI_GetMapsInCurrentMapGroup
+    alias:
+    - GameStateAPI::GetMapsInCurrentMapGroup
+  - name: GameStateAPI_GetPlayerLifetime
+    alias:
+    - GameStateAPI::GetPlayerLifetime
+  - name: GameStateAPI_GetPlayerColor
+    alias:
+    - GameStateAPI::GetPlayerColor
+  - name: GameStateAPI_GetPlayerXpLevel
+    alias:
+    - GameStateAPI::GetPlayerXpLevel
+  - name: GameStateAPI_GetPlayerXpTrailLevel
+    alias:
+    - GameStateAPI::GetPlayerXpTrailLevel
+  - name: GameStateAPI_GetPlayerCommendsLeader
+    alias:
+    - GameStateAPI::GetPlayerCommendsLeader
+  - name: GameStateAPI_GetPlayerCommendsTeacher
+    alias:
+    - GameStateAPI::GetPlayerCommendsTeacher
+  - name: GameStateAPI_GetPlayerCommendsFriendly
+    alias:
+    - GameStateAPI::GetPlayerCommendsFriendly
+  - name: GameStateAPI_HasCommunicationAbuseMute
+    alias:
+    - GameStateAPI::HasCommunicationAbuseMute
+  - name: GameStateAPI_HasCommunicationBan
+    alias:
+    - GameStateAPI::HasCommunicationBan
+  - name: GameStateAPI_ShouldShowHudElements
+    alias:
+    - GameStateAPI::ShouldShowHudElements
+  - name: GameStateAPI_IsQueuedMatchmaking
+    alias:
+    - GameStateAPI::IsQueuedMatchmaking
+  - name: GameStateAPI_GetKickTargets
+    alias:
+    - GameStateAPI::GetKickTargets
+  - name: GameStateAPI_GetPlayerCharacterItemID
+    alias:
+    - GameStateAPI::GetPlayerCharacterItemID
+  - name: GameStateAPI_GetCharacterDefaultCheerByXuid
+    alias:
+    - GameStateAPI::GetCharacterDefaultCheerByXuid
+  - name: GameStateAPI_GetCharacterDefaultDefeatByXuid
+    alias:
+    - GameStateAPI::GetCharacterDefaultDefeatByXuid
+  - name: GameStateAPI_ArePlayersEnemies
+    alias:
+    - GameStateAPI::ArePlayersEnemies
+  - name: GameStateAPI_GetCSGOGameUIStateName
+    alias:
+    - GameStateAPI::GetCSGOGameUIStateName
+  - name: GameStateAPI_IsLocalPlayerPlayingMatch
+    alias:
+    - GameStateAPI::IsLocalPlayerPlayingMatch
+  - name: GameStateAPI_IsConnectedOrConnectingToServer
+    alias:
+    - GameStateAPI::IsConnectedOrConnectingToServer
+  - name: GameStateAPI_AreTeamsPlayingSwitchedSides
+    alias:
+    - GameStateAPI::AreTeamsPlayingSwitchedSides
+  - name: GameStateAPI_AreTeamsPlayingSwitchedSidesInRound
+    alias:
+    - GameStateAPI::AreTeamsPlayingSwitchedSidesInRound
+  - name: GameStateAPI_IsReportCategoryEnabledForSelectedPlayer
+    alias:
+    - GameStateAPI::IsReportCategoryEnabledForSelectedPlayer
+  - name: GameStateAPI_SubmitPlayerReport
+    alias:
+    - GameStateAPI::SubmitPlayerReport
+  - name: GameStateAPI_SubmitServerReport
+    alias:
+    - GameStateAPI::SubmitServerReport
+  - name: GameStateAPI_QueryServersForCommendation
+    alias:
+    - GameStateAPI::QueryServersForCommendation
+  - name: GameStateAPI_GetCommendationTokensAvailable
+    alias:
+    - GameStateAPI::GetCommendationTokensAvailable
+  - name: GameStateAPI_GetMyCommendationsJSOForUser
+    alias:
+    - GameStateAPI::GetMyCommendationsJSOForUser
+  - name: GameStateAPI_SubmitCommendation
+    alias:
+    - GameStateAPI::SubmitCommendation
+  - name: GameStateAPI_IsSelectedPlayerMuted
+    alias:
+    - GameStateAPI::IsSelectedPlayerMuted
+  - name: GameStateAPI_ToggleMute
+    alias:
+    - GameStateAPI::ToggleMute
+  - name: GameStateAPI_GetCrosshairCode
+    alias:
+    - GameStateAPI::GetCrosshairCode
+  - name: GameStateAPI_IsDemoOrHltv
+    alias:
+    - GameStateAPI::IsDemoOrHltv
+  - name: GameStateAPI_IsOverwatch
+    alias:
+    - GameStateAPI::IsOverwatch
+  - name: GameStateAPI_IsLocalPlayerWatchingOwnDemo
+    alias:
+    - GameStateAPI::IsLocalPlayerWatchingOwnDemo
+  - name: GameStateAPI_IsLocalPlayerHLTV
+    alias:
+    - GameStateAPI::IsLocalPlayerHLTV
+  - name: GameStateAPI_IsHLTVAutodirectorOn
+    alias:
+    - GameStateAPI::IsHLTVAutodirectorOn
+  - name: GameStateAPI_SetCasterIsCameraman
+    alias:
+    - GameStateAPI::SetCasterIsCameraman
+  - name: GameStateAPI_SetCasterIsHeard
+    alias:
+    - GameStateAPI::SetCasterIsHeard
+  - name: GameStateAPI_SetCasterControlsXray
+    alias:
+    - GameStateAPI::SetCasterControlsXray
+  - name: GameStateAPI_SetCasterControlsUI
+    alias:
+    - GameStateAPI::SetCasterControlsUI
+  - name: GameStateAPI_GetServerName
+    alias:
+    - GameStateAPI::GetServerName
+  - name: GameStateAPI_GetMapName
+    alias:
+    - GameStateAPI::GetMapName
+  - name: GameStateAPI_GetTournamentEventStage
+    alias:
+    - GameStateAPI::GetTournamentEventStage
+  - name: GameStateAPI_GetGameModeInternalName
+    alias:
+    - GameStateAPI::GetGameModeInternalName
+  - name: GameStateAPI_GetGameModeImagePath
+    alias:
+    - GameStateAPI::GetGameModeImagePath
+  - name: GameStateAPI_GetGameModeName
+    alias:
+    - GameStateAPI::GetGameModeName
+  - name: GameStateAPI_GetViewerCount
+    alias:
+    - GameStateAPI::GetViewerCount
+  - name: GameStateAPI_GetMapBSPName
+    alias:
+    - GameStateAPI::GetMapBSPName
+  - name: GameStateAPI_IsQueuedMatchmakingMode_Team
+    alias:
+    - GameStateAPI::IsQueuedMatchmakingMode_Team
+  - name: GameStateAPI_HasHalfTime
+    alias:
+    - GameStateAPI::HasHalfTime
+  - name: GameStateAPI_GetPlayerModel
+    alias:
+    - GameStateAPI::GetPlayerModel
+  - name: GameStateAPI_GetAllPlayersMatchDataJSO
+    alias:
+    - GameStateAPI::GetAllPlayersMatchDataJSO
+  - name: GameStateAPI_GetPlayerDataJSO
+    alias:
+    - GameStateAPI::GetPlayerDataJSO
+  - name: GameStateAPI_GetTimeDataJSO
+    alias:
+    - GameStateAPI::GetTimeDataJSO
+  - name: GameStateAPI_GetScoreDataJSO
+    alias:
+    - GameStateAPI::GetScoreDataJSO
+  - name: GameStateAPI_GetPlayerStatsJSO
+    alias:
+    - GameStateAPI::GetPlayerStatsJSO
+  - name: GameStateAPI_GetMatchInfoJSO
+    alias:
+    - GameStateAPI::GetMatchInfoJSO
+  - name: GameStateAPI_GetMatchEndWinDataJSO
+    alias:
+    - GameStateAPI::GetMatchEndWinDataJSO
+  - name: GameStateAPI_GetAccoladeLocalizationString
+    alias:
+    - GameStateAPI::GetAccoladeLocalizationString
+  - name: GameStateAPI_GetTeamClanName
+    alias:
+    - GameStateAPI::GetTeamClanName
+  - name: GameStateAPI_GetTeamLogoImagePath
+    alias:
+    - GameStateAPI::GetTeamLogoImagePath
+  - name: GameStateAPI_GetTeamFlagImagePath
+    alias:
+    - GameStateAPI::GetTeamFlagImagePath
+  - name: GameStateAPI_GetTeamTotalPlayerCount
+    alias:
+    - GameStateAPI::GetTeamTotalPlayerCount
+  - name: GameStateAPI_GetTeamLivingPlayerCount
+    alias:
+    - GameStateAPI::GetTeamLivingPlayerCount
+  - name: GameStateAPI_GetTeamNextRoundLossBonus
+    alias:
+    - GameStateAPI::GetTeamNextRoundLossBonus
+  - name: GameStateAPI_GetActiveQuestID
+    alias:
+    - GameStateAPI::GetActiveQuestID
+  - name: GameStateAPI_GetAnnotationsViewingLevel
+    alias:
+    - GameStateAPI::GetAnnotationsViewingLevel
+  - name: GameStateAPI_BIsLocalServerHost
+    alias:
+    - GameStateAPI::BIsLocalServerHost
+- name: server
+  symbols:
+  - name: CSource2Server_GetAllServerClasses
+    alias:
+    - CSource2Server::GetAllServerClasses
+  - name: CSource2Server_GetActiveWorldName
+    alias:
+    - CSource2Server::GetActiveWorldName
+  - name: CSource2Server_ShouldTimeoutClient
+    alias:
+    - CSource2Server::ShouldTimeoutClient
+  - name: CSource2Server_OnStreamEntitiesFromFileCompleted
+    alias:
+    - CSource2Server::OnStreamEntitiesFromFileCompleted
+  - name: CSource2Server_PreWorldUpdate
+    alias:
+    - CSource2Server::PreWorldUpdate
+  - name: CSource2Server_UpdateWhenNotInGame
+    alias:
+    - CSource2Server::UpdateWhenNotInGame
+  - name: CGameSystemReallocatingFactory_CSource2EntitySystem_Init
+    alias:
+    - CGameSystemReallocatingFactory<CSource2EntitySystem>::Init
+  - name: CGameSystemReallocatingFactory_CSource2EntitySystem_CreateGameSystem
+    alias:
+    - CGameSystemReallocatingFactory<CSource2EntitySystem>::CreateGameSystem
+  - name: IGameSystemFactory_Init
+    alias:
+    - IGameSystemFactory::Init
+  - name: IGameSystemFactory_Shutdown
+    alias:
+    - IGameSystemFactory::Shutdown
+  - name: IGameSystemFactory_SetGlobalPtr
+    alias:
+    - IGameSystemFactory::SetGlobalPtr
+  - name: CGameSystemReallocatingFactory_CSpawnGroupMgrGameSystem_DestroyGameSystem
+    alias:
+    - CGameSystemReallocatingFactory<CSpawnGroupMgrGameSystem>::Deallocate
+  - name: IGameSystem_SetGameSystemGlobalPtrs
+    alias:
+    - IGameSystem::SetGameSystemGlobalPtrs
+  - name: IGameSystem_vdtor
+    alias:
+    - IGameSystem::~IGameSystem
+  - name: IGameSystem_OnGameInit
+    alias:
+    - IGameSystem::GameInit
+  - name: CMultiplayRules_ctor
+    alias:
+    - CMultiplayRules::CMultiplayRules
+  - name: CGameMoney_OnMoneySpent
+    alias:
+    - CGameMoney::OnMoneySpent
+  - name: CGameMoney_m_DataMap
+    alias:
+    - CGameMoney::m_DataMap
+  - name: CGameMoney_GetDataDescMap
+    alias:
+    - CGameMoney::GetDataDescMap
+  - name: CCSPlayer_UseServices_OnUseImpl
+    alias:
+    - CCSPlayer_UseServices::OnUseImpl
+  - name: CCSPlayer_UseServices_OnUse
+    alias:
+    - CCSPlayer_UseServices::OnUse
+  - name: CCSPlayer_MovementServices_ProcessMovement
+    alias:
+    - CCSPlayer_MovementServices::ProcessMovement
+    - ProcessMovement
+  - name: CCSPlayer_MovementServices_CheckMovingGround
+    alias:
+    - CCSPlayer_MovementServices::CheckMovingGround
+    - CheckMovingGround
+  - name: CCSPlayer_MovementServices_WalkMove
+    alias:
+    - CCSPlayer_MovementServices::WalkMove
+    - WalkMove
+  - name: CCSPlayer_MovementServices_FullWalkMove
+    alias:
+    - CCSPlayer_MovementServices::FullWalkMove
+    - FullWalkMove
+  - name: CCSPlayer_MovementServices_CheckVelocity
+    alias:
+    - CCSPlayer_MovementServices::CheckVelocity
+    - CheckVelocity
+  - name: CCSPlayer_MovementServices_WaterMove
+    alias:
+    - CCSPlayer_MovementServices::WaterMove
+    - WaterMove
+  - name: CCSPlayer_MovementServices_FullWalkMove_SpeedClamp
+    alias:
+    - ServerMovementUnlock
+  - name: CCSPlayer_MovementServices_CheckJumpButton
+    alias:
+    - CCSPlayer_MovementServices::CheckJumpButton
+  - name: CCSPlayer_MovementServices_CheckJumpButton_WaterPatch
+    alias:
+    - CheckJumpButtonWater
+    - FixWaterFloorJump
+  - name: CPlayer_MovementServices_PlayWaterStepSound
+    alias:
+    - CPlayer_MovementServices::PlayWaterStepSound
+  - name: CPlayer_MovementServices_ForceButtons
+    alias:
+    - CPlayer_MovementServices::ForceButtons
+  - name: CPlayer_MovementServices_ForceButtonState
+    alias:
+    - CPlayer_MovementServices::ForceButtonState
+  - name: CPlayer_MovementServices_s_pRunCommandPawn
+    alias:
+    - CPlayer_MovementServices::s_pRunCommandPawn
+  - name: CEntityInstance_m_pEntity
+    alias:
+    - CEntityInstance::m_pEntity
+  - name: CEntityInstance_m_hPrivateScope
+    alias:
+    - CEntityInstance::m_hPrivateScope
+  - name: CEntityInstance_m_CScriptComponent
+    alias:
+    - CEntityInstance::m_CScriptComponent
+  - name: CEntityInstance_m_pKeyValues
+    alias:
+    - CEntityInstance::m_pKeyValues
+  - name: CEntityInstance_m_iszPrivateVScripts
+    alias:
+    - CEntityInstance::m_iszPrivateVScripts
+  - name: CBaseEntity_OnRestore
+    alias:
+    - CBaseEntity::OnRestore
+  - name: CBaseEntity_UpdateOnRemove
+    alias:
+    - CBaseEntity::UpdateOnRemove
+  - name: CBaseEntity_ModifyOrAppendCriteria
+    alias:
+    - CBaseEntity::ModifyOrAppendCriteria
+  - name: CEntityInstance_OnRestore
+    alias:
+    - CEntityInstance::OnRestore
+  - name: CBaseEntity_ctor
+    alias:
+    - CBaseEntity::CBaseEntity
+  - name: CBaseEntity_dtor
+    alias:
+    - CBaseEntity::~CBaseEntity
+  - name: CBaseEntity_vdtor
+    alias:
+    - CBaseEntity::~CBaseEntity (virtual)
+  - name: CEntityInstance_vdtor
+    alias:
+    - CEntityInstance::~CEntityInstance (virtual)
+  - name: CEntityInstance_dtor
+    alias:
+    - CEntityInstance::~CEntityInstance
+  - name: CEntitySaveRestoreBlockHandler_PreSave
+    alias:
+    - CEntitySaveRestoreBlockHandler::PreSave
+  - name: CEntitySaveRestoreBlockHandler_SaveInternal
+    alias:
+    - CEntitySaveRestoreBlockHandler::SaveInternal
+  - name: CEntitySaveRestoreBlockHandler_Save
+    alias:
+    - CEntitySaveRestoreBlockHandler::Save
+  - name: CEntitySaveRestoreBlockHandler_Restore
+    alias:
+    - CEntitySaveRestoreBlockHandler::Restore
+  - name: CEntitySaveRestoreBlockHandler_DoRestoreEntity
+    alias:
+    - CEntitySaveRestoreBlockHandler::DoRestoreEntity
+  - name: CEntitySaveRestoreBlockHandler_RestoreEntity
+    alias:
+    - CEntitySaveRestoreBlockHandler::RestoreEntity
+  - name: CreateEntityTransitionList
+    alias:
+    - CreateEntityTransitionList
+  - name: CEntitySaveRestoreBlockHandler_WriteSaveHeaders
+    alias:
+    - CEntitySaveRestoreBlockHandler::WriteSaveHeaders
+  - name: CEntitySaveRestoreBlockHandler_ReadRestoreHeaders
+    alias:
+    - CEntitySaveRestoreBlockHandler::ReadRestoreHeaders
+  - name: CEntity2SaveRestore_StreamEntitiesFromFile
+    alias:
+    - CEntity2SaveRestore::StreamEntitiesFromFile
+  - name: CSaveRestoreBlockSet_PreRestore
+    alias:
+    - CSaveRestoreBlockSet::PreRestore
+  - name: CSaveRestoreBlockSet_PostRestore
+    alias:
+    - CSaveRestoreBlockSet::PostRestore
+  - name: CEntitySaveRestoreBlockHandler_PreRestore
+    alias:
+    - CEntitySaveRestoreBlockHandler::PreRestore
+  - name: CEntitySaveRestoreBlockHandler_PostRestore
+    alias:
+    - CEntitySaveRestoreBlockHandler::PostRestore
+  - name: CEntitySystem_ForceSetInPVSCallsIntoQueue
+    alias:
+    - CEntitySystem::ForceSetInPVSCallsIntoQueue
+  - name: CEntitySystem_ExecuteQueuedSetInPVS
+    alias:
+    - CEntitySystem::ExecuteQueuedSetInPVS
+  - name: CEntitySystem_m_nSuppressDormancyChangeCount
+    alias:
+    - CEntitySystem::m_nSuppressDormancyChangeCount
+  - name: CEntitySystem_m_nExecuteQueuedCreationDepth
+    alias:
+    - CEntitySystem::m_nExecuteQueuedCreationDepth
+  - name: CEntitySystem_m_queuedDormancyChanges
+    alias:
+    - CEntitySystem::m_queuedDormancyChanges
+  - name: CEntitySystem_SetInPVS
+    alias:
+    - CEntitySystem::SetInPVS
+  - name: CEntitySystem_OnSetDormant
+    alias:
+    - CEntitySystem::OnSetDormant
+  - name: CEntitySystem_BuildResourceManifestForEntity
+    alias:
+    - CEntitySystem::BuildResourceManifestForEntity
+  - name: CEntityInstance_ObjectCaps
+    alias:
+    - CEntityInstance::ObjectCaps
+  - name: CEntityInstance_Save
+    alias:
+    - CEntityInstance::Save
+  - name: CEntityInstance_Restore
+    alias:
+    - CEntityInstance::Restore
+  - name: CEntitySaveRestoreBlockHandler_SaveInitEntities
+    alias:
+    - CEntitySaveRestoreBlockHandler::SaveInitEntities
+  - name: CEntityInstance_OnSave
+    alias:
+    - CEntityInstance::OnSave
+  - name: CEntityInstance_RequiredEdictIndex
+    alias:
+    - CEntityInstance::RequiredEdictIndex
+  - name: PolymorphicHelper_t__SetPolymorphicPointer
+    alias:
+    - PolymorphicHelper_t::SetPolymorphicPointer
+  - name: CEntityInstance_AddChangeAccessorPathPolymorphic
+    alias:
+    - CEntityInstance::AddChangeAccessorPathPolymorphic
+  - name: CEntityInstance_AssignChangeAccessorPathIdsPolymorphic
+    alias:
+    - CEntityInstance::AssignChangeAccessorPathIdsPolymorphic
+  - name: CEntityInstance_AddChangeAccessorPath
+    alias:
+    - CEntityInstance::AddChangeAccessorPath
+  - name: CBaseEntity_AddChangeAccessorPath
+    alias:
+    - CBaseEntity::AddChangeAccessorPath
+  - name: CEntityInstance_AssignChangeAccessorPathIds
+    alias:
+    - CEntityInstance::AssignChangeAccessorPathIds
+  - name: CEntityInstance_GetChangeAccessorPathInfo_2
+    alias:
+    - CEntityInstance::GetChangeAccessorPathInfo_2
+  - name: CBaseEntity_GetChangeAccessorPathInfo_2
+    alias:
+    - CBaseEntity::GetChangeAccessorPathInfo_2
+  - name: CBaseEntity_GetChangeAccessorPathInfo_1
+    alias:
+    - CBaseEntity::GetChangeAccessorPathInfo_1
+  - name: CBasePlayerPawn_PrePhysicsSimulate
+    alias:
+    - CBasePlayerPawn::PrePhysicsSimulate
+  - name: CBasePlayerPawn_PhysicsSimulate
+    alias:
+    - CBasePlayerPawn::PhysicsSimulate
+  - name: CMomentaryRotButton_Use
+    alias:
+    - CMomentaryRotButton::Use
+  - name: CBaseEntity_TakeDamageOld
+    alias:
+    - CBaseEntity::TakeDamageOld
+  - name: CBaseEntity_OnTakeDamage
+    alias:
+    - CBasePlayerPawn::OnTakeDamage
+  - name: CBasePlayerPawn_OnTakeDamage_Alive
+    alias:
+    - CBasePlayerPawn::OnTakeDamage_Alive
+  - name: CBasePlayerPawn_OnTakeDamage_Dying
+    alias:
+    - CBasePlayerPawn::OnTakeDamage_Dying
+  - name: CBasePlayerPawn_OnTakeDamage_Dead
+    alias:
+    - CBasePlayerPawn::OnTakeDamage_Dead
+  - name: DecalPlacementInfo_ctor
+    alias:
+    - DecalPlacementInfo::DecalPlacementInfo
+  - name: CBaseModelEntity_GetBoneTransform
+    alias:
+    - CBaseModelEntity::GetBoneTransform
+  - name: CBaseModelEntity_DamageDecal
+    alias:
+    - CBaseModelEntity::DamageDecal
+  - name: CBreakable_DamageDecal
+    alias:
+    - CBreakable::DamageDecal
+  - name: CBasePlayerPawn_OnTakeDamage
+    alias:
+    - CBasePlayerPawn::OnTakeDamage
+  - name: CCSPlayerPawn_OnTakeDamage_Alive
+    alias:
+    - CCSPlayerPawn::OnTakeDamage_Alive
+  - name: CCSPlayerPawn_CreatePlayerPawnServices
+    alias:
+    - CCSPlayerPawn::CreatePlayerPawnServices
+  - name: CCSPlayerPawn_OnTakeDamage_Dying
+    alias:
+    - CCSPlayerPawn::OnTakeDamage_Dying
+  - name: CCSPlayerPawn_OnTakeDamage_Dead
+    alias:
+    - CCSPlayerPawn::OnTakeDamage_Dead
+  - name: CFlashbangProjectile_Spawn
+    alias:
+    - CFlashbangProjectile::Spawn
+  - name: CFlashbangProjectile_Detonate
+    alias:
+    - CFlashbangProjectile::Detonate
+  - name: CSmokeGrenadeProjectile_Detonate
+    alias:
+    - CSmokeGrenadeProjectile::Detonate
+  - name: CSmokeGrenadeProjectile_Create
+    alias:
+    - CSmokeGrenadeProjectile::Create
+  - name: CSmokeGrenadeProjectile_m_SmokeVolume
+    alias:
+    - CSmokeGrenadeProjectile::m_SmokeVolume
+  - name: SmokeVolume_BuildSmokeSimulation
+    alias:
+    - SmokeVolume::BuildSmokeSimulation
+  - name: SmokeVolume_BuildSmokeSimulation_Initialize
+    alias:
+    - sub_1402310
+  - name: SmokeVolume_m_vecCenterOrigin
+    alias:
+    - SmokeVolume::m_vecCenterOrigin
+  - name: SmokeVolume_m_pStorage
+    alias:
+    - SmokeVolume::m_pStorage
+  - name: SmokeVolume_m_flStartTime
+    alias:
+    - SmokeVolume::m_flStartTime
+  - name: SmokeVolume_GetSmokeDensityInLine_Lambda1_operator_call
+    alias:
+    - SmokeVolume::GetSmokeDensityInLine::<lambda_1>::operator()
+  - name: SmokeVolume_m_nFrame
+    alias:
+    - SmokeVolume::m_nFrame
+  - name: CEntitySystem_QueueDestroyEntity
+    alias:
+    - CEntitySystem::QueueDestroyEntity
+  - name: CEntitySystem_ExecuteQueuedDeletion
+    alias:
+    - CEntitySystem::ExecuteQueuedDeletion
+  - name: CEntitySystem_m_nExecuteQueuedDeletionDepth
+    alias:
+    - CEntitySystem::m_nExecuteQueuedDeletionDepth
+  - name: CBaseModelEntity_SetModel
+    alias:
+    - CBaseModelEntity::SetModel
+  - name: CBaseModelEntity_SetRenderAttribute
+    alias:
+    - CBaseModelEntity::SetRenderAttribute
+  - name: CBaseEntity_GetScriptDescInternal
+    alias:
+    - CBaseEntity::GetScriptDescInternal
+  - name: CBaseModelEntity_GetScriptDescInternal
+    alias:
+    - CBaseModelEntity::GetScriptDescInternal
+  - name: CBaseModelEntity_GetModelScale
+    alias:
+    - CBaseModelEntity::GetModelScale
+  - name: CBaseModelEntity_Script_SetModelScale
+    alias:
+    - CBaseModelEntity::Script_SetModelScale
+  - name: CBaseModelEntity_ScriptLookupAttachment
+    alias:
+    - CBaseModelEntity::ScriptLookupAttachment
+  - name: CBaseModelEntity_ScriptGetAttachmentOrigin
+    alias:
+    - CBaseModelEntity::ScriptGetAttachmentOrigin
+  - name: CBaseModelEntity_ScriptGetAttachmentAngles
+    alias:
+    - CBaseModelEntity::ScriptGetAttachmentAngles
+  - name: CBaseModelEntity_ScriptGetAttachmentForward
+    alias:
+    - CBaseModelEntity::ScriptGetAttachmentForward
+  - name: CBaseModelEntity_ScriptSetSize
+    alias:
+    - CBaseModelEntity::ScriptSetSize
+  - name: CBaseModelEntity_ScriptSetModel
+    alias:
+    - CBaseModelEntity::ScriptSetModel
+  - name: ScriptBinding_CBaseModelEntity_SetModel
+    alias:
+    - CS_Script_SetModel
+  - name: CBaseModelEntity_ScriptGetRenderAlpha
+    alias:
+    - CBaseModelEntity::ScriptGetRenderAlpha
+  - name: CBaseModelEntity_ScriptSetRenderAlpha
+    alias:
+    - CBaseModelEntity::ScriptSetRenderAlpha
+  - name: CBaseModelEntity_ScriptSetRenderMode
+    alias:
+    - CBaseModelEntity::ScriptSetRenderMode
+  - name: CBaseModelEntity_ScriptSetRenderColor
+    alias:
+    - CBaseModelEntity::ScriptSetRenderColor
+  - name: CBaseModelEntity_ScriptGetRenderColor
+    alias:
+    - CBaseModelEntity::ScriptGetRenderColor
+  - name: CBaseModelEntity_ScriptSetMaterialGroup
+    alias:
+    - CBaseModelEntity::ScriptSetMaterialGroup
+  - name: CBaseModelEntity_ScriptSetMaterialGroupHash
+    alias:
+    - CBaseModelEntity::ScriptSetMaterialGroupHash
+  - name: CBaseModelEntity_ScriptGetMaterialGroupHash
+    alias:
+    - CBaseModelEntity::ScriptGetMaterialGroupHash
+  - name: CBaseModelEntity_ScriptSetSingleMeshGroup
+    alias:
+    - CBaseModelEntity::ScriptSetSingleMeshGroup
+  - name: CBaseModelEntity_ScriptSetMeshGroupMask
+    alias:
+    - CBaseModelEntity::ScriptSetMeshGroupMask
+  - name: CBaseModelEntity_ScriptGetMeshGroupMask
+    alias:
+    - CBaseModelEntity::ScriptGetMeshGroupMask
+  - name: CBaseModelEntity_ScriptSetBodygroupByName
+    alias:
+    - CBaseModelEntity::ScriptSetBodygroupByName
+  - name: CBaseModelEntity_Script_SetBodygroup
+    alias:
+    - CBaseModelEntity::Script_SetBodygroup
+  - name: CBaseModelEntity_Script_SetSkin
+    alias:
+    - CBaseModelEntity::Script_SetSkin
+  - name: CEntityInstance_NetworkUpdateState_thunk
+    alias:
+    - CEntityInstance::NetworkUpdateState_thunk
+  - name: CBaseEntity_SetGravityScale
+    alias:
+    - CBaseEntity::SetGravityScale
+  - name: CTriggerGravity_GravityTouch
+    alias:
+    - CTriggerGravity::GravityTouch
+  - name: CTriggerGravity_GetTouchFunction
+    alias:
+    - CTriggerGravity::GetTouchFunction
+  - name: CBasePlayerController_HandleCommand_JoinTeam
+    alias:
+    - CBasePlayerController::HandleCommand_JoinTeam
+  - name: CBasePlayerController_SetPlayerName
+    alias:
+    - CBasePlayerController::SetPlayerName
+  - name: CBasePlayerController_ProcessUsercmds
+    alias:
+    - ProcessUsercmds
+  - name: CBasePlayerController_SetPawn
+    alias:
+    - CBasePlayerController::SetPawn
+  - name: CBasePlayerController_GetPawn
+    alias:
+    - CBasePlayerController::GetPawn
+  - name: CBasePlayerController_Connect
+    alias:
+    - CBasePlayerController::Connect
+  - name: CBasePlayerController_SetConnectedState
+    alias:
+    - CBasePlayerController::SetConnectedState
+  - name: CSource2GameClients_ClientSettingsChanged
+    alias:
+    - CSource2GameClients::ClientSettingsChanged
+  - name: CSource2GameClients_ClientSetConVarUserInfoSet
+    alias:
+    - CSource2GameClients::ClientSetConVarUserInfoSet
+  - name: CSource2GameClients_ClientSetupVisibility
+    alias:
+    - CSource2GameClients::ClientSetupVisibility
+  - name: CSource2GameClients_ClientDisconnect
+    alias:
+    - CSource2GameClients::ClientDisconnect
+  - name: CSource2GameClients_ClientPutInServer
+    alias:
+    - CSource2GameClients::ClientPutInServer
+  - name: CSource2GameClients_ClientConnect
+    alias:
+    - CSource2GameClients::ClientConnect
+  - name: CSource2GameClients_ClientActive
+    alias:
+    - CSource2GameClients::ClientActive
+  - name: CSource2GameClients_ClientFullyConnect
+    alias:
+    - CSource2GameClients::ClientFullyConnect
+  - name: CSource2GameClients_ClientCommand
+    alias:
+    - CSource2GameClients::ClientCommand
+  - name: CSource2GameClients_ProcessUsercmds
+    alias:
+    - CSource2GameClients::ProcessUsercmds
+  - name: CSource2GameClients_GetBugReportInfo
+    alias:
+    - CSource2GameClients::GetBugReportInfo
+  - name: CSource2GameClients_ClientDiagnostic
+    alias:
+    - CSource2GameClients::ClientDiagnostic
+  - name: CSource2GameClients_SendHLTVStatusMessage
+    alias:
+    - CSource2GameClients::SendHLTVStatusMessage
+  - name: CSource2GameClients_OnClientConnected
+    alias:
+    - CSource2GameClients::OnClientConnected
+  - name: CGameRules_FindPickerEntity
+    alias:
+    - CGameRules::FindPickerEntity
+  - name: CCSGameRules_FindPickerEntity
+    alias:
+    - CCSGameRules::FindPickerEntity
+  - name: CCSGameRules_TerminateRound
+    alias:
+    - CCSGameRules::TerminateRound
+    - CGameRules::TerminateRound
+    - CGameRules_TerminateRound
+  - name: CCSGameRules_GoToIntermission
+    alias:
+    - CCSGameRules::GoToIntermission
+  - name: CEntityInstance_AcceptInput
+    alias:
+    - CEntityInstance::AcceptInput
+    - AcceptInput
+  - name: CEntityIdentity_AcceptInput
+    alias:
+    - CEntityIdentity::AcceptInput
+  - name: CEntityIdentity_AcceptInputInternal
+    alias:
+    - CEntityIdentity::AcceptInputInternal
+  - name: CEntityInstance_ScriptAcceptInput
+    alias:
+    - CEntityInstance::ScriptAcceptInput
+  - name: CEntityIdentity_SetEntityName
+    alias:
+    - CEntityIdentity::SetEntityName
+  - name: CEntitySystem_RemoveEntityFromNameMap
+    alias:
+    - CEntitySystem::RemoveEntityFromNameMap
+  - name: CEntitySystem_AddEntityToNameMap
+    alias:
+    - CEntitySystem::AddEntityToNameMap
+  - name: ScriptBinding_Entity_SetEntityName
+    alias:
+    - Entity::SetEntityName
+  - name: CBtActionCoordinatedBuy_Update
+    alias:
+    - CBtActionCoordinatedBuy::Update
+  - name: CCSPlayer_ItemServices_CanAcquire
+    alias:
+    - CCSPlayer_ItemServices::CanAcquire
+  - name: CCSPlayer_ItemServices_GiveDefaultItems
+    alias:
+    - CCSPlayer_ItemServices::GiveDefaultItems
+  - name: CCSPlayer_ItemServices_GiveNamedItem
+    alias:
+    - CCSPlayer_ItemServices::GiveNamedItem
+  - name: CCSPlayer_ItemServices_GiveNamedItemBool
+    alias:
+    - CCSPlayer_ItemServices::GiveNamedItemBool
+  - name: CCSPlayer_WeaponServices_CanUse
+    alias:
+    - CCSPlayer_WeaponServices::CanUse
+  - name: CCSPlayer_WeaponServices_PickupItem
+    alias:
+    - CCSPlayer_WeaponServices::PickupItem
+  - name: CCSPlayer_WeaponServices_EquipWeapon
+    alias:
+    - CCSPlayer_WeaponServices::EquipWeapon
+  - name: CCSPlayer_WeaponServices_Weapon_GetSlot
+    alias:
+    - CCSPlayer_WeaponServices_Weapon_GetSlot
+  - name: CCSPlayerController_ChangeTeam
+    alias:
+    - CCSPlayerController::ChangeTeam
+  - name: CCSPlayerController_GetThinkFunction
+    alias:
+    - CCSPlayerController::GetThinkFunction
+  - name: CCSPlayerController_PlayerForceTeamThink
+    alias:
+    - PlayerForceTeamThink
+    - CCSPlayerController::PlayerForceTeamThink
+  - name: CCSPlayerController_ResetForceTeamThink
+    alias:
+    - ResetForceTeamThink
+    - CCSPlayerController::ResetForceTeamThink
+  - name: CCSPlayerController_ResourceDataThink
+    alias:
+    - ResourceDataThink
+    - CCSPlayerController::ResourceDataThink
+  - name: CCSPlayerController_InventoryUpdateThink
+    alias:
+    - InventoryUpdateThink
+    - CCSPlayerController::InventoryUpdateThink
+  - name: g_CCSPlayerController_PlayerForceTeamThink
+    alias:
+    - g_CCSPlayerController::PlayerForceTeamThink
+  - name: g_CCSPlayerController_ResetForceTeamThink
+    alias:
+    - g_CCSPlayerController::ResetForceTeamThink
+  - name: g_CCSPlayerController_ResourceDataThink
+    alias:
+    - g_CCSPlayerController::ResourceDataThink
+  - name: g_CCSPlayerController_InventoryUpdateThink
+    alias:
+    - g_CCSPlayerController::InventoryUpdateThink
+  - name: CCSGameRules__sm_mapGcBanInformation
+    alias:
+    - CCSGameRules::sm_mapGcBanInformation
+  - name: CCSGameRules_BeginRound
+    alias:
+    - CCSGameRules::BeginRound
+  - name: CCSGameRules_PlayerSpawn
+    alias:
+    - CCSGameRules::PlayerSpawn
+  - name: CCSPlayerController_Respawn
+    alias:
+    - CCSPlayerController::Respawn
+  - name: CCSPlayerController_Connect
+    alias:
+    - CCSPlayerController::Connect
+  - name: CCSPlayerController_Disconnect
+    alias:
+    - CCSPlayerController::Disconnect
+  - name: CCSPlayerController_SwitchTeam
+    alias:
+    - CCSPlayerController::SwitchTeam
+  - name: CCSPlayerPawnBase_OnSetDormant
+    alias:
+    - CCSPlayerPawnBase::OnSetDormant
+  - name: CCSPlayerPawnBase_CheckForIdle
+    alias:
+    - CCSPlayerPawnBase::CheckForIdle
+  - name: CCSPlayerPawnBase_CheckForIdleInternal
+    alias:
+    - CCSPlayerPawnBase::CheckForIdleInternal
+  - name: CCSPlayerPawn_PostThink
+    alias:
+    - CCSPlayerPawnBase::PostThink
+    - CCSPlayerPawn::PostThink
+    - CCSPlayerPawnBase_PostThink
+    - CCSPlayerPawn_PostThink
+    - PostThink
+  - name: CCSPlayerPawn_OnSwitchWeapons
+    alias:
+    - CCSPlayerPawn::OnSwitchWeapons
+  - name: CCSPlayerPawn_ProcessSuicideAsKillReward
+    alias:
+    - CCSPlayerPawn::ProcessSuicideAsKillReward
+  - name: CGameRules_ClientSettingsChanged
+    alias:
+    - CGameRules::ClientSettingsChanged
+  - name: CGameRules_SetGamePaused
+    alias:
+    - CGameRules::SetGamePaused
+  - name: CGameRulesGameSystem_OnGameInit
+    alias:
+    - CGameRulesGameSystem::GameInit
+  - name: CGameRulesGameSystem_OnGameShutdown
+    alias:
+    - CGameRulesGameSystem::GameShutdown
+  - name: IGameSystem_OnGameShutdown
+    alias:
+    - IGameSystem::GameShutdown
+  - name: IGameSystem_OnGamePostInit
+    alias:
+    - IGameSystem::GamePostInit
+  - name: IGameSystem_OnGamePreShutdown
+    alias:
+    - IGameSystem::GamePreShutdown
+  - name: CMultiplayRules_ClientDisconnected
+    alias:
+    - CMultiplayRules::ClientDisconnected
+  - name: CSource2Server_Init
+    alias:
+    - CSource2Server::Init
+  - name: CSource2Server_ApplyGameSettings
+    alias:
+    - CSource2Server::ApplyGameSettings
+  - name: CSource2Server_GetEntityReport
+    alias:
+    - CSource2Server::GetEntityReport
+  - name: CSource2Server_BroadcastServerFrameTime
+    alias:
+    - CSource2Server::BroadcastServerFrameTime
+  - name: CSource2Server_WriteSignonMessages
+    alias:
+    - CSource2Server::WriteSignonMessages
+  - name: CSource2Server_GameCreateNetworkStringTables
+    alias:
+    - CSource2Server::GameCreateNetworkStringTables
+  - name: CSource2Server_GetMatchmakingGameData
+    alias:
+    - CSource2Server::GetMatchmakingGameData
+  - name: CSource2Server_GameServerSteamAPIActivated
+    alias:
+    - CSource2Server::GameServerSteamAPIActivated
+  - name: CSource2Server_GameServerSteamAPIDeactivated
+    alias:
+    - CSource2Server::GameServerSteamAPIDeactivated
+  - name: CSource2Server_OnHostNameChanged
+    alias:
+    - CSource2Server::OnHostNameChanged
+  - name: CSource2Server_GetLevelsFromSaveFile
+    alias:
+    - CSource2Server::GetLevelsFromSaveFile
+  - name: CSource2Server_ServerConVarChanged
+    alias:
+    - CSource2Server::ServerConVarChanged
+  - name: CSource2Server_Save
+    alias:
+    - CSource2Server::Save
+  - name: CSource2Server_Connect
+    alias:
+    - CSource2Server::Connect
+  - name: CSource2Server_PreShutdown
+    alias:
+    - CSource2Server::PreShutdown
+  - name: IAppSystem_Connect
+    alias:
+    - IAppSystem::Connect
+  - name: IAppSystem_PreShutdown
+    alias:
+    - IAppSystem::PreShutdown
+  - name: IVEngineServer2_ServerCommand
+    alias:
+    - IVEngineServer2::ServerCommand
+  - name: IVEngineServer2_IsDedicatedServer
+    alias:
+    - IVEngineServer2::IsDedicatedServer
+  - name: IVEngineServer2_GetServerGlobals
+    alias:
+    - IVEngineServer2::GetServerGlobals
+  - name: IVEngineServer2_GetAchievementMgr
+    alias:
+    - IVEngineServer2::GetAchievementMgr
+  - name: IVEngineServer2_IsLogEnabled
+    alias:
+    - IVEngineServer2::IsLogEnabled
+  - name: CSource2Server_Shutdown
+    alias:
+    - CSource2Server::Shutdown
+  - name: CGameEventManager_Shutdown
+    alias:
+    - CGameEventManager::Shutdown
+  - name: CLoopModeRegistry_UnregisterLoopModes
+    alias:
+    - CLoopModeRegistry::UnregisterLoopModes
+  - name: CEngineServiceRegistry_UnregisterEngineServices
+    alias:
+    - CEngineServiceRegistry::UnregisterEngineServices
+  - name: IEngineServiceMgr_UnregisterLoopMode
+    alias:
+    - IEngineServiceMgr::UnregisterLoopMode
+  - name: IEngineServiceMgr_UnregisterEngineService
+    alias:
+    - IEngineServiceMgr::UnregisterEngineService
+  - name: CSource2Server_GameFrame
+    alias:
+    - CSource2Server::GameFrame
+  - name: CGameEventManager_Init
+    alias:
+    - CGameEventManager::Init
+  - name: CTakeDamageInfo_HitGroupInfo
+    alias:
+    - CTakeDamageInfo::HitGroupInfo
+    - CTakeDamageInfo::HitGroup
+    - CTakeDamageInfo_HitGroup
+  - name: CEntitySystem_RegisterEntityClass
+    alias:
+    - CEntitySystem::RegisterEntityClass
+  - name: CEntitySystem_CreateEntityByName
+    alias:
+    - CEntitySystem::CreateEntityByName
+  - name: CEntitySystem_CreateEntity
+    alias:
+    - CEntitySystem::CreateEntity
+  - name: CEntitySystem_AddEntityToEntityDataBase
+    alias:
+    - CEntitySystem::AddEntityToEntityDataBase
+  - name: CEntitySystem_OnAddEntity
+    alias:
+    - CEntitySystem::OnAddEntity
+  - name: CEntitySystem_OnEntityParentChanged
+    alias:
+    - CEntitySystem::OnEntityParentChanged
+  - name: CEntitySystem_PrecacheEntity
+    alias:
+    - CEntitySystem::PrecacheEntity
+  - name: CEntitySystem_InvokePrecacheCallback
+    alias:
+    - CEntitySystem::InvokePrecacheCallback
+  - name: CEntitySystem_DestroyEntity
+    alias:
+    - CEntitySystem::DestroyEntity
+  - name: CConcreteEntityList_AllocEntity
+    alias:
+    - CConcreteEntityList::AllocEntity
+  - name: CEntitySystem_ConstructEntity
+    alias:
+    - CEntitySystem::ConstructEntity
+  - name: CEntitySystem_DoConstructEntity
+    alias:
+    - CEntitySystem::DoConstructEntity
+  - name: CEntitySystem_GetSpawnGroupWorldId
+    alias:
+    - CEntitySystem::GetSpawnGroupWorldId
+  - name: CEntitySystem_FindClassByDesignName
+    alias:
+    - CEntitySystem::FindClassByDesignName
+  - name: CEntitySystem_m_EntityList
+    alias:
+    - CEntitySystem::m_EntityList
+  - name: CEntitySystem_m_entityNames
+    alias:
+    - CEntitySystem::m_entityNames
+  - name: CEntitySystem_m_entityComponentHelpers
+    alias:
+    - CEntitySystem::m_entityComponentHelpers
+  - name: CEntitySystem_m_DataDescKeyUnserializers
+    alias:
+    - CEntitySystem::m_DataDescKeyUnserializers
+  - name: CEntitySystem_m_EntityPostSpawnCallback
+    alias:
+    - CEntitySystem::m_EntityPostSpawnCallback
+  - name: CEntityIdentity_FreeAttributes
+    alias:
+    - CEntityIdentity::FreeAttributes
+  - name: CConcreteEntityList_FreeEntity
+    alias:
+    - CConcreteEntityList::FreeEntity
+  - name: UTIL_CreateEntityByName
+    alias:
+    - CreateEntityByName
+  - name: CBaseEntity_DispatchSpawn
+    alias:
+    - CBaseEntity::DispatchSpawn
+    - DispatchSpawn
+  - name: CEntitySystem_QueueSpawnEntity
+    alias:
+    - CEntitySystem::QueueSpawnEntity
+  - name: CEntitySystem_HelperExecuteQueuedSpawn
+    alias:
+    - CEntitySystem::HelperExecuteQueuedSpawn
+  - name: CEntitySystem_SortEntities
+    alias:
+    - CEntitySystem::SortEntities
+  - name: CGameEntitySystem_SortEntities
+    alias:
+    - CGameEntitySystem::SortEntities
+  - name: CEntitySystem_InstallCreationWrapperCallbacks
+    alias:
+    - CEntitySystem::InstallCreationWrapperCallbacks
+  - name: CEntitySystem_ExecuteQueuedCreation
+    alias:
+    - CEntitySystem::ExecuteQueuedCreation
+  - name: CEntitySystem_ExecuteQueuedActivates
+    alias:
+    - CEntitySystem::ExecuteQueuedActivates
+  - name: CEntitySystem_ExecuteQueuedPostDataUpdateAndActivates
+    alias:
+    - CEntitySystem::ExecuteQueuedPostDataUpdateAndActivates
+  - name: CEntitySystem_Activate
+    alias:
+    - CEntitySystem::Activate
+  - name: CEntitySystem_PostDataUpdate
+    alias:
+    - CEntitySystem::PostDataUpdate
+  - name: CBaseEntity_NetworkStateChangedLog
+    alias:
+    - CBaseEntity::NetworkStateChangedLog
+  - name: CBaseEntity_NetworkStateChanged
+    alias:
+    - CBaseEntity::NetworkStateChanged
+  - name: CBaseEntity_FullEdictChanged
+    alias:
+    - CBaseEntity::FullEdictChanged
+  - name: CBaseEntity_m_NetworkTransmitComponent
+    alias:
+    - CBaseEntity::m_NetworkTransmitComponent
+  - name: CNetworkTransmitComponent_StateChanged
+    alias:
+    - CNetworkTransmitComponent::StateChanged
+  - name: CNetworkTransmitComponent_m_nStateFlags
+    alias:
+    - CNetworkTransmitComponent::m_nStateFlags
+  - name: CInferno_InfernoThink
+    alias:
+    - CInferno::InfernoThink
+  - name: CPhysExplosion_Activate
+    alias:
+    - CPhysExplosion::Activate
+  - name: CPhysExplosion_Explode
+    alias:
+    - CPhysExplosion::Explode
+  - name: UTIL_SayTextFilter2
+    alias:
+    - UTIL_SayText2Filter
+  - name: CCSWeaponBase_ItemPostFrame_ProcessReloadAction
+    alias:
+    - CCSWeaponBase::ItemPostFrame::ProcessReloadAction
+  - name: CCSPlayer_WeaponServices_HandleDropWeapon
+    alias:
+    - CCSPlayer_WeaponServices::HandleDropWeapon
+  - name: CCSPlayer_UseServices_BumpWeapon
+    alias:
+    - CCSPlayer_UseServices::BumpWeapon
+  - name: CCSPlayerPawn_HandleDropWeapon
+    alias:
+    - CCSPlayerPawn::HandleDropWeapon
+  - name: CCSPlayerPawn_ClientCommand
+    alias:
+    - CCSPlayerPawn::ClientCommand
+  - name: CCSPlayerPawn_SprayPaint
+    alias:
+    - CCSPlayerPawn::SprayPaint
+  - name: CEntitySpawner_CPlayerSprayDecal_Spawn
+    alias:
+    - CEntitySpawner<CPlayerSprayDecal>::Spawn
+  - name: CEntityKeyValuesAllocator_GetTempBuffer
+    alias:
+    - CEntityKeyValuesAllocator::GetTempBuffer
+  - name: CEntityKeyValues_LoadFromContext
+    alias:
+    - CEntityKeyValues::LoadFromContext
+  - name: CEntityKeyValues_Initialized
+    alias:
+    - CEntityKeyValues::Initialized
+  - name: CEntitySystem_m_nEntityKeyValuesAllocatorRefCount
+    alias:
+    - CEntitySystem::m_nEntityKeyValuesAllocatorRefCount
+  - name: CEntitySystem_AddRefKeyValues
+    alias:
+    - CEntitySystem::AddRefKeyValues
+  - name: CEntitySystem_ReleaseKeyValues
+    alias:
+    - CEntitySystem::ReleaseKeyValues
+  - name: CCSPlayerController_HandleCommandDrop
+    alias:
+    - CCSPlayerController::HandleCommandDrop
+  - name: IGameSystem_InitAllSystems
+    alias:
+    - IGameSystem::InitAllSystems
+  - name: IGameSystem_LoopInitAllSystems
+    alias:
+    - IGameSystem::LoopInitAllSystems
+  - name: IGameSystem_LoopPostInitAllSystems
+    alias:
+    - IGameSystem::LoopPostInitAllSystems
+  - name: IGameSystem_PostInit
+    alias:
+    - IGameSystem::PostInit
+  - name: IGameSystemFactory_PostInit
+    alias:
+    - IGameSystemFactory::PostInit
+  - name: IGameSystemFactory_GetStaticGameSystem
+    alias:
+    - IGameSystemFactory::GetStaticGameSystem
+  - name: IGameSystem_InitAllSystems_pFirst
+    alias:
+    - IGameSystem::InitAllSystems::pFirst
+    - IGameSystem::InitAllSystems->pFirst
+  - name: IGameSystem_LoopPostInitAllSystems_pEventDispatcher
+    alias:
+    - IGameSystem::LoopPostInitAllSystems::pEventDispatcher
+    - IGameSystem::LoopPostInitAllSystems->pEventDispatcher
+  - name: IGameSystem_LoopDestroyAllSystems_s_GameSystems
+    alias:
+    - IGameSystem::LoopDestroyAllSystems::s_GameSystems
+    - IGameSystem::LoopDestroyAllSystems->s_GameSystems
+  - name: CSource2GameEntities_CheckTransmit
+    alias:
+    - CSource2GameEntities::CheckTransmit
+    - ISource2GameEntities::CheckTransmit
+    - ISource2GameEntities_CheckTransmit
+    - CheckTransmit
+  - name: CSource2GameEntities_ShouldClientReceiveStringTableUserData
+    alias:
+    - CSource2GameEntities::ShouldClientReceiveStringTableUserData
+    - ISource2GameEntities::ShouldClientReceiveStringTableUserData
+    - ISource2GameEntities_ShouldClientReceiveStringTableUserData
+    - ShouldClientReceiveStringTableUserData
+  - name: INetworkGameServer_IsBackgroundMap
+    alias:
+    - INetworkGameServer::IsBackgroundMap
+  - name: ILoopModeGameSharedState_IsBackgroundMap
+    alias:
+    - ILoopModeGameSharedState::IsBackgroundMap
+  - name: CNetworkGameServerBase_IsBackgroundMap
+    alias:
+    - CNetworkGameServerBase::IsBackgroundMap
+  - name: CBaseEntity_EmitSoundFilter
+    alias:
+    - CBaseEntity::EmitSoundFilter
+  - name: CBaseEntity_ScriptInputKill
+    alias:
+    - CBaseEntity::ScriptInputKill
+  - name: CBaseEntity_ScriptGetForward
+    alias:
+    - CBaseEntity::ScriptGetForward
+  - name: CBaseEntity_ScriptGetRight
+    alias:
+    - CBaseEntity::ScriptGetRight
+  - name: CBaseEntity_ScriptGetLeft
+    alias:
+    - CBaseEntity::ScriptGetLeft
+  - name: CBaseEntity_ScriptGetUp
+    alias:
+    - CBaseEntity::ScriptGetUp
+  - name: CBaseEntity_ScriptGetModelName
+    alias:
+    - CBaseEntity::ScriptGetModelName
+  - name: CBaseEntity_ScriptGetMoveParent
+    alias:
+    - CBaseEntity::ScriptGetMoveParent
+  - name: CBaseEntity_ScriptGetRootMoveParent
+    alias:
+    - CBaseEntity::ScriptGetRootMoveParent
+  - name: CBaseEntity_ScriptFirstMoveChild
+    alias:
+    - CBaseEntity::ScriptFirstMoveChild
+  - name: CBaseEntity_ScriptNextMovePeer
+    alias:
+    - CBaseEntity::ScriptNextMovePeer
+  - name: CBaseEntity_ScriptGetOwnerEntity
+    alias:
+    - CBaseEntity::ScriptGetOwnerEntity
+  - name: CBaseEntity_Script_GetChildren
+    alias:
+    - CBaseEntity::Script_GetChildren
+  - name: CBaseEntity_ScriptSetParent
+    alias:
+    - CBaseEntity::ScriptSetParent
+  - name: CBaseEntity_ScriptEyePosition
+    alias:
+    - CBaseEntity::ScriptEyePosition
+  - name: CBaseEntity_ScriptSetAngles
+    alias:
+    - CBaseEntity::ScriptSetAngles
+  - name: CBaseEntity_ScriptSetAbsAngles
+    alias:
+    - CBaseEntity::ScriptSetAbsAngles
+  - name: CBaseEntity_ScriptGetAngles
+    alias:
+    - CBaseEntity::ScriptGetAngles
+  - name: CBaseEntity_ScriptEyeAngles
+    alias:
+    - CBaseEntity::ScriptEyeAngles
+  - name: CBaseEntity_ScriptSetOrigin
+    alias:
+    - CBaseEntity::ScriptSetOrigin
+  - name: CBaseEntity_ScriptSetLocalAngles
+    alias:
+    - CBaseEntity::ScriptSetLocalAngles
+  - name: CBaseEntity_ScriptGetLocalAngles
+    alias:
+    - CBaseEntity::ScriptGetLocalAngles
+  - name: CBaseEntity_ScriptSetLocalOrigin
+    alias:
+    - CBaseEntity::ScriptSetLocalOrigin
+  - name: CBaseEntity_ScriptGetLocalOrigin
+    alias:
+    - CBaseEntity::ScriptGetLocalOrigin
+  - name: CBaseEntity_ScriptTransformPointEntityToWorld
+    alias:
+    - CBaseEntity::ScriptTransformPointEntityToWorld
+  - name: CBaseEntity_ScriptTransformPointWorldToEntity
+    alias:
+    - CBaseEntity::ScriptTransformPointWorldToEntity
+  - name: CBaseEntity_ScriptSetForward
+    alias:
+    - CBaseEntity::ScriptSetForward
+  - name: CBaseEntity_ScriptGetBoundingMins
+    alias:
+    - CBaseEntity::ScriptGetBoundingMins
+  - name: CBaseEntity_ScriptGetBoundingMaxs
+    alias:
+    - CBaseEntity::ScriptGetBoundingMaxs
+  - name: CBaseEntity_ScriptGetBounds
+    alias:
+    - CBaseEntity::ScriptGetBounds
+  - name: CBaseEntity_ScriptGetLocalAngularVelocity_OBSOLETE
+    alias:
+    - CBaseEntity::ScriptGetLocalAngularVelocity_OBSOLETE
+  - name: CBaseEntity_ScriptSetLocalAngularVelocity_OBSOLETE
+    alias:
+    - CBaseEntity::ScriptSetLocalAngularVelocity_OBSOLETE
+  - name: CBaseEntity_ScriptAddEffects
+    alias:
+    - CBaseEntity::ScriptAddEffects
+  - name: CBaseEntity_ScriptRemoveEffects
+    alias:
+    - CBaseEntity::ScriptRemoveEffects
+  - name: CBaseEntity_ScriptSetAttributeFloatValue
+    alias:
+    - CBaseEntity::ScriptSetAttributeFloatValue
+  - name: CBaseEntity_ScriptGetAttributeFloatValue
+    alias:
+    - CBaseEntity::ScriptGetAttributeFloatValue
+  - name: CBaseEntity_ScriptSetAttributeIntValue
+    alias:
+    - CBaseEntity::ScriptSetAttributeIntValue
+  - name: CBaseEntity_ScriptGetAttributeIntValue
+    alias:
+    - CBaseEntity::ScriptGetAttributeIntValue
+  - name: CBaseEntity_ScriptHasAttribute
+    alias:
+    - CBaseEntity::ScriptHasAttribute
+  - name: CBaseEntity_ScriptDeleteAttribute
+    alias:
+    - CBaseEntity::ScriptDeleteAttribute
+  - name: CBaseEntity_GetScriptOwnerEntity
+    alias:
+    - CBaseEntity::GetScriptOwnerEntity
+  - name: CBaseEntity_SetScriptOwnerEntity
+    alias:
+    - CBaseEntity::SetScriptOwnerEntity
+  - name: CBaseEntity_ScriptSetEntityName
+    alias:
+    - CBaseEntity::ScriptSetEntityName
+  - name: CBaseEntity_ScriptGetMass
+    alias:
+    - CBaseEntity::ScriptGetMass
+  - name: CBaseEntity_ScriptSetMass
+    alias:
+    - CBaseEntity::ScriptSetMass
+  - name: CBaseEntity_ScriptGetSpawnGroupHandle
+    alias:
+    - CBaseEntity::ScriptGetSpawnGroupHandle
+  - name: CBaseEntity_GetAbsAngles
+    alias:
+    - CBaseEntity::GetAbsAngles
+  - name: CBaseEntity_Script_GetTeamNumber
+    alias:
+    - CBaseEntity::Script_GetTeamNumber
+  - name: CBaseEntity_Script_FollowEntity
+    alias:
+    - CBaseEntity::Script_FollowEntity
+  - name: CBaseEntity_Script_FollowEntityMerge
+    alias:
+    - CBaseEntity::Script_FollowEntityMerge
+  - name: CBaseEntity_Script_Trigger
+    alias:
+    - CBaseEntity::Script_Trigger
+  - name: CBaseEntity_Script_SetContextThink
+    alias:
+    - CBaseEntity::Script_SetContextThink
+  - name: CBaseEntity_AddContextForScript
+    alias:
+    - CBaseEntity::AddContextForScript
+  - name: CBaseEntity_AddContextForScriptNumeric
+    alias:
+    - CBaseEntity::AddContextForScriptNumeric
+  - name: CBaseEntity_GetContextForScript
+    alias:
+    - CBaseEntity::GetContextForScript
+  - name: CBaseEntity_ScriptGatherCriteria
+    alias:
+    - CBaseEntity::ScriptGatherCriteria
+  - name: CBaseEntity_Script_TakeDamage
+    alias:
+    - CBaseEntity::Script_TakeDamage
+  - name: CBaseEntity_SetAbsVelocity
+    alias:
+    - CBaseEntity::SetAbsVelocity
+  - name: CBaseEntity_GetAbsVelocity
+    alias:
+    - CBaseEntity::GetAbsVelocity
+  - name: CBaseEntity_Script_ApplyLocalAngularVelocityImpulse
+    alias:
+    - CBaseEntity::Script_ApplyLocalAngularVelocityImpulse
+  - name: CBaseEntity_GetLocalAngularVelocity_OBSOLETE
+    alias:
+    - CBaseEntity::GetLocalAngularVelocity_OBSOLETE
+  - name: CBaseEntity_ScriptEmitSoundParams
+    alias:
+    - CBaseEntity::ScriptEmitSoundParams
+    - CBaseEntity::EmitSoundParams
+    - CBaseEntity_EmitSoundParams
+  - name: CBaseEntity_ScriptStopSound
+    alias:
+    - CBaseEntity::ScriptStopSound
+  - name: CBaseEntity_ScriptSoundDuration
+    alias:
+    - CBaseEntity::ScriptSoundDuration
+  - name: CBaseEntity_ScriptGetAbsOrigin
+    alias:
+    - CBaseEntity::ScriptGetAbsOrigin
+  - name: CBaseEntity_OnSetDormant
+    alias:
+    - CBaseEntity::OnSetDormant
+  - name: CBaseEntity_Precache
+    alias:
+    - CBaseEntity::Precache
+    - Precache
+  - name: CCSPlayerController_AddedToEntityDatabase
+    alias:
+    - CCSPlayerController::AddedToEntityDatabase
+  - name: CEnvEntityIgniter_Precache
+    alias:
+    - CEnvEntityIgniter::Precache
+  - name: CEnvShake_Spawn
+    alias:
+    - CEnvShake::Spawn
+  - name: CBaseEntity_SetMoveType
+    alias:
+    - CBaseEntity::SetMoveType
+  - name: CBasePlayerPawn_CommitSuicide
+    alias:
+    - CBasePlayerPawn::CommitSuicide
+    - CommitSuicide
+  - name: CBaseCombatCharacter_OnKilled
+    alias:
+    - CBaseCombatCharacter::OnKilled
+  - name: CCSPlayerPawn_Event_KilledOther
+    alias:
+    - CCSPlayerPawn::Event_KilledOther
+  - name: CCSPlayerPawn_Event_Killed
+    alias:
+    - CCSPlayerPawn::Event_Killed
+  - name: CBasePlayerPawn_Event_Killed
+    alias:
+    - CBasePlayerPawn::Event_Killed
+  - name: ScriptBinding_CSPlayerPawn_DestroyWeapon
+    alias:
+    - CSPlayerPawn::DestroyWeapon
+  - name: CBasePlayerPawn_RemovePlayerItem
+    alias:
+    - CBasePlayerPawn::RemovePlayerItem
+  - name: CBasePlayerPawn_DropActivePlayerWeapon
+    alias:
+    - CBasePlayerPawn::DropActivePlayerWeapon
+  - name: CBasePlayerPawn_GetEyePosition
+    alias:
+    - CBasePlayerPawn::GetEyePosition
+  - name: CBaseEntity_GetEyePosition
+    alias:
+    - CBaseEntity::GetEyePosition
+  - name: CCSBotManager_BotPlaceCommand
+    alias:
+    - CCSBotManager::BotPlace
+  - name: CBasePlayerPawn_EyeVectors
+    alias:
+    - CBasePlayerPawn::EyeVectors
+  - name: CBasePlayerPawn_GetEyeAngles
+    alias:
+    - CBasePlayerPawn::GetEyeAngles
+  - name: CBaseEntity_GetEyeAngles
+    alias:
+    - CBaseEntity::GetEyeAngles
+  - name: CCSBot_Upkeep
+    alias:
+    - CCSBot::Upkeep
+  - name: CCSBot_SetState
+    alias:
+    - CCSBot::SetState
+  - name: CCSBot_UpdatePathMovement
+    alias:
+    - CCSBot::UpdatePathMovement
+  - name: CCSBot_PrintIfWatched
+    alias:
+    - CCSBot::PrintIfWatched
+  - name: CHostage_Follow
+    alias:
+    - CHostage::Follow
+  - name: CHostage_DropHostage
+    alias:
+    - CHostage::DropHostage
+  - name: HideState_OnUpdate
+    alias:
+    - HideState::OnUpdate
+  - name: CCSBot_Attack
+    alias:
+    - CCSBot::Attack
+  - name: CCSBot_MoveTo
+    alias:
+    - CCSBot::MoveTo
+  - name: CCSBot_InhibitLookAround
+    alias:
+    - CCSBot::InhibitLookAround
+  - name: CCSBot_SetDisposition
+    alias:
+    - CCSBot::SetDisposition
+  - name: CCSBot_Idle
+    alias:
+    - CCSBot::Idle
+  - name: CCSBot_ComputePath
+    alias:
+    - CCSBot::ComputePath
+  - name: CBaseEntity_IsAlive
+    alias:
+    - CBaseEntity::IsAlive
+  - name: CBaseEntity_SetOwner
+    alias:
+    - CBaseEntity::SetOwner
+  - name: CBaseEntity_CollisionRulesChanged
+    alias:
+    - CBaseEntity::CollisionRulesChanged
+    - CollisionRulesChanged
+  - name: CBaseEntity_Use
+    alias:
+    - CBaseEntity::Use
+  - name: CGameSceneNode_PostSpawnKeyValues
+    alias:
+    - CGameSceneNode::PostSpawnKeyValues
+  - name: CBaseEntity_Spawn
+    alias:
+    - CBaseEntity::Spawn
+    - Spawn
+  - name: CBaseEntity_SpawnRadius
+    alias:
+    - CBaseEntity::SpawnRadius
+  - name: CCSPlayer_ItemServices_DropActivePlayerWeapon
+    alias:
+    - CCSPlayer_ItemServices::DropActivePlayerWeapon
+  - name: CCSPlayer_WeaponServices_DropWeapon
+    alias:
+    - CCSPlayer_WeaponServices::DropWeapon
+  - name: CBasePlayerWeapon_Shoot_Secondary
+    alias:
+    - CBasePlayerWeapon::Shoot_Secondary
+  - name: CCSPlayer_ItemServices_RemoveWeapons
+    alias:
+    - CCSPlayer_ItemServices::RemoveWeapons
+  - name: CCSPlayer_WeaponServices_SelectItem
+    alias:
+    - CCSPlayer_WeaponServices::SelectItem
+  - name: CEntFireOutputAutoCompletionFunctor_FireOutput
+    alias:
+    - CEntFireOutputAutoCompletionFunctor::FireOutput
+  - name: CEntityInstance_FindOutputsByName
+    alias:
+    - CEntityInstance::FindOutputsByName
+  - name: CEntityInstance_ScriptEntityIO
+    alias:
+    - CEntityInstance::ScriptEntityIO
+  - name: CEntityIOOutput_FireOutputInternal
+    alias:
+    - CEntityIOOutput::FireOutputInternal
+  - name: CEntitySystem_AddEntityIOEvent
+    alias:
+    - CEntitySystem::AddEntityIOEvent
+  - name: CEntitySystem_AddEntityIOEvent2
+    alias:
+    - CEntitySystem::AddEntityIOEvent2
+  - name: CEntitySystem_AddEntityIOEventBuildStruct
+    alias:
+    - CEntitySystem::AddEntityIOEventBuildStruct
+  - name: CEntitySystem_AddEntityIOEventToQueue
+    alias:
+    - CEntitySystem::AddEntityIOEventToQueue
+  - name: CEntitySystem_m_EventQueue
+    alias:
+    - CEntitySystem::m_EventQueue
+  - name: CGameEntitySystem_FindEntityByClassName
+    alias:
+    - CGameEntitySystem::FindEntityByClassName
+  - name: CGameEntitySystem_FindEntityByName
+    alias:
+    - CGameEntitySystem::FindEntityByName
+  - name: CChicken_Event_Killed
+    alias:
+    - CChicken::Event_Killed
+  - name: CBaseEntity_EmitSound
+    alias:
+    - CBaseEntity::EmitSound
+  - name: CBaseModelEntity_FindBone
+    alias:
+    - CBaseModelEntity::FindBone
+  - name: CGameEntitySystem_OnAddEntity
+    alias:
+    - CGameEntitySystem::OnAddEntity
+  - name: CGameEntitySystem_BuildResourceManifest_ManifestNameOrGroupName
+    alias:
+    - CGameEntitySystem::BuildResourceManifest_ManifestNameOrGroupName
+  - name: CGameEntitySystem_BuildResourceManifest_KeyValuesVectors
+    alias:
+    - CGameEntitySystem::BuildResourceManifest_KeyValuesVectors
+  - name: CGameEntitySystem_FindEntityProcedural
+    alias:
+    - CGameEntitySystem::FindEntityProcedural
+  - name: CGameEntitySystem_Spawn
+    alias:
+    - CGameEntitySystem::Spawn
+  - name: CEntitySystem_Spawn
+    alias:
+    - CEntitySystem::Spawn
+  - name: CBodyGameSystem_SpawnDependencyIsland
+    alias:
+    - CBodyGameSystem::SpawnDependencyIsland
+  - name: CGameEntitySystem_CheckGlobalState
+    alias:
+    - CGameEntitySystem::CheckGlobalState
+  - name: IGameSystem_OnBuildGameSessionManifest
+    alias:
+    - IGameSystem::BuildGameSessionManifest
+  - name: IGameSystem_OnServerPreEntityThink
+    alias:
+    - IGameSystem::OnServerPreEntityThink
+  - name: IGameSystem_OnServerPostEntityThink
+    alias:
+    - IGameSystem::OnServerPostEntityThink
+  - name: IGameSystem_OnServerPreClientUpdate
+    alias:
+    - IGameSystem::ServerPreClientUpdate
+  - name: IGameSystem_OnServerAdvanceTick
+    alias:
+    - IGameSystem::ServerAdvanceTick
+  - name: IGameSystem_OnServerGamePostSimulate
+    alias:
+    - IGameSystem::ServerGamePostSimulate
+  - name: IGameSystem_OnServerPostAdvanceTick
+    alias:
+    - IGameSystem::ServerPostAdvanceTick
+  - name: IGameSystem_OnServerPreBeginAsyncPostTickWork
+    alias:
+    - IGameSystem::OnServerPreBeginAsyncPostTickWork
+  - name: IGameSystem_OnServerBeginAsyncPostTickWork
+    alias:
+    - IGameSystem::OnServerBeginAsyncPostTickWork
+  - name: IGameSystem_OnServerPreEndAsyncPostTickWork
+    alias:
+    - IGameSystem::OnServerPreEndAsyncPostTickWork
+  - name: IGameSystem_OnServerPostEndAsyncPostTickWork
+    alias:
+    - IGameSystem::OnServerPostEndAsyncPostTickWork
+  - name: IGameSystem_OnSaveGame
+    alias:
+    - IGameSystem::OnSaveGame
+  - name: IGameSystem_OnRestoreGame
+    alias:
+    - IGameSystem::OnRestoreGame
+  - name: IGameSystem_OnOutOfGameFrameBoundary
+    alias:
+    - IGameSystem::OnOutOfGameFrameBoundary
+  - name: CSource2GameClients_StartHLTVServer
+    alias:
+    - CSource2GameClients::StartHLTVServer
+  - name: LegacyGameEventListener
+    alias:
+    - GetLegacyGameEventListener
+  - name: CPhysicsGameSystem_ProcessContactEvents
+    alias:
+    - CPhysicsGameSystem::ProcessContactEvents
+  - name: CBaseEntity_VPhysicsCollision
+    alias:
+    - CBaseEntity::VPhysicsCollision
+  - name: CBaseEntity_VPhysicsStartTouch
+    alias:
+    - CBaseEntity::VPhysicsStartTouch
+  - name: CBaseEntity_PhysicsTouch
+    alias:
+    - CBaseEntity::PhysicsTouch
+  - name: CBaseEntity_VPhysicsEndTouch
+    alias:
+    - CBaseEntity::VPhysicsEndTouch
+  - name: CBaseEntity_StartTouch
+    alias:
+    - CBaseEntity::StartTouch
+    - StartTouch
+  - name: CBaseEntity_Touch
+    alias:
+    - CBaseEntity::Touch
+    - Touch
+  - name: CBaseEntity_EndTouch
+    alias:
+    - CBaseEntity::EndTouch
+    - EndTouch
+  - name: IVPhys2World_GetTouchingList
+    alias:
+    - IVPhys2World::GetTouchingList
+    - CVPhys2World::GetTouchingList
+  - name: CTriggerPush_Touch
+    alias:
+    - CTriggerPush::Touch
+    - TriggerPush_Touch
+  - name: CPhysBox_Use
+    alias:
+    - CPhysBox::Use
+  - name: CBaseEntity_SetGroundEntity
+    alias:
+    - SetGroundEntity
+  - name: CBaseEntity_GetHammerUniqueId
+    alias:
+    - CBaseEntity::GetHammerUniqueId
+    - GetHammerUniqueId
+  - name: CBaseEntity_IsPlayerPawn
+    alias:
+    - CBaseEntity::IsPlayerPawn
+    - IsEntityPawn
+    - IsPlayerPawn
+  - name: CBaseEntity_IsPlayerController
+    alias:
+    - CBaseEntity::IsPlayerController
+    - IsEntityController
+    - IsPlayerController
+  - name: CBaseTrigger_StartTouch
+    alias:
+    - CBaseTrigger::StartTouch
+  - name: CBaseTrigger_EndTouch
+    alias:
+    - CBaseTrigger::EndTouch
+  - name: CBaseTrigger_PassesTriggerFilters
+    alias:
+    - CBaseTrigger::PassesTriggerFilters
+    - PassesTriggerFilters
+  - name: CBaseAnimGraph_GetAnimationController
+    alias:
+    - CBaseAnimGraph::GetAnimationController
+  - name: CBaseAnimGraph_m_skeletonInstance
+    alias:
+    - CBaseAnimGraph::m_skeletonInstance
+  - name: CGameSceneNode_PreInstanceSpawn
+    alias:
+    - CGameSceneNode::PreInstanceSpawn
+  - name: CGameSceneNode_GetSkeletonInstance
+    alias:
+    - CGameSceneNode::GetSkeletonInstance
+  - name: CSkeletonInstance_m_animationController
+    alias:
+    - CSkeletonInstance::m_animationController
+  - name: CSkeletonInstance_PostDataUpdate
+    alias:
+    - CSkeletonInstance::PostDataUpdate
+  - name: CGameSceneNode_PostDataUpdate
+    alias:
+    - CGameSceneNode::PostDataUpdate
+  - name: CGameSceneNode_UpdateEntityForHierarchyChange
+    alias:
+    - CGameSceneNode::UpdateEntityForHierarchyChange
+  - name: CPointTeleportAPI_TeleportEntityInternal
+    alias:
+    - CPointTeleportAPI::TeleportEntityInternal
+  - name: CBaseEntity_Teleport
+    alias:
+    - CBaseEntity::Teleport
+  - name: CPointTeleport_Activate
+    alias:
+    - CPointTeleport::Activate
+  - name: CBaseEntity_Activate
+    alias:
+    - CBaseEntity::Activate
+    - Activate
+  - name: CBaseEntity_DrawDebugTextOverlays
+    alias:
+    - CBaseEntity::DrawDebugTextOverlays
+  - name: CRagdollProp_DrawEntityDebugOverlays
+    alias:
+    - CRagdollProp::DrawEntityDebugOverlays
+  - name: CBaseEntity_ReloadPrivateScripts
+    alias:
+    - CBaseEntity::ReloadPrivateScripts
+  - name: CCheckTransmitInfo_m_nPlayerSlot
+    alias:
+    - CCheckTransmitInfo::m_nPlayerSlot
+    - CheckTransmitPlayerSlot
+  - name: CCheckTransmitInfo_m_bFullUpdate
+    alias:
+    - CCheckTransmitInfo::m_bFullUpdate
+  - name: CDedicatedServerWorkshopManager_SwitchToWorkshopMapGroup
+    alias:
+    - CDedicatedServerWorkshopManager::SwitchToWorkshopMapGroup
+  - name: IGameTypes_CreateWorkshopMapGroup
+    alias:
+    - IGameTypes::CreateWorkshopMapGroup
+  - name: CEngineServer_UnloadSpawnGroup
+    alias:
+    - CEngineServer::UnloadSpawnGroup
+  - name: INetworkServerService_SetGameSpawnGroupMgr
+    alias:
+    - INetworkServerService::SetGameSpawnGroupMgr
+  - name: INetworkServerService_AddServerPrerequisites
+    alias:
+    - INetworkServerService::AddServerPrerequisites
+  - name: INetworkServerService_SetFinalSimulationTickThisFrame
+    alias:
+    - INetworkServerService::SetFinalSimulationTickThisFrame
+  - name: CSpawnGroupMgrGameSystem_GetSpawnGroups
+    alias:
+    - CSpawnGroupMgrGameSystem::GetSpawnGroups
+    - GetSpawnGroups
+  - name: CSpawnGroupMgrGameSystem_DumpSpawnGroups
+    alias:
+    - CSpawnGroupMgrGameSystem::DumpSpawnGroups
+    - DumpSpawnGroups
+  - name: CSpawnGroupMgrGameSystem_SpawnGroupSpawnEntitiesInternal
+    alias:
+    - CSpawnGroupMgrGameSystem::SpawnGroupSpawnEntitiesInternal
+    - SpawnGroupSpawnEntitiesInternal
+  - name: IGameSystem_OnPreSpawnGroupLoad
+    alias:
+    - IGameSystem::OnPreSpawnGroupLoad
+  - name: IGameSystem_OnPostSpawnGroupLoad
+    alias:
+    - IGameSystem::OnPostSpawnGroupLoad
+  - name: CSpawnGroupMgrGameSystem_SpawnGroupShutdown
+    alias:
+    - CSpawnGroupMgrGameSystem::SpawnGroupShutdown
+    - SpawnGroupShutdown
+  - name: CSpawnGroupMgrGameSystem_SpawnGroupActuallyShutdown
+    alias:
+    - CSpawnGroupMgrGameSystem::SpawnGroupActuallyShutdown
+    - SpawnGroupActuallyShutdown
+  - name: IGameSystem_OnPreSpawnGroupUnload
+    alias:
+    - IGameSystem::OnPreSpawnGroupUnload
+  - name: IGameSystem_OnPostSpawnGroupUnload
+    alias:
+    - IGameSystem::OnPostSpawnGroupUnload
+  - name: CLoadingSpawnGroup_CreateEntityToSpawn
+    alias:
+    - CLoadingSpawnGroup::CreateEntityToSpawn
+  - name: CSpawnGroupMgrGameSystem_OnSpawnGroupPrecache
+    alias:
+    - CSpawnGroupMgrGameSystem::OnSpawnGroupPrecache
+    - SpawnGroupPrecache
+  - name: CSpawnGroupMgrGameSystem_AllocateSpawnGroup
+    alias:
+    - CSpawnGroupMgrGameSystem::AllocateSpawnGroup
+  - name: CSpawnGroupMgrGameSystem_ReleaseSpawnGroup
+    alias:
+    - CSpawnGroupMgrGameSystem::ReleaseSpawnGroup
+  - name: CSpawnGroupMgrGameSystem_SpawnGroupInit
+    alias:
+    - CSpawnGroupMgrGameSystem::SpawnGroupInit
+  - name: CSpawnGroupMgrGameSystem_CreateLoadingSpawnGroup
+    alias:
+    - CSpawnGroupMgrGameSystem::CreateLoadingSpawnGroup
+  - name: CSpawnGroupMgrGameSystem_CreateLoadingSpawnGroupForSaveFile
+    alias:
+    - CSpawnGroupMgrGameSystem::CreateLoadingSpawnGroupForSaveFile
+  - name: CSpawnGroupMgrGameSystem_SpawnGroupSpawnEntities
+    alias:
+    - CSpawnGroupMgrGameSystem::SpawnGroupSpawnEntities
+  - name: CSpawnGroupMgrGameSystem_SetActiveSpawnGroup
+    alias:
+    - CSpawnGroupMgrGameSystem::SetActiveSpawnGroup
+  - name: IVEngineServer2_MakeSpawnGroupActive
+    alias:
+    - IVEngineServer2::MakeSpawnGroupActive
+  - name: CSpawnGroupMgrGameSystem_UnloadSpawnGroup
+    alias:
+    - CSpawnGroupMgrGameSystem::UnloadSpawnGroup
+  - name: CSpawnGroupMgrGameSystem_SaveGame_Start
+    alias:
+    - CSpawnGroupMgrGameSystem::SaveGame_Start
+  - name: IGameSystem_OnSpawnGroupPrecache
+    alias:
+    - IGameSystem::OnSpawnGroupPrecache
+  - name: IGameSystem_OnSpawnGroupUncache
+    alias:
+    - IGameSystem::OnSpawnGroupUncache
+  - name: CBaseFilter_InputTestActivator
+    alias:
+    - CBaseFilter::InputTestActivator
+  - name: CGamePlayerEquip_InputTriggerForAllPlayers
+    alias:
+    - CGamePlayerEquip::InputTriggerForAllPlayers
+  - name: CGamePlayerEquip_InputTriggerForActivatedPlayer
+    alias:
+    - CGamePlayerEquip::InputTriggerForActivatedPlayer
+  - name: CNavMesh_GetNearestNavArea
+    alias:
+    - CNavMesh::GetNearestNavArea
+  - name: CCSBotManager_AddBot
+    alias:
+    - CCSBotManager::AddBot
+  - name: BotAdd_CommandHandler
+    alias:
+    - CCSBotManager::BotAddCommand
+  - name: BotKill_CommandHandler
+    alias:
+    - CCSBotManager::BotKillCommand
+  - name: EntInfo_CommandHandler
+    alias:
+    - CC_Ent_Info
+  - name: CEntitySystem_DestroyEntityImmediate
+    alias:
+    - CEntitySystem::DestroyEntityImmediate
+  - name: CEntitySystem_OnRemoveEntityFromDatabase
+    alias:
+    - CEntitySystem::OnRemoveEntityFromDatabase
+  - name: CEntitySystem_DoDestructEntity
+    alias:
+    - CEntitySystem::DoDestructEntity
+  - name: CEntitySystem_UpdateOnRemove
+    alias:
+    - CEntitySystem::UpdateOnRemove
+  - name: ClientPrintToController
+    alias:
+    - ClientPrint
+  - name: CCSBotManager_AddBot_BotNavIgnore
+    alias:
+    - BotNavIgnore
+  - name: CEnvHudHint_API_ShowHudHint
+    alias:
+    - CEnvHudHint_API::ShowHudHint
+  - name: UTIL_GetPlayerControllerForEntity
+    alias:
+    - UTIL_GetPlayerControllerForEntity
+  - name: CEntitySystem_ctor
+    alias:
+    - CEntitySystem::CEntitySystem
+  - name: CGameEntitySystem_ctor
+    alias:
+    - CGameEntitySystem::CGameEntitySystem
+  - name: CEntitySystem_RegisterAccessor
+    alias:
+    - CEntitySystem::RegisterAccessor
+  - name: CEntitySystem_Init
+    alias:
+    - CEntitySystem::Init
+  - name: CEntitySystem_ProcessEntityRegistration
+    alias:
+    - CEntitySystem::ProcessEntityRegistration
+  - name: CEntitySystem_PostCreateEntitySystem
+    alias:
+    - CEntitySystem::PostCreateEntitySystem
+  - name: CSource2EntitySystem_StaticInit
+    alias:
+    - CSource2EntitySystem::StaticInit
+  - name: CSpawnGroupEntityFilterRegistrar_RegisterSpawnGroupEntityFilters
+    alias:
+    - CSpawnGroupEntityFilterRegistrar::RegisterSpawnGroupEntityFilters
+  - name: CGameEntitySystem_m_spawnGroupEntityFilters
+    alias:
+    - CGameEntitySystem::m_spawnGroupEntityFilters
+  - name: CGameEntitySystem_m_pEntity2Networkables
+    alias:
+    - CGameEntitySystem::m_pEntity2Networkables
+  - name: CEntity2NetworkClasses_ServerClass_InitEntity2NetworkClasses
+    alias:
+    - CEntity2NetworkClasses<ServerClass>::InitEntity2NetworkClasses
+  - name: CEntitySystem_m_Symbols
+    alias:
+    - CEntitySystem::m_Symbols
+  - name: CEntitySystem_m_pNetworkFieldChangedEventQueue
+    alias:
+    - CEntitySystem::m_pNetworkFieldChangedEventQueue
+  - name: CEntitySystem_m_pNetworkFieldScratchData
+    alias:
+    - CEntitySystem::m_pNetworkFieldScratchData
+  - name: CEntitySystem_m_pFieldChangeLimitSpew
+    alias:
+    - CEntitySystem::m_pFieldChangeLimitSpew
+  - name: CEntitySystem_m_ComponentUnserializerInfoAllocator
+    alias:
+    - CEntitySystem::m_ComponentUnserializerInfoAllocator
+  - name: CEntitySystem_m_EntityMaterialAttributes
+    alias:
+    - CEntitySystem::m_EntityMaterialAttributes
+  - name: CEntitySystem_m_flChangeCallbackSpewThreshold
+    alias:
+    - CEntitySystem::m_flChangeCallbackSpewThreshold
+  - name: CEntitySystem_ClearEntityDatabase
+    alias:
+    - CEntitySystem::ClearEntityDatabase
+  - name: INetworkMessages_SetNetworkSerializationContextData
+    alias:
+    - INetworkMessages::SetNetworkSerializationContextData
+  - name: CFlattenedSerializers_CreateFieldChangedEventQueue
+    alias:
+    - CFlattenedSerializers::CreateFieldChangedEventQueue
+  - name: INetworkMessages_RegisterSchemaTypeOverride
+    alias:
+    - INetworkMessages::RegisterSchemaTypeOverride
+  - name: CSceneEntity_GetScriptDesc
+    alias:
+    - CSceneEntity::GetScriptDesc
+  - name: CEntityInstance_GetScriptDesc
+    alias:
+    - CEntityInstance::GetScriptDesc
+  - name: CEntityInstance_Spawn
+    alias:
+    - CEntityInstance::Spawn
+  - name: CEntityInstance_Activate
+    alias:
+    - CEntityInstance::Activate
+  - name: CEntityInstance_Precache
+    alias:
+    - CEntityInstance::Precache
+  - name: CEntityInstance_GetDataDescMap
+    alias:
+    - CEntityInstance::GetDataDescMap
+  - name: CEntityInstance_ReloadPrivateScripts
+    alias:
+    - CEntityInstance::ReloadPrivateScripts
+  - name: CEntityInstance_ValidatePrivateScriptScope
+    alias:
+    - CEntityInstance::ValidatePrivateScriptScope
+  - name: CEntityInstance_NetworkStateChanged
+    alias:
+    - CEntityInstance::NetworkStateChanged
+  - name: CEntityInstance_FullEdictChanged
+    alias:
+    - CEntityInstance::FullEdictChanged
+  - name: CEntityInstance_NetworkUpdateState
+    alias:
+    - CEntityInstance::NetworkUpdateState
+  - name: CEntityInstance_NetworkStateChangedLog
+    alias:
+    - CEntityInstance::NetworkStateChangedLog
+  - name: CEntityInstance_DrawDebugTextOverlays
+    alias:
+    - CEntityInstance::DrawDebugTextOverlays
+  - name: CEntityInstance_DrawEntityDebugOverlays
+    alias:
+    - CEntityInstance::DrawEntityDebugOverlays
+  - name: CEntityInstance_PostDataUpdateDelta
+    alias:
+    - CEntityInstance::PostDataUpdateDelta
+  - name: CEntityInstance_PreDataUpdate
+    alias:
+    - CEntityInstance::PreDataUpdate
+  - name: CEntityInstance_PostDataUpdate
+    alias:
+    - CEntityInstance::PostDataUpdate
+  - name: CEntityInstance_PostDataUpdatePreserve
+    alias:
+    - CEntityInstance::PostDataUpdatePreserve
+  - name: CEntityInstance_Connect
+    alias:
+    - CEntityInstance::Connect
+  - name: CEntityInstance_UpdateOnRemove
+    alias:
+    - CEntityInstance::UpdateOnRemove
+  - name: CEntityInstance_Disconnect
+    alias:
+    - CEntityInstance::Disconnect
+  - name: CEntityInstance_AddedToEntityDatabase
+    alias:
+    - CEntityInstance::AddedToEntityDatabase
+  - name: CEntityInstance_OnSetDormant
+    alias:
+    - CEntityInstance::OnSetDormant
+  - name: CEntityInstance_Schema_DynamicBinding
+    alias:
+    - CEntityInstance::Schema_DynamicBinding
+  - name: CEntitySystem_OnRemoveEntity
+    alias:
+    - CEntitySystem::OnRemoveEntity
+  - name: CEntityComponentHelperT_Free
+    alias:
+    - CEntityComponentHelperT::Free
+  - name: CScriptedSequence_SynchronizeSequence
+    alias:
+    - CScriptedSequence::SynchronizeSequence
+  - name: CNetworkUtlVectorEmbedded_NetworkStateChanged_m_vecRenderAttributes
+    alias:
+    - CNetworkUtlVectorEmbedded<CRenderAttribute>::NetworkStateChanged_m_vecRenderAttributes
+  - name: CNetworkUtlVectorEmbedded_NetworkStateChanged_m_perRoundStats
+    alias:
+    - CNetworkUtlVectorEmbedded<CSPerRoundStats_t>::NetworkStateChanged_m_perRoundStats
+  - name: CUtlVectorEmbeddedNetworkVar_CSPerRoundStats_t_NetworkVar_m_perRoundStats_SetCount
+    alias:
+    - CUtlVectorEmbeddedNetworkVar<CSPerRoundStats_t, NetworkVar>::SetCount
+  - name: CNetworkUtlVectorEmbedded_TryLateResolve_m_vecRenderAttributes
+    alias:
+    - CNetworkUtlVectorEmbedded<CRenderAttribute>::TryLateResolve
+  - name: INetworkMessages_GetLoggingChannel
+    alias:
+    - INetworkMessages::GetLoggingChannel
+  - name: CPhysicsEntitySolver_PhysEnableEntityCollisions
+    alias:
+    - CPhysicsEntitySolver::PhysEnableEntityCollisions
+  - name: CLoopModeGame_StaticInit
+    alias:
+    - CLoopModeGame::StaticInit
+  - name: CLoopModeGame_ctor
+    alias:
+    - CLoopModeGame::CLoopModeGame
+  - name: CLoopModeFactory_CLoopModeGame_Init
+    alias:
+    - CLoopModeFactory<CLoopModeGame>::Init
+  - name: CLoopModeFactory_CLoopModeGame_CreateLoopMode
+    alias:
+    - CLoopModeFactory<CLoopModeGame>::CreateLoopMode
+  - name: CLoopModeFactory_CLoopModeGame_Shutdown
+    alias:
+    - CLoopModeFactory<CLoopModeGame>::Shutdown
+  - name: CLoopModeGame_OnLoopActivate
+    alias:
+    - CLoopModeGame::OnLoopActivate
+  - name: ILoopMode_OnLoopActivate
+    alias:
+    - ILoopMode::OnLoopActivate
+  - name: CLoopModeGame_AddViewsToSceneSystem
+    alias:
+    - CLoopModeGame::AddViewsToSceneSystem
+  - name: ILoopMode_AddViewsToSceneSystem
+    alias:
+    - ILoopMode::AddViewsToSceneSystem
+  - name: CLoopModeGame_LoopInitInternal
+    alias:
+    - CLoopModeGame::LoopInitInternal
+  - name: CLoopModeGame_LoopInit
+    alias:
+    - CLoopModeGame::LoopInit
+  - name: ILoopMode_LoopInit
+    alias:
+    - ILoopMode::LoopInit
+  - name: ILoopMode_LoopShutdown
+    alias:
+    - ILoopMode::LoopShutdown
+  - name: CLoopModeGame_RegisterEventMapInternal
+    alias:
+    - CLoopModeGame::RegisterEventMapInternal
+  - name: CLoopModeGame_RegisterEventMap
+    alias:
+    - CLoopModeGame::RegisterEventMap
+  - name: CLoopModeGame_dtor
+    alias:
+    - CLoopModeGame::~CLoopModeGame
+  - name: CLoopModeGame_OnServerAdvanceTick
+    alias:
+    - CLoopModeGame::OnServerAdvanceTick
+  - name: CLoopModeGame_OnServerBeginSimulate
+    alias:
+    - CLoopModeGame::OnServerBeginSimulate
+  - name: CLoopModeGame_OnServerPostSimulate
+    alias:
+    - CLoopModeGame::OnServerPostSimulate
+  - name: CLoopModeGame_OnServerPostAdvanceTick
+    alias:
+    - CLoopModeGame::OnServerPostAdvanceTick
+  - name: CLoopModeGame_OnServerBeginAsyncPostTickWork
+    alias:
+    - CLoopModeGame::OnServerBeginAsyncPostTickWork
+  - name: CLoopModeGame_OnServerEndAsyncPostTickWork
+    alias:
+    - CLoopModeGame::OnServerEndAsyncPostTickWork
+  - name: CLoopModeGame_OnFrameBoundary
+    alias:
+    - CLoopModeGame::OnFrameBoundary
+  - name: CLoopModeGame_ReceivedServerInfo
+    alias:
+    - CLoopModeGame::ReceivedServerInfo
+  - name: CLoopModeGame_SetWorldSession
+    alias:
+    - CLoopModeGame::SetWorldSession
+  - name: CLoopModeGame_SetGameSystemState
+    alias:
+    - CLoopModeGame::SetGameSystemState
+  - name: IGameSystem_DestroyAllGameSystems
+    alias:
+    - IGameSystem::DestroyAllGameSystems
+  - name: IGameSystem_ShutdownAllSystems
+    alias:
+    - IGameSystem::ShutdownAllSystems
+  - name: IGameSystem_LoopDestroyAllSystems
+    alias:
+    - IGameSystem::LoopDestroyAllSystems
+  - name: IGameSystem_LoopPreShutdownAllSystems
+    alias:
+    - IGameSystem::LoopPreShutdownAllSystems
+  - name: CLoopModeGame_Shutdown
+    alias:
+    - CLoopModeGame::Shutdown
+  - name: CLoopModeGame_LoopShutdown
+    alias:
+    - CLoopModeGame::LoopShutdown
+  - name: CLoopModeGame_ShutdownServer
+    alias:
+    - CLoopModeGame::ShutdownServer
+  - name: CLoopModeGame_OnLoopDeactivate
+    alias:
+    - CLoopModeGame::OnLoopDeactivate
+  - name: ILoopMode_OnLoopDeactivate
+    alias:
+    - ILoopMode::OnLoopDeactivate
+  - name: CPlayerCommandQueue_ctor
+    alias:
+    - CPlayerCommandQueue::CPlayerCommandQueue
+  - name: CBasePlayerController_IsFakeClient
+    alias:
+    - CBasePlayerController::IsFakeClient
+    - IsFakeClient
+  - name: INetworkGameServer_GetClientConnectionType
+    alias:
+    - INetworkGameServer::GetClientConnectionType
+  - name: IGameResourceService_SetEntityResourceManifestHandler
+    alias:
+    - IGameResourceService::SetEntityResourceManifestHandler
+  - name: CNetworkSerializerBindingBuildFilter_GetFieldPriority
+    alias:
+    - CNetworkSerializerBindingBuildFilter::GetFieldPriority
+  - name: CEntitySystem_FindComponentTypeByName
+    alias:
+    - CEntitySystem::FindComponentTypeByName
+- name: networksystem
+  symbols:
+  - name: INetworkMessages_GetFieldChangeCallbackOrderCount
+    alias:
+    - INetworkMessages::GetFieldChangeCallbackOrderCount
+  - name: INetworkMessages_GetFieldChangeCallbackPriorities
+    alias:
+    - INetworkMessages::GetFieldChangeCallbackPriorities

--- a/gamesymbols/14176.metadata.yaml
+++ b/gamesymbols/14176.metadata.yaml
@@ -1,0 +1,3797 @@
+modules:
+- name: scenesystem
+  symbols:
+  - name: ISceneSystem_GetWorldsInfo
+    alias:
+    - ISceneSystem::GetWorldsInfo
+  - name: ISceneWorld_GetObjectsInfo
+    alias:
+    - ISceneWorld::GetObjectsInfo
+  - name: ISceneWorld_GetWorldName
+    alias:
+    - ISceneWorld::GetWorldName
+  - name: ISceneSystem_GetObjectBounds
+    alias:
+    - ISceneSystem::GetObjectBounds
+  - name: ISceneSystem_GetObjectClassName
+    alias:
+    - ISceneSystem::GetObjectClassName
+  - name: CSceneObject_pDesc
+    alias:
+    - CSceneObject::pDesc
+  - name: CSceneObject_nFlags
+    alias:
+    - CSceneObject::nFlags
+  - name: CSceneObject_fOriginX
+    alias:
+    - CSceneObject::fOriginX
+  - name: CSceneObject_fOriginY
+    alias:
+    - CSceneObject::fOriginY
+  - name: CSceneObject_fOriginZ
+    alias:
+    - CSceneObject::fOriginZ
+  - name: CSceneObject_nClassIndex
+    alias:
+    - CSceneObject::nClassIndex
+- name: networksystem
+  symbols:
+  - name: CNetworkMessages_RegisterNetworkCategory
+    alias:
+    - CNetworkMessages::RegisterNetworkCategory
+  - name: CNetworkMessages_AssociateNetMessageWithChannelCategoryAbstract
+    alias:
+    - CNetworkMessages::AssociateNetMessageWithChannelCategoryAbstract
+  - name: CNetworkMessages_FindOrCreateNetMessage
+    alias:
+    - CNetworkMessages::FindOrCreateNetMessage
+  - name: CNetworkMessages_SerializeInternal
+    alias:
+    - CNetworkMessages::SerializeInternal
+  - name: CNetworkMessages_UnserializeMessageInternal
+    alias:
+    - CNetworkMessages::UnserializeMessageInternal
+  - name: CNetworkMessages_SerializeMessageInternal
+    alias:
+    - CNetworkMessages::SerializeMessageInternal
+  - name: CNetworkMessages_UnserializeFromStream
+    alias:
+    - CNetworkMessages::UnserializeFromStream
+  - name: CNetworkMessages_AllocateAndCopyConstructNetMessageAbstract
+    alias:
+    - CNetworkMessages::AllocateAndCopyConstructNetMessageAbstract
+  - name: CNetworkMessages_DeallocateNetMessageAbstract
+    alias:
+    - CNetworkMessages::DeallocateNetMessageAbstract
+  - name: CNetworkMessages_RegisterNetworkFieldSerializer
+    alias:
+    - CNetworkMessages::RegisterNetworkFieldSerializer
+  - name: CNetworkMessages_RegisterNetworkArrayFieldSerializer
+    alias:
+    - CNetworkMessages::RegisterNetworkArrayFieldSerializer
+  - name: CNetworkMessages_AssociateNetMessageGroupIdWithChannelCategory
+    alias:
+    - CNetworkMessages::AssociateNetMessageGroupIdWithChannelCategory
+  - name: CNetworkMessages_RegisterNetworkFieldChangeCallbackInternal
+    alias:
+    - CNetworkMessages::RegisterNetworkFieldChangeCallbackInternal
+  - name: CNetworkMessages_AllowAdditionalMessageRegistration
+    alias:
+    - CNetworkMessages::AllowAdditionalMessageRegistration
+  - name: CNetworkMessages_IsAdditionalMessageRegistrationAllowed
+    alias:
+    - CNetworkMessages::IsAdditionalMessageRegistrationAllowed
+  - name: CNetworkMessages_RegisterFieldChangeCallbackPriority
+    alias:
+    - CNetworkMessages::RegisterFieldChangeCallbackPriority
+  - name: CNetworkMessages_ComputeOrderForPriority
+    alias:
+    - CNetworkMessages::ComputeOrderForPriority
+  - name: CNetworkMessages_dtor
+    alias:
+    - CNetworkMessages::~CNetworkMessages
+  - name: CNetworkMessages_GetIsForServer
+    alias:
+    - CNetworkMessages::GetIsForServer
+  - name: CNetworkMessages_GetNetworkSerializationContextData
+    alias:
+    - CNetworkMessages::GetNetworkSerializationContextData
+  - name: CNetChan_ParseMessagesDemoInternal
+    alias:
+    - CNetChan::ParseMessagesDemoInternal
+  - name: CNetChan_ParseNetMessageShowFilter
+    alias:
+    - CNetChan::ParseNetMessageShowFilter
+  - name: CNetworkMessages_FindNetworkMessagePartial
+    alias:
+    - CNetworkMessages::FindNetworkMessagePartial
+  - name: CNetworkMessages_FindNetworkMessage
+    alias:
+    - CNetworkMessages::FindNetworkMessage
+  - name: CNetworkMessages_FindNetworkGroup
+    alias:
+    - CNetworkMessages::FindNetworkGroup
+  - name: CNetworkSystem_InitGameServer
+    alias:
+    - CNetworkSystem::InitGameServer
+  - name: CNetworkSystem_SendNetworkStats
+    alias:
+    - CNetworkSystem::SendNetworkStats
+  - name: CNetworkMessages_GetNetworkGroupCount
+    alias:
+    - CNetworkMessages::GetNetworkGroupCount
+  - name: CNetworkMessages_GetNetworkGroupName
+    alias:
+    - CNetworkMessages::GetNetworkGroupName
+  - name: CNetworkMessages_GetNetworkGroupColor
+    alias:
+    - CNetworkMessages::GetNetworkGroupColor
+  - name: CNetworkMessages_ConfirmAllMessageHandlersInstalled
+    alias:
+    - CNetworkMessages::ConfirmAllMessageHandlersInstalled
+- name: engine
+  symbols:
+  - name: CServerSideClient_ctor
+    alias:
+    - CServerSideClient::CServerSideClient
+  - name: CNetworkGameServer_CreateNewClient
+    alias:
+    - CNetworkGameServer::CreateNewClient
+  - name: CServerSideClient_IsHearingClient
+    alias:
+    - IsHearingClient
+  - name: CServerSideClient_ExecuteStringCommand
+    alias:
+    - CServerSideClient::ExecuteStringCommand
+  - name: CServerSideClient_ActivatePlayer
+    alias:
+    - CServerSideClient::ActivatePlayer
+  - name: ISource2GameClients_ClientSettingsChanged
+    alias:
+    - ISource2GameClients::ClientSettingsChanged
+  - name: CGameResourceService_BuildResourceManifest
+    alias:
+    - CGameResourceService::BuildResourceManifest
+    - BuildResourceManifest
+  - name: CGameResourceService_m_pEntitySystem
+    alias:
+    - GameEntitySystem
+  - name: CGameResourceService_LoadGameResourceManifestNamed
+    alias:
+    - CGameResourceService::LoadGameResourceManifestNamed
+  - name: CGameResourceService_LoadGameResourceManifestGroup
+    alias:
+    - CGameResourceService::LoadGameResourceManifestGroup
+  - name: CGameResourceService_GetResourceManifestDebugName
+    alias:
+    - CGameResourceService::GetResourceManifestDebugName
+  - name: CGameResourceService_PrecacheEntitiesAndConfirmResourcesAreLoaded
+    alias:
+    - CGameResourceService::PrecacheEntitiesAndConfirmResourcesAreLoaded
+  - name: CGameResourceService_LoadGameResourceManifest_IEntityResourceManifest
+    alias:
+    - CGameResourceService::LoadGameResourceManifest
+  - name: CGameResourceService_DescribeContents
+    alias:
+    - CGameResourceService::DescribeContents
+  - name: CGameResourceService_AppendToGameResourceManifest
+    alias:
+    - CGameResourceService::AppendToGameResourceManifest
+  - name: CGameResourceService_RegisterEventMap
+    alias:
+    - CGameResourceService::RegisterEventMap
+  - name: IEntityResourceManifestBuilder_BuildResourceManifest_ManifestNameOrGroupName
+    alias:
+    - IEntityResourceManifestBuilder::BuildResourceManifest
+  - name: CServerSideClientBase_ClientPrintf
+    alias:
+    - CServerSideClientBase::ClientPrintf
+    - ClientPrintf
+  - name: CNetworkGameServer_ClientList
+    alias:
+    - CNetworkGameServer::ClientList
+  - name: CNetworkGameServerBase_SendPeerList
+    alias:
+    - CNetworkGameServerBase::SendPeerList
+  - name: CNetworkGameServerBase_ConnectClient
+    alias:
+    - CNetworkGameServerBase::ConnectClient
+  - name: CNetworkGameServerBase_CheckPassword
+    alias:
+    - CNetworkGameServerBase::CheckPassword
+  - name: CNetworkGameServerBase_GetClientConnectionType
+    alias:
+    - CNetworkGameServerBase::GetClientConnectionType
+  - name: CNetworkGameServerBase_ServerSimulateInternal
+    alias:
+    - CNetworkGameServerBase::ServerSimulateInternal
+  - name: CNetworkGameServerBase_ServerSimulate
+    alias:
+    - CNetworkGameServerBase::ServerSimulate
+  - name: CNetworkGameServerBase_ServerPollNetworking
+    alias:
+    - CNetworkGameServerBase::ServerPollNetworking
+  - name: INetworkGameServer_IsChangelevelPending
+    alias:
+    - INetworkGameServer::IsChangelevelPending
+  - name: CNetworkGameServerBase_IsChangelevelPending
+    alias:
+    - CNetworkGameServerBase::IsChangelevelPending
+  - name: CNetworkGameServerBase_BroadcastMessage
+    alias:
+    - CNetworkGameServerBase::BroadcastMessage
+  - name: CNetworkGameServerBase_BroadcastPrintf
+    alias:
+    - CNetworkGameServerBase::BroadcastPrintf
+  - name: CNetworkGameServerBase_BroadcastEntityVoice
+    alias:
+    - CNetworkGameServerBase::BroadcastEntityVoice
+  - name: CNetworkGameServerBase_WriteDeltaEntities
+    alias:
+    - CNetworkGameServerBase::WriteDeltaEntities
+  - name: CNetworkGameServerBase_ReserveServerForQueuedGame
+    alias:
+    - CNetworkGameServerBase::ReserveServerForQueuedGame
+  - name: CNetworkGameServerBase_FinishChangeLevel
+    alias:
+    - CNetworkGameServerBase::FinishChangeLevel
+  - name: CNetworkGameServerBase_StartChangeLevel
+    alias:
+    - CNetworkGameServerBase::StartChangeLevel
+  - name: CNetworkGameServerBase_SetServerState
+    alias:
+    - CNetworkGameServerBase::SetServerState
+  - name: CNetworkGameServer_GetFreeClient
+    alias:
+    - CNetworkGameServer::GetFreeClient
+    - GetFreeClient
+  - name: CNetworkGameServerBase_CreateFakeClient
+    alias:
+    - CNetworkGameServerBase::CreateFakeClient
+  - name: CNetworkGameServerBase_UserInfoChanged
+    alias:
+    - CNetworkGameServerBase::UserInfoChanged
+  - name: CNetworkGameServerBase_GetPlayerNetworkIDString
+    alias:
+    - CNetworkGameServerBase::GetPlayerNetworkIDString
+  - name: CNetworkGameServerBase_StartHLTVMaster
+    alias:
+    - CNetworkGameServerBase::StartHLTVMaster
+  - name: CNetworkGameServerBase_RegisterLoadingSpawnGroups
+    alias:
+    - CNetworkGameServerBase::RegisterLoadingSpawnGroups
+  - name: CNetworkServerSpawnGroupCreatePrerequisites_Init
+    alias:
+    - CNetworkServerSpawnGroupCreatePrerequisites::Init
+  - name: CNetworkGameServerBase_LoadSpawnGroup
+    alias:
+    - CNetworkGameServerBase::LoadSpawnGroup
+  - name: CNetworkGameServerBase_SpawnGroupThink
+    alias:
+    - CNetworkGameServerBase::SpawnGroupThink
+  - name: CNetworkGameServerBase_PrintSpawnGroupStatus
+    alias:
+    - CNetworkGameServerBase::PrintSpawnGroupStatus
+  - name: CNetworkGameServerBase_AsyncUnloadSpawnGroup
+    alias:
+    - CNetworkGameServerBase::AsyncUnloadSpawnGroup
+  - name: CNetworkGameServerBase_AsyncUnloadSpawnGroupInternal
+    alias:
+    - CNetworkGameServerBase::AsyncUnloadSpawnGroupInternal
+  - name: CNetworkGameServer_PrepareForAssetLoad
+    alias:
+    - CNetworkGameServer::PrepareForAssetLoad
+  - name: CNetworkGameServerBase_IsSaveRestoreAllowed
+    alias:
+    - CNetworkGameServerBase::IsSaveRestoreAllowed
+  - name: CNetworkGameServer_IsPausable
+    alias:
+    - CNetworkGameServer::IsPausable
+  - name: CNetworkGameServerBase_Init
+    alias:
+    - CNetworkGameServerBase::Init
+  - name: CNetworkGameServerBase_Shutdown
+    alias:
+    - CNetworkGameServerBase::Shutdown
+  - name: CNetworkGameServerBase_ShutdownInternal
+    alias:
+    - CNetworkGameServerBase::ShutdownInternal
+  - name: CNetworkGameServer_ActivateServer
+    alias:
+    - CNetworkGameServer::ActivateServer
+  - name: CNetworkGameServer_DirectUpdate
+    alias:
+    - CNetworkGameServer::DirectUpdate
+  - name: CNetworkGameServerBase_ReplyChallenge
+    alias:
+    - CNetworkGameServerBase::ReplyChallenge
+  - name: CNetworkGameServerBase_GetChallengeType
+    alias:
+    - CNetworkGameServerBase::GetChallengeType
+  - name: CNetworkGameServer_Init
+    alias:
+    - CNetworkGameServer::Init
+  - name: CNetworkGameServer_Shutdown
+    alias:
+    - CNetworkGameServer::Shutdown
+  - name: ISource2Server_GetAllServerClasses
+    alias:
+    - ISource2Server::GetAllServerClasses
+  - name: CNetworkGameServer_SpawnServer
+    alias:
+    - CNetworkGameServer::SpawnServer
+  - name: CNetworkGameServerBase_GetMaxClients
+    alias:
+    - CNetworkGameServerBase::GetMaxClients
+  - name: CNetworkGameServerBase_GetClassBaseline
+    alias:
+    - CNetworkGameServerBase::GetClassBaseline
+  - name: CSteam3Server_SendUpdatedServerDetails
+    alias:
+    - CSteam3Server::SendUpdatedServerDetails
+  - name: CNetworkGameServerBase_GetMapName
+    alias:
+    - CNetworkGameServerBase::GetMapName
+  - name: CNetworkGameServerBase_GetHostName
+    alias:
+    - CNetworkGameServerBase::GetHostName
+  - name: CNetworkGameServerBase_SetMaxClients
+    alias:
+    - CNetworkGameServerBase::SetMaxClients
+  - name: CNetworkGameServerBase_FillKV3ServerInfo
+    alias:
+    - CNetworkGameServerBase::FillKV3ServerInfo
+  - name: CNetworkGameServerBase_CheckTimeouts
+    alias:
+    - CNetworkGameServerBase::CheckTimeouts
+  - name: CNetworkGameServerBase_IsHLTV
+    alias:
+    - CNetworkGameServerBase::IsHLTV
+  - name: ISource2Server_ShouldTimeoutClient
+    alias:
+    - ISource2Server::ShouldTimeoutClient
+  - name: CNetworkGameServerBase_GetPassword
+    alias:
+    - CNetworkGameServerBase::GetPassword
+  - name: CNetworkGameServerBase_OnKickById
+    alias:
+    - CNetworkGameServerBase::OnKickById
+  - name: CNetworkGameServerBase_OnKickByName
+    alias:
+    - CNetworkGameServerBase::OnKickByName
+  - name: CNetworkGameClient_SendMovePacket
+    alias:
+    - CNetworkGameClient::SendMovePacket
+    - SendMovePacket
+  - name: CNetworkGameClient_SendMove
+    alias:
+    - CNetworkGameClient::SendMove
+    - SendMove
+  - name: INetworkMessages_Serialize
+    alias:
+    - INetworkMessages::Serialize
+  - name: CDemoPlayer_SkipToTick
+    alias:
+    - CDemoPlayer::SkipToTick
+  - name: CDemoPlayer_PlayDemo
+    alias:
+    - CDemoPlayer::PlayDemo
+  - name: CDemoPlayer_StopPlayback
+    alias:
+    - CDemoPlayer::StopPlayback
+  - name: CDemoPlayer_StartPlayback
+    alias:
+    - CDemoPlayer::StartPlayback
+  - name: CDemoPlayer_SetIgnorePacketsForResourceLoading
+    alias:
+    - CDemoPlayer::SetIgnorePacketsForResourceLoading
+  - name: CDemoPlayer_InternalReadPacket
+    alias:
+    - CDemoPlayer::InternalReadPacket
+  - name: CDemoPlayer_Pause
+    alias:
+    - CDemoPlayer::Pause
+  - name: CDemoPlayer_m_bIsPlaying
+    alias:
+    - CDemoPlayer::m_bIsPlaying
+  - name: CDemoPlayer_m_bIsPaused
+    alias:
+    - CDemoPlayer::m_bIsPaused
+  - name: CDemoRecorder_ParseMessage
+    alias:
+    - CDemoRecorder::ParseMessage
+  - name: CDemoRecorder_WriteSpawnGroups
+    alias:
+    - CDemoRecorder::WriteSpawnGroups
+  - name: CHLTVDemoRecorder_WriteFrameImmediate
+    alias:
+    - CHLTVDemoRecorder::WriteFrameImmediate
+  - name: INetworkMessages_SerializeAbstract
+    alias:
+    - INetworkMessages::SerializeAbstract
+  - name: INetworkMessages_GetNetMessageInfo
+    alias:
+    - INetworkMessages::GetNetMessageInfo
+  - name: INetworkMessages_FindNetworkMessageById
+    alias:
+    - INetworkMessages::FindNetworkMessageById
+  - name: CNetChan_ProcessMessages
+    alias:
+    - CNetChan::ProcessMessages
+  - name: CNetChan_ParseMessagesDemo
+    alias:
+    - CNetChan::ParseMessagesDemo
+  - name: CNetworkGameClient_ProcessPacketEntitiesInternal
+    alias:
+    - CNetworkGameClient::ProcessPacketEntitiesInternal
+  - name: CNetworkGameClient_ProcessPacketEntities
+    alias:
+    - CNetworkGameClient::ProcessPacketEntities
+    - ProcessPacketEntities
+  - name: CNetworkGameClient_RecordEntityBandwidth
+    alias:
+    - CNetworkGameClient::RecordEntityBandwidth
+    - RecordEntityBandwidth
+  - name: CNetworkGameClient_PrintNetStats
+    alias:
+    - CNetworkGameClient::PrintNetStats
+  - name: CMsgSource2NetworkFlowQuality_PrintStats
+    alias:
+    - CMsgSource2NetworkFlowQuality::PrintStats
+  - name: CNetworkGameClientBase__ProcessNetworking
+    alias:
+    - CNetworkGameClientBase::ProcessNetworking
+  - name: CNetworkGameClient_CreateMove
+    alias:
+    - CNetworkGameClient::CreateMove
+  - name: ISource2Client_CreateMove
+    alias:
+    - ISource2Client::CreateMove
+  - name: CNetworkGameClient_SetSignonState
+    alias:
+    - CNetworkGameClient::SetSignonState
+  - name: CNetworkGameClient_ProcessReadPacketEntitiesWorkItems
+    alias:
+    - CNetworkGameClient::ProcessReadPacketEntitiesWorkItems
+  - name: CNetworkGameClient_OnPreserveEntity
+    alias:
+    - CNetworkGameClient::OnPreserveEntity
+  - name: CNetworkGameClient_GetClientNetworkable
+    alias:
+    - CNetworkGameClient::GetClientNetworkable
+  - name: CNetworkGameClient_CopyNewEntity
+    alias:
+    - CNetworkGameClient::CopyNewEntity
+  - name: CNetworkGameClient_CopyExistingEntity
+    alias:
+    - CNetworkGameClient::CopyExistingEntity
+  - name: CNetworkGameClient_OnReceivedUncompressedPacket
+    alias:
+    - CNetworkGameClient::OnReceivedUncompressedPacket
+  - name: CNetworkGameClient_Clear
+    alias:
+    - CNetworkGameClient::Clear
+  - name: CNetworkGameClient_DisconnectGame
+    alias:
+    - CNetworkGameClient::DisconnectGame
+  - name: INetworkMessages_FindNetworkGroup
+    alias:
+    - INetworkMessages::FindNetworkGroup
+  - name: INetworkClientService_IsActive
+    alias:
+    - INetworkClientService::IsActive
+  - name: INetworkClientService_IsConnected
+    alias:
+    - INetworkClientService::IsConnected
+  - name: INetworkClientService_IsPutInServer
+    alias:
+    - INetworkClientService::IsPutInServer
+  - name: INetworkClientService_IsConnecting
+    alias:
+    - INetworkClientService::IsConnecting
+  - name: CInputService_ProcessConVar
+    alias:
+    - CInputService::ProcessConVar
+  - name: CInputService_ProcessCommand
+    alias:
+    - CInputService::ProcessCommand
+  - name: CInputService_IsClientOnlyCommandAllowed
+    alias:
+    - CInputService::IsClientOnlyCommandAllowed
+  - name: CServerSideClientBase_SetConVarUserInfo
+    alias:
+    - CServerSideClientBase::SetConVarUserInfo
+  - name: CNetworkClientService_RegisterEventMapInternal
+    alias:
+    - CNetworkClientService::RegisterEventMapInternal
+  - name: CNetworkClientService_RegisterEventMap
+    alias:
+    - CNetworkClientService::RegisterEventMap
+  - name: CNetworkClientService_OnClientAdvanceTick
+    alias:
+    - CNetworkClientService::OnClientAdvanceTick
+  - name: CNetworkClientService_OnClientProcessGameInput
+    alias:
+    - CNetworkClientService::OnClientProcessGameInput
+  - name: ISource2Client_ProcessGameInput
+    alias:
+    - ISource2Client::ProcessGameInput
+  - name: CNetworkClientService_OnClientPollNetworking
+    alias:
+    - CNetworkClientService::OnClientPollNetworking
+  - name: CNetworkClientService_OnClientProcessNetworking
+    alias:
+    - CNetworkClientService::OnClientProcessNetworking
+  - name: CNetworkClientService_OnClientSimulate
+    alias:
+    - CNetworkClientService::OnClientSimulate
+  - name: CNetworkClientService_OnClientPauseSimulate
+    alias:
+    - CNetworkClientService::OnClientPauseSimulate
+  - name: CNetworkClientService_OnClientFrameSimulate
+    alias:
+    - CNetworkClientService::OnClientFrameSimulate
+  - name: CNetworkClientService_OnSimpleLoopFrameUpdate
+    alias:
+    - CNetworkClientService::OnSimpleLoopFrameUpdate
+  - name: CNetworkClientService_OnFrameBoundary
+    alias:
+    - CNetworkClientService::OnFrameBoundary
+  - name: CNetworkClientService_OnServerPostSimulate
+    alias:
+    - CNetworkClientService::OnServerPostSimulate
+  - name: CNetworkClientService_OnServerBeginAsyncPostTickWork
+    alias:
+    - CNetworkClientService::OnServerBeginAsyncPostTickWork
+  - name: CNetworkClientService_ReceivedServerInfo
+    alias:
+    - CNetworkClientService::ReceivedServerInfo
+  - name: CNetworkClientService_SplitScreenConnect
+    alias:
+    - CNetworkClientService::SplitScreenConnect
+  - name: CNetworkClientService_SendNetMessage
+    alias:
+    - CNetworkClientService::SendNetMessage
+  - name: CNetworkClientService_SendStringCmd
+    alias:
+    - CNetworkClientService::SendStringCmd
+  - name: CNetworkClientService_StartChangeLevel
+    alias:
+    - CNetworkClientService::StartChangeLevel
+  - name: CNetworkClientService_FinishChangeLevel
+    alias:
+    - CNetworkClientService::FinishChangeLevel
+  - name: CNetworkClientService_PrintConnectionStatus
+    alias:
+    - CNetworkClientService::PrintConnectionStatus
+  - name: CNetworkClientService_OnStatus
+    alias:
+    - CNetworkClientService::OnStatus
+  - name: CNetworkClientService_ServerCmd
+    alias:
+    - CNetworkClientService::ServerCmd
+  - name: CNetworkClientService_GetDisconnectReason
+    alias:
+    - CNetworkClientService::GetDisconnectReason
+  - name: CNetworkClientService_PrintSpawnGroupStatus
+    alias:
+    - CNetworkClientService::PrintSpawnGroupStatus
+  - name: CNetworkClientService_IsActive
+    alias:
+    - CNetworkClientService::IsActive
+  - name: CNetworkClientService_IsConnected
+    alias:
+    - CNetworkClientService::IsConnected
+  - name: CNetworkClientService_IsPutInServer
+    alias:
+    - CNetworkClientService::IsPutInServer
+  - name: CNetworkClientService_IsConnecting
+    alias:
+    - CNetworkClientService::IsConnecting
+  - name: CEngineSoundServices_ShouldSuppressNonUISounds
+    alias:
+    - CEngineSoundServices::ShouldSuppressNonUISounds
+  - name: CNetworkClientService_ClockDriftAdjustFrameTime
+    alias:
+    - CNetworkClientService::ClockDriftAdjustFrameTime
+  - name: CNetworkClientService_Init
+    alias:
+    - CNetworkClientService::Init
+  - name: CNetworkClientService_Shutdown
+    alias:
+    - CNetworkClientService::Shutdown
+  - name: CNetworkClientService_DisconnectGameNow
+    alias:
+    - CNetworkClientService::DisconnectGameNow
+  - name: CGameClientConnectPrerequisite_ctor
+    alias:
+    - CGameClientConnectPrerequisite::CGameClientConnectPrerequisite
+  - name: CNetworkClientSpawnGroupCreatePrerequisites_GetStatus
+    alias:
+    - CNetworkClientSpawnGroupCreatePrerequisites::GetStatus
+  - name: CWaitForInitialSpawnGroupsPrerequisite_GetStatus
+    alias:
+    - CWaitForInitialSpawnGroupsPrerequisite::GetStatus
+  - name: INetworkGameServer_GetSpawnGroupLoadingStatus
+    alias:
+    - INetworkGameServer::GetSpawnGroupLoadingStatus
+  - name: CNetworkClientService_AddClientPrerequisites
+    alias:
+    - CNetworkClientService::AddClientPrerequisites
+  - name: CNetworkClientService_AllocateRemoteConnectionClient
+    alias:
+    - CNetworkClientService::AllocateRemoteConnectionClient
+  - name: CNetworkGameServer_WriteClassInfosAndSerializesToBuffer
+    alias:
+    - CNetworkGameServer::WriteClassInfosAndSerializesToBuffer
+  - name: INetworkServerService_GetServerSerializersCRC
+    alias:
+    - INetworkServerService::GetServerSerializersCRC
+  - name: CNetworkServerService_GetServerSerializersCRC
+    alias:
+    - CNetworkServerService::GetServerSerializersCRC
+  - name: CSteam3ServerS1_InitGameServer
+    alias:
+    - CSteam3ServerS1::InitGameServer
+  - name: INetworkServerService_IsActiveInGame
+    alias:
+    - INetworkServerService::IsActiveInGame
+  - name: INetworkServerService_IsServerRunning
+    alias:
+    - INetworkServerService::IsServerRunning
+  - name: CNetworkServerService_SetGameSpawnGroupMgr
+    alias:
+    - CNetworkServerService::SetGameSpawnGroupMgr
+  - name: CNetworkServerService_AddServerPrerequisites
+    alias:
+    - CNetworkServerService::AddServerPrerequisites
+  - name: CNetworkServerService_SetFinalSimulationTickThisFrame
+    alias:
+    - CNetworkServerService::SetFinalSimulationTickThisFrame
+  - name: CNetworkServerService_Init
+    alias:
+    - CNetworkServerService::Init
+  - name: CNetworkServerService_StartupServer
+    alias:
+    - CNetworkServerService::StartupServer
+  - name: CNetworkServerService_RegisterEventMapInternal
+    alias:
+    - CNetworkServerService::RegisterEventMapInternal
+  - name: CNetworkServerService_OnServerAdvanceTick
+    alias:
+    - CNetworkServerService::OnServerAdvanceTick
+  - name: CNetworkServerService_OnServerPollNetworking
+    alias:
+    - CNetworkServerService::OnServerPollNetworking
+  - name: CNetworkServerService_OnServerProcessNetworking
+    alias:
+    - CNetworkServerService::OnServerProcessNetworking
+  - name: CNetworkServerService_OnServerBeginSimulate
+    alias:
+    - CNetworkServerService::OnServerBeginSimulate
+  - name: CNetworkServerService_OnServerEndSimulate
+    alias:
+    - CNetworkServerService::OnServerEndSimulate
+  - name: CNetworkServerService_OnServerPostSimulate
+    alias:
+    - CNetworkServerService::OnServerPostSimulate
+  - name: CNetworkServerService_OnServerPostAdvanceTick
+    alias:
+    - CNetworkServerService::OnServerPostAdvanceTick
+  - name: CNetworkServerService_OnFrameBoundary
+    alias:
+    - CNetworkServerService::OnFrameBoundary
+  - name: CNetworkServerService_OnClientPollNetworking
+    alias:
+    - CNetworkServerService::OnClientPollNetworking
+  - name: CNetworkServerService_OnSimpleLoopFrameUpdate
+    alias:
+    - CNetworkServerService::OnSimpleLoopFrameUpdate
+  - name: CNetworkServerService_OnKickByIdHLTV
+    alias:
+    - CNetworkServerService::OnKickByIdHLTV
+  - name: CNetworkServerService_DisconnectGameNow
+    alias:
+    - CNetworkServerService::DisconnectGameNow
+  - name: INetworkGameServer_GetMaxClients
+    alias:
+    - INetworkGameServer::GetMaxClients
+  - name: INetworkGameServer_PreWorldUpdate
+    alias:
+    - INetworkGameServer::PreWorldUpdate
+  - name: CNetworkGameServer_PreWorldUpdate
+    alias:
+    - CNetworkGameServer::PreWorldUpdate
+  - name: INetworkGameServer_ServerEndSimulate
+    alias:
+    - INetworkGameServer::ServerEndSimulate
+  - name: CNetworkGameServerBase_ServerEndSimulate
+    alias:
+    - CNetworkGameServerBase::ServerEndSimulate
+  - name: CNetworkGameServerBase_CalculateCPUUsage
+    alias:
+    - CNetworkGameServerBase::CalculateCPUUsage
+  - name: INetworkGameServer_ServerPostSimulate
+    alias:
+    - INetworkGameServer::ServerPostSimulate
+  - name: CNetworkGameServerBase_ServerPostSimulate
+    alias:
+    - CNetworkGameServerBase::ServerPostSimulate
+  - name: CNetworkGameServer_ServerPostSimulate
+    alias:
+    - CNetworkGameServer::ServerPostSimulate
+  - name: INetworkGameServer_ServerAdvanceTick
+    alias:
+    - INetworkGameServer::ServerAdvanceTick
+  - name: CNetworkGameServerBase_ServerAdvanceTick
+    alias:
+    - CNetworkGameServerBase::ServerAdvanceTick
+  - name: INetworkGameServer_GetTime
+    alias:
+    - INetworkGameServer::GetTime
+  - name: INetworkGameServer_ServerProcessNetworking
+    alias:
+    - INetworkGameServer::ServerProcessNetworking
+  - name: CNetworkGameServerBase_ServerProcessNetworking
+    alias:
+    - CNetworkGameServerBase::ServerProcessNetworking
+  - name: INetworkGameServer_GetTimescale
+    alias:
+    - INetworkGameServer::GetTimescale
+  - name: CNetworkGameServerBase_GetTimescale
+    alias:
+    - CNetworkGameServerBase::GetTimescale
+  - name: INetworkGameServer_GetServerNetworkAddress
+    alias:
+    - INetworkGameServer::GetServerNetworkAddress
+  - name: ISource2Server_PreWorldUpdate
+    alias:
+    - ISource2Server::PreWorldUpdate
+  - name: ISource2Server_UpdateWhenNotInGame
+    alias:
+    - ISource2Server::UpdateWhenNotInGame
+  - name: INetworkMessages_SetIsForServer
+    alias:
+    - INetworkMessages::SetIsForServer
+  - name: CRenderingWorldSession_FindOrCreateWorldSession
+    alias:
+    - CRenderingWorldSession::FindOrCreateWorldSession
+  - name: CRenderingWorldSession_GetEntityLumpForTemplate
+    alias:
+    - CRenderingWorldSession::GetEntityLumpForTemplate
+  - name: CEngineClient_GetEntityLumpForTemplate
+    alias:
+    - CEngineClient::GetEntityLumpForTemplate
+  - name: CEngineClient_FindOrCreateWorldSession
+    alias:
+    - CEngineClient::FindOrCreateWorldSession
+  - name: CEngineClient_GetStatsAppID
+    alias:
+    - CEngineClient::GetStatsAppID
+  - name: CEngineClient_DumpNetStats
+    alias:
+    - CEngineClient::DumpNetStats
+  - name: CEngineClient_ExecuteClientCmd
+    alias:
+    - CEngineClient::ExecuteClientCmd
+  - name: CEngineClient_IsPlayingDemo
+    alias:
+    - CEngineClient::IsPlayingDemo
+  - name: CInputService_ProcessCommandBuffer
+    alias:
+    - CInputService::ProcessCommandBuffer
+  - name: CInputService_ProcessCommandBuffers
+    alias:
+    - CInputService::ProcessCommandBuffers
+  - name: CInputService_HandleAnalogValueChange
+    alias:
+    - CInputService::HandleAnalogValueChange
+  - name: CInputService_HandleInputEvent
+    alias:
+    - CInputService::HandleInputEvent
+  - name: CEngineClient_ClientCmd_Unrestricted
+    alias:
+    - CEngineClient::ClientCmd_Unrestricted
+  - name: INetworkGameClient_SendStringCmd
+    alias:
+    - INetworkGameClient::SendStringCmd
+  - name: CEngineServer_DumpNetStats
+    alias:
+    - CEngineServer::DumpNetStats
+  - name: CEngineServer_ClientPrintf
+    alias:
+    - CEngineServer::ClientPrintf
+  - name: CEngineServer_GetFrameTimeAmnesty
+    alias:
+    - CEngineServer::GetFrameTimeAmnesty
+  - name: CEngineServer_ShowFrameTimeReport
+    alias:
+    - CEngineServer::ShowFrameTimeReport
+  - name: CEngineServer_SetFrameTimeAmnesty
+    alias:
+    - CEngineServer::SetFrameTimeAmnesty
+  - name: CEngineServer_GetSteamUniverse
+    alias:
+    - CEngineServer::GetSteamUniverse
+  - name: CEngineServer_ChangeLevel
+    alias:
+    - CEngineServer::ChangeLevel
+  - name: CMapListService_IsMapValid
+    alias:
+    - CMapListService::IsMapValid
+    - IMapListService::IsMapValid
+  - name: CEngineServer_IsMapValid
+    alias:
+    - CEngineServer::IsMapValid
+  - name: CEngineServer_PrecacheGeneric
+    alias:
+    - CEngineServer::PrecacheGeneric
+  - name: CEngineServer_ClientCommand
+    alias:
+    - CEngineServer::ClientCommand
+  - name: CEngineServer_GetClientConVarValue
+    alias:
+    - CEngineServer::GetClientConVarValue
+  - name: CEngineServer_SetFakeClientConVarValue
+    alias:
+    - CEngineServer::SetFakeClientConVarValue
+  - name: CEngineServer_CreateFakeClient
+    alias:
+    - CEngineServer::CreateFakeClient
+  - name: CEngineServer_GetPlayerInfo
+    alias:
+    - CEngineServer::GetPlayerInfo
+  - name: CEngineServer_ClientCommandKeyValues
+    alias:
+    - CEngineServer::ClientCommandKeyValues
+  - name: CLog_Print
+    alias:
+    - CLog::Print
+  - name: CEngineServer_LogPrint
+    alias:
+    - CEngineServer::LogPrint
+  - name: CEngineServer_KickClient
+    alias:
+    - CEngineServer::KickClient
+  - name: CEngineServer_IsDedicatedServer
+    alias:
+    - CEngineServer::IsDedicatedServer
+  - name: CEngineServer_GetServerGlobals
+    alias:
+    - CEngineServer::GetServerGlobals
+  - name: CEngineServer_GetAchievementMgr
+    alias:
+    - CEngineServer::GetAchievementMgr
+  - name: CEngineServer_IsLogEnabled
+    alias:
+    - CEngineServer::IsLogEnabled
+  - name: CEngineServer_ServerCommand
+    alias:
+    - CEngineServer::ServerCommand
+  - name: CLoopTypeClientSimple_ActivateEngineServices
+    alias:
+    - CLoopTypeClientServer::ActivateEngineServices
+  - name: CLoopTypeClientServer_LoopTypeInit
+    alias:
+    - CLoopTypeClientServer::LoopTypeInit
+  - name: CLoopTypeClientServer_AdvanceTime
+    alias:
+    - CLoopTypeClientServer::AdvanceTime
+  - name: CLoopTypeClientServer_Update
+    alias:
+    - CLoopTypeClientServer::Update
+  - name: CLoopTypeClientServer_ActivateLoop
+    alias:
+    - CLoopTypeClientServer::ActivateLoop
+  - name: ISource2Server_GetActiveWorldName
+    alias:
+    - ISource2Server::GetActiveWorldName
+  - name: CLoopTypeClientServer_AllocateLoopMode
+    alias:
+    - CLoopTypeClientServer::AllocateLoopMode
+  - name: CLoopTypeClientServer_WritePerfStats
+    alias:
+    - CLoopTypeClientServer::WritePerfStats
+  - name: CLoopTypeClientServer_DeactivateLoop
+    alias:
+    - CLoopTypeClientServer::DeactivateLoop
+  - name: CLoopTypeClientServer_OutputListeners
+    alias:
+    - CLoopTypeClientServer::OutputListeners
+  - name: CLoopTypeSimple_FrameUpdate
+    alias:
+    - CLoopTypeSimple::FrameUpdate
+  - name: CLoopTypeClientServerService_OnLoopActivate
+    alias:
+    - CLoopTypeClientServerService::OnLoopActivate
+  - name: CLoopTypeSimpleService_OnLoopActivate
+    alias:
+    - CLoopTypeSimpleService::OnLoopActivate
+  - name: CLoopTypeClientServerService_HandleInputEvent
+    alias:
+    - CLoopTypeClientServerService::HandleInputEvent
+  - name: ILoopMode_HandleInputEvent
+    alias:
+    - ILoopMode::HandleInputEvent
+  - name: ILoopType_AddEngineService
+    alias:
+    - ILoopType::AddEngineService
+  - name: CLoopTypeBase_DeallocateLoopMode
+    alias:
+    - CLoopTypeBase::DeallocateLoopMode
+  - name: CLoopTypeBase_EngineLoop
+    alias:
+    - CLoopTypeBase::EngineLoop
+  - name: CLoopTypeBase_FrameUpdate
+    alias:
+    - CLoopTypeBase::FrameUpdate
+  - name: CLoopTypeBase_ActivateLoop
+    alias:
+    - CLoopTypeBase::ActivateLoop
+  - name: CLoopTypeBase_AllocateLoopMode
+    alias:
+    - CLoopTypeBase::AllocateLoopMode
+  - name: CLoopTypeBase_DeactivateLoop
+    alias:
+    - CLoopTypeBase::DeactivateLoop
+  - name: CLoopTypeBase_LoopTypeInit
+    alias:
+    - CLoopTypeBase::LoopTypeInit
+  - name: CLoopTypeBase_LoopTypeShutdown
+    alias:
+    - CLoopTypeBase::LoopTypeShutdown
+  - name: CLoopTypeBase_GetClientServerMode
+    alias:
+    - CLoopTypeBase::GetClientServerMode
+  - name: CLoopTypeBase_GetImplType
+    alias:
+    - CLoopTypeBase::GetImplType
+  - name: CLoopTypeBase_AddDependentServices
+    alias:
+    - CLoopTypeBase::AddDependentServices
+  - name: CLoopTypeBase_GenerateServiceDependencies
+    alias:
+    - CLoopTypeBase::GenerateServiceDependencies
+  - name: CLoopTypeBase_GenerateSecondaryDependencies
+    alias:
+    - CLoopTypeBase::GenerateSecondaryDependencies
+  - name: CLoopTypeBase_LoadDependentServices
+    alias:
+    - CLoopTypeBase::LoadDependentServices
+  - name: IEngineService_GetServiceDependencies
+    alias:
+    - IEngineService::GetServiceDependencies
+  - name: IEngineService_GetName
+    alias:
+    - IEngineService::GetName
+  - name: ILoopModeFactory_GetLoopModeType
+    alias:
+    - ILoopModeFactory::GetLoopModeType
+  - name: ILoopModeFactory_Shutdown
+    alias:
+    - ILoopModeFactory::Shutdown
+  - name: CEngineServiceMgr_RegisterEngineService
+    alias:
+    - CEngineServiceMgr::RegisterEngineService
+  - name: CEngineServiceMgr_RegisterLoopMode
+    alias:
+    - CEngineServiceMgr::RegisterLoopMode
+  - name: CEngineServiceMgr_UnregisterLoopMode
+    alias:
+    - CEngineServiceMgr::UnregisterLoopMode
+  - name: CEngineServiceMgr_UnregisterEngineService
+    alias:
+    - CEngineServiceMgr::UnregisterEngineService
+  - name: CEngineServiceMgr_SwitchToLoop
+    alias:
+    - CEngineServiceMgr::SwitchToLoop
+  - name: CEngineServiceMgr_PrintStatus
+    alias:
+    - CEngineServiceMgr::PrintStatus
+  - name: CEngineServiceMgr__MainLoop
+    alias:
+    - CEngineServiceMgr::_MainLoop
+  - name: CEngineServiceMgr_DeactivateLoop
+    alias:
+    - CEngineServiceMgr::DeactivateLoop
+  - name: CEngineServiceMgr_Shutdown
+    alias:
+    - CEngineServiceMgr::Shutdown
+  - name: CEngineServiceMgr_GetActiveLoopClientServerMode
+    alias:
+    - CEngineServiceMgr::GetActiveLoopClientServerMode
+  - name: CEngineServiceMgr_GetEventDispatcher
+    alias:
+    - CEngineServiceMgr::GetEventDispatcher
+  - name: CEngineGameUI_Shutdown
+    alias:
+    - CEngineGameUI::Shutdown
+  - name: IAppSystem_Shutdown
+    alias:
+    - IAppSystem::Shutdown
+  - name: CSplitScreenService_AddSplitScreenUser
+    alias:
+    - CSplitScreenService::AddSplitScreenUser
+  - name: CSplitScreenService_LoadUserConfiguration
+    alias:
+    - CSplitScreenService::LoadUserConfiguration
+  - name: CHLTVClient_ProcessSetConVar
+    alias:
+    - CHLTVClient::ProcessSetConVar
+  - name: CHLTVBroadcast_RecordSnapshot
+    alias:
+    - CHLTVBroadcast::RecordSnapshot
+  - name: CServerSideClientBase_SendServerInfo
+    alias:
+    - CServerSideClientBase::SendServerInfo
+  - name: CNetworkGameServerBase_FillServerInfo
+    alias:
+    - CNetworkGameServerBase::FillServerInfo
+  - name: CServerSideClientBase_ProcessTick
+    alias:
+    - CServerSideClientBase::ProcessTick
+  - name: CServerSideClientBase_ProcessStringCmd
+    alias:
+    - CServerSideClientBase::ProcessStringCmd
+  - name: CServerSideClientBase_MarkSpawnGroupLoadCompleted
+    alias:
+    - CServerSideClientBase::MarkSpawnGroupLoadCompleted
+  - name: CServerSideClientBase_ProcessSpawnGroup_LoadCompleted
+    alias:
+    - CServerSideClientBase::ProcessSpawnGroup_LoadCompleted
+  - name: CServerSideClientBase_ProcessClientInfo
+    alias:
+    - CServerSideClientBase::ProcessClientInfo
+  - name: CServerSideClientBase_ProcessBaselineAck
+    alias:
+    - CServerSideClientBase::ProcessBaselineAck
+  - name: CServerSideClientBase_ProcessSplitPlayerConnectInternal
+    alias:
+    - CServerSideClientBase::ProcessSplitPlayerConnectInternal
+  - name: CServerSideClientBase_ProcessSplitPlayerConnect
+    alias:
+    - CServerSideClientBase::ProcessSplitPlayerConnect
+  - name: CServerSideClientBase_GetUserIDString
+    alias:
+    - CServerSideClientBase::GetUserIDString
+  - name: CServerSideClientBase_GetNetworkIDString
+    alias:
+    - CServerSideClientBase::GetNetworkIDString
+  - name: CServerSideClientBase_dtor
+    alias:
+    - CServerSideClientBase::~CServerSideClientBase
+  - name: CServerSideClientBase_Connect
+    alias:
+    - CServerSideClientBase::Connect
+  - name: CServerSideClientBase_GetPlayerInfo
+    alias:
+    - CServerSideClientBase::GetPlayerInfo
+  - name: CNetworkGameServer_GetPlayerNetworkIDString
+    alias:
+    - CNetworkGameServer::GetPlayerNetworkIDString
+  - name: CNetworkGameServer_RemoveClientFromGame
+    alias:
+    - CNetworkGameServer::RemoveClientFromGame
+  - name: CEngineServer_GetPlayerNetworkIDString
+    alias:
+    - CEngineServer::GetPlayerNetworkIDString
+  - name: CNetworkGameClientBase_ServerCmd
+    alias:
+    - CNetworkGameClientBase::ServerCmd
+  - name: CNetworkGameClientBase_ProcessSetConVar
+    alias:
+    - CNetworkGameClientBase::ProcessSetConVar
+  - name: CNetworkGameClientBase_SendStringCmd
+    alias:
+    - CNetworkGameClientBase::SendStringCmd
+  - name: CNetworkGameClientBase_StartChangeLevel
+    alias:
+    - CNetworkGameClientBase::StartChangeLevel
+  - name: CNetworkGameClientBase_FinishChangeLevel
+    alias:
+    - CNetworkGameClientBase::FinishChangeLevel
+  - name: CNetworkGameClientBase_DeferActivate
+    alias:
+    - CNetworkGameClientBase::DeferActivate
+  - name: CNetworkGameClientBase_ClockDrift_AdjustFrameTime
+    alias:
+    - CNetworkGameClientBase::ClockDrift_AdjustFrameTime
+  - name: CNetworkGameClientBase_Connect
+    alias:
+    - CNetworkGameClientBase::Connect
+  - name: CNetworkGameClientBase_DisconnectGame
+    alias:
+    - CNetworkGameClientBase::DisconnectGame
+  - name: CNetSupportImpl_Connect
+    alias:
+    - CNetSupportImpl::Connect
+- name: client
+  symbols:
+  - name: CLoopModeGame_RegisterEventMapInternal
+    alias:
+    - CLoopModeGame::RegisterEventMapInternal
+  - name: CLoopModeGame_OnClientPollNetworking
+    alias:
+    - CLoopModeGame::OnClientPollNetworking
+  - name: CLoopModeGame_OnClientAdvanceTick
+    alias:
+    - CLoopModeGame::OnClientAdvanceTick
+  - name: CLoopModeGame_OnClientPostAdvanceTick
+    alias:
+    - CLoopModeGame::OnClientPostAdvanceTick
+  - name: CLoopModeGame_OnClientPreSimulate
+    alias:
+    - CLoopModeGame::OnClientPreSimulate
+  - name: CLoopModeGame_OnClientPreOutput
+    alias:
+    - CLoopModeGame::OnClientPreOutput
+  - name: CLoopModeGame_OnClientPreOutputParallelWithServer
+    alias:
+    - CLoopModeGame::OnClientPreOutputParallelWithServer
+  - name: CLoopModeGame_OnClientPostOutput
+    alias:
+    - CLoopModeGame::OnClientPostOutput
+  - name: CLoopModeGame_OnClientFrameSimulate
+    alias:
+    - CLoopModeGame::OnClientFrameSimulate
+  - name: CLoopModeGame_OnClientAdvanceNonRenderedFrame
+    alias:
+    - CLoopModeGame::OnClientAdvanceNonRenderedFrame
+  - name: CLoopModeGame_OnClientPostSimulate
+    alias:
+    - CLoopModeGame::OnClientPostSimulate
+  - name: CLoopModeGame_OnClientPauseSimulate
+    alias:
+    - CLoopModeGame::OnClientPauseSimulate
+  - name: CLoopModeGame_OnClientSimulate
+    alias:
+    - CLoopModeGame::OnClientSimulate
+  - name: CLoopModeGame_OnPostDataUpdate
+    alias:
+    - CLoopModeGame::OnPostDataUpdate
+  - name: CLoopModeGame_OnPreDataUpdate
+    alias:
+    - CLoopModeGame::OnPreDataUpdate
+  - name: CLoopModeGame_OnFrameBoundary
+    alias:
+    - CLoopModeGame::OnFrameBoundary
+  - name: CLoopModeGame_StaticInit
+    alias:
+    - CLoopModeGame::StaticInit
+  - name: CLoopModeFactory_CLoopModeGame_Init
+    alias:
+    - CLoopModeFactory<CLoopModeGame>::Init
+  - name: CLoopModeFactory_CLoopModeGame_Shutdown
+    alias:
+    - CLoopModeFactory<CLoopModeGame>::Shutdown
+  - name: CLoopModeGame_OnLoopActivate
+    alias:
+    - CLoopModeGame::OnLoopActivate
+  - name: ILoopMode_OnLoopActivate
+    alias:
+    - ILoopMode::OnLoopActivate
+  - name: CLoopModeGame_AddViewsToSceneSystem
+    alias:
+    - CLoopModeGame::AddViewsToSceneSystem
+  - name: ILoopMode_AddViewsToSceneSystem
+    alias:
+    - ILoopMode::AddViewsToSceneSystem
+  - name: CLoopModeGame_LoopInitInternal
+    alias:
+    - CLoopModeGame::LoopInitInternal
+  - name: CLoopModeGame_LoopInit
+    alias:
+    - CLoopModeGame::LoopInit
+  - name: ILoopMode_LoopInit
+    alias:
+    - ILoopMode::LoopInit
+  - name: ILoopMode_LoopShutdown
+    alias:
+    - ILoopMode::LoopShutdown
+  - name: CLoopModeGame_ReceivedServerInfo
+    alias:
+    - CLoopModeGame::ReceivedServerInfo
+  - name: CLoopModeGame_RegisterEventMap
+    alias:
+    - CLoopModeGame::RegisterEventMap
+  - name: ILoopMode_RegisterEventMap
+    alias:
+    - ILoopMode::RegisterEventMap
+  - name: CLoopModeGame_SetWorldSession
+    alias:
+    - CLoopModeGame::SetWorldSession
+  - name: CLoopModeGame_SetGameSystemState
+    alias:
+    - CLoopModeGame::SetGameSystemState
+  - name: CLoopModeGame_LoopShutdown
+    alias:
+    - CLoopModeGame::LoopShutdown
+  - name: IGameSystem_AddByName
+    alias:
+    - IGameSystem::AddByName
+  - name: IGameSystem_Add
+    alias:
+    - IGameSystem::Add
+  - name: IGameSystem_PostInit
+    alias:
+    - IGameSystem::PostInit
+  - name: IGameSystem_InitAllSystems
+    alias:
+    - IGameSystem::InitAllSystems
+  - name: IGameSystem_LoopInitAllSystems
+    alias:
+    - IGameSystem::LoopInitAllSystems
+  - name: IGameSystemFactory_PostInit
+    alias:
+    - IGameSystemFactory::PostInit
+  - name: IGameSystemFactory_GetStaticGameSystem
+    alias:
+    - IGameSystemFactory::GetStaticGameSystem
+  - name: IGameSystemFactory_ShouldAutoAdd
+    alias:
+    - IGameSystemFactory::ShouldAutoAdd
+  - name: IGameSystemFactory_CreateGameSystem
+    alias:
+    - IGameSystemFactory::CreateGameSystem
+  - name: IGameSystemFactory_IsReallocating
+    alias:
+    - IGameSystemFactory::IsReallocating
+  - name: IGameSystem_SetName
+    alias:
+    - IGameSystem::SetName
+  - name: CSpawnGroupMgrGameSystem_DoesGameSystemReallocate
+    alias:
+    - IGameSystem::DoesGameSystemReallocate
+  - name: IGameSystem_DestroyAllGameSystems
+    alias:
+    - IGameSystem::DestroyAllGameSystems
+  - name: IGameSystem_ShutdownAllSystems
+    alias:
+    - IGameSystem::ShutdownAllSystems
+  - name: IGameSystem_LoopDestroyAllSystems
+    alias:
+    - IGameSystem::LoopDestroyAllSystems
+  - name: IGameSystem_LoopPreShutdownAllSystems
+    alias:
+    - IGameSystem::LoopPreShutdownAllSystems
+  - name: IGameSystem_OnClientPollNetworking
+    alias:
+    - IGameSystem::OnClientPollNetworking
+  - name: IGameSystem_OnClientGamePostSimulate
+    alias:
+    - IGameSystem::ClientGamePostSimulate
+  - name: IGameSystem_OnClientPauseSimulate
+    alias:
+    - IGameSystem::OnClientPauseSimulate
+  - name: IGameSystem_OnClientPreUpdate
+    alias:
+    - IGameSystem::OnClientPreUpdate
+  - name: IGameSystem_OnClientPostUpdate
+    alias:
+    - IGameSystem::OnClientPostUpdate
+  - name: IGameSystem_OnClientPostDataUpdate
+    alias:
+    - IGameSystem::OnClientPostDataUpdate
+  - name: IGameSystem_OnGameFrameBoundary
+    alias:
+    - IGameSystem::OnGameFrameBoundary
+  - name: IGameSystem_OnClientAdvanceNonRenderedFrame
+    alias:
+    - IGameSystem::OnClientAdvanceNonRenderedFrame
+  - name: IGameSystem_OnClientFrameSimulate
+    alias:
+    - IGameSystem::OnClientFrameSimulate
+  - name: IGameSystem_OnClientAdvanceTick
+    alias:
+    - IGameSystem::ClientAdvanceTick
+  - name: IGameSystem_OnClientPostAdvanceTick
+    alias:
+    - IGameSystem::ClientPostAdvanceTick
+  - name: IGameSystem_OnClientPostRender
+    alias:
+    - IGameSystem::OnClientPostRender
+  - name: IGameSystem_OnClientPreRender
+    alias:
+    - IGameSystem::OnClientPreRender
+  - name: IGameSystem_OnClientPreRenderAlt
+    alias:
+    - IGameSystem::OnClientPreRenderAlt
+  - name: CSource2Client_CreateMove
+    alias:
+    - CSource2Client::CreateMove
+  - name: CClientInput_CreateMove
+    alias:
+    - CClientInput::CreateMove
+  - name: CClientInput_m_viewangles
+    alias:
+    - CClientInput::m_viewangles
+  - name: CSource2Client_ProcessGameInput
+    alias:
+    - CSource2Client::ProcessGameInput
+  - name: ISource2Client_FrameStageNotify
+    alias:
+    - ISource2Client::FrameStageNotify
+  - name: CSource2Client_FrameStageNotify
+    alias:
+    - CSource2Client::FrameStageNotify
+  - name: IViewRender_OnRenderStart
+    alias:
+    - IViewRender::OnRenderStart
+  - name: CViewRender_OnRenderStart
+    alias:
+    - CViewRender::OnRenderStart
+  - name: CViewRender_Render
+    alias:
+    - CViewRender::Render
+  - name: C_BaseEntity_SetInterpolationPhase
+    alias:
+    - C_BaseEntity::SetInterpolationPhase
+  - name: CSource2Client_SetGlobals
+    alias:
+    - CSource2Client::SetGlobals
+  - name: CSource2Client_Connect
+    alias:
+    - CSource2Client::Connect
+  - name: CBasePlayerController_CheckForLocalPlayer
+    alias:
+    - CBasePlayerController::CheckForLocalPlayer
+  - name: CSource2Client_OnDisconnect
+    alias:
+    - CSource2Client::OnDisconnect
+  - name: IGameSystem_OnClientDisconnect
+    alias:
+    - IGameSystem::OnClientDisconnect
+  - name: IGameSystem_OnClientPreEntityThink
+    alias:
+    - IGameSystem::OnClientPreEntityThink
+  - name: CNetworkGameClient_OnSource1Source1LegacyGameEvent
+    alias:
+    - CNetworkGameClient::OnSource1Source1LegacyGameEvent
+  - name: CMapAnNodeManager_FireGameEvent
+    alias:
+    - CMapAnNodeManager::FireGameEvent
+  - name: C_ServerVoiceHandler_OnServerVoiceData
+    alias:
+    - C_ServerVoiceHandler::OnServerVoiceData
+  - name: IVEngineClient2_IsPlayingDemo
+    alias:
+    - IVEngineClient2::IsPlayingDemo
+  - name: IVEngineClient2_ExecuteClientCmd
+    alias:
+    - IVEngineClient2::ExecuteClientCmd
+  - name: IGameEventManager2_UnserializeEvent
+    alias:
+    - IGameEventManager2::UnserializeEvent
+  - name: IGameEventManager2_FireEventClientSide
+    alias:
+    - IGameEventManager2::FireEventClientSide
+  - name: CGameEventManager_FireEventClientSide
+    alias:
+    - CGameEventManager::FireEventClientSide
+  - name: CGameEventManager_UnserializeEvent
+    alias:
+    - CGameEventManager::UnserializeEvent
+  - name: CSteamworksGameStats_OnReceivedSessionID
+    alias:
+    - CSteamworksGameStats::OnReceivedSessionID
+  - name: IGameSystem_GetName
+    alias:
+    - IGameSystem::GetName
+  - name: IGameSystemFactory_DestroyGameSystem
+    alias:
+    - IGameSystemFactory::DestroyGameSystem
+  - name: IGameSystemFactory_Init
+    alias:
+    - IGameSystemFactory::Init
+  - name: IGameSystemFactory_GetPriority
+    alias:
+    - IGameSystemFactory::GetPriority
+  - name: IGameSystemFactory_Shutdown
+    alias:
+    - IGameSystemFactory::Shutdown
+  - name: IGameSystemFactory_SetGlobalPtr
+    alias:
+    - IGameSystemFactory::SetGlobalPtr
+  - name: CPrediction_PostNetworkDataReceived
+    alias:
+    - CPrediction::PostNetworkDataReceived
+  - name: IEngineServiceMgr_GetActiveLoopClientServerMode
+    alias:
+    - IEngineServiceMgr::GetActiveLoopClientServerMode
+  - name: IEngineServiceMgr_GetEventDispatcher
+    alias:
+    - IEngineServiceMgr::GetEventDispatcher
+  - name: ClientModeCSNormal_Update
+    alias:
+    - ClientModeCSNormal::Update
+  - name: CEntitySystem_ctor
+    alias:
+    - CEntitySystem::CEntitySystem
+  - name: CGameEntitySystem_ctor
+    alias:
+    - CGameEntitySystem::CGameEntitySystem
+  - name: CEntitySystem_Init
+    alias:
+    - CEntitySystem::Init
+  - name: CEntitySystem_PostCreateEntitySystem
+    alias:
+    - CEntitySystem::PostCreateEntitySystem
+  - name: CSource2EntitySystem_StaticInit
+    alias:
+    - CSource2EntitySystem::StaticInit
+  - name: CGameSystemReallocatingFactory_CSource2EntitySystem_Init
+    alias:
+    - CGameSystemReallocatingFactory<CSource2EntitySystem>::Init
+  - name: CGameSystemReallocatingFactory_CSource2EntitySystem_CreateGameSystem
+    alias:
+    - CGameSystemReallocatingFactory<CSource2EntitySystem>::CreateGameSystem
+  - name: CSkeletonInstance_PostDataUpdate
+    alias:
+    - CSkeletonInstance::PostDataUpdate
+  - name: CSkeletonInstance_m_modelState_m_simulationState
+    alias:
+    - CSkeletonInstance::m_modelState.m_simulationState
+  - name: CSkeletonInstance_m_modelState_m_hModel
+    alias:
+    - CSkeletonInstance::m_modelState.m_hModel
+  - name: CSimulationState_SetupJointState
+    alias:
+    - CSimulationState::SetupJointState
+  - name: CSimulationState_m_nTotalTransformCount
+    alias:
+    - CSimulationState::m_nTotalTransformCount
+  - name: CSimulationState_m_nBoneCount
+    alias:
+    - CSimulationState::m_nBoneCount
+  - name: CSimulationState_m_nAttachmentCount
+    alias:
+    - CSimulationState::m_nAttachmentCount
+  - name: IVEngineClient2_GetNetworkClient
+    alias:
+    - IVEngineClient2::GetNetworkClient
+  - name: INetworkClient_GetLocalAddress
+    alias:
+    - INetworkClient::GetLocalAddress
+  - name: INetworkClientService_IsConnected
+    alias:
+    - INetworkClientService::IsConnected
+  - name: INetworkClientService_SendNetMessage
+    alias:
+    - INetworkClientService::SendNetMessage
+  - name: C_GameRules_ctor
+    alias:
+    - C_GameRules::C_GameRules
+  - name: IGameResourceService_SetEntityResourceManifestHandler
+    alias:
+    - IGameResourceService::SetEntityResourceManifestHandler
+  - name: CNetworkSerializerBindingBuildFilter_GetFieldPriority
+    alias:
+    - CNetworkSerializerBindingBuildFilter::GetFieldPriority
+  - name: GameStateAPI_RegisterAPIs
+    alias:
+    - GameStateAPI::RegisterAPIs
+  - name: GameStateAPI_IsLatched
+    alias:
+    - GameStateAPI::IsLatched
+  - name: GameStateAPI_GetPlayerSlot
+    alias:
+    - GameStateAPI::GetPlayerSlot
+  - name: GameStateAPI_GetPlayerName
+    alias:
+    - GameStateAPI::GetPlayerName
+  - name: GameStateAPI_GetPlayerXuidStringFromPlayerSlot
+    alias:
+    - GameStateAPI::GetPlayerXuidStringFromPlayerSlot
+  - name: GameStateAPI_GetLocalPlayerXuid
+    alias:
+    - GameStateAPI::GetLocalPlayerXuid
+  - name: GameStateAPI_GetLocalOrInEyePlayerXuid
+    alias:
+    - GameStateAPI::GetLocalOrInEyePlayerXuid
+  - name: GameStateAPI_GetHudPlayerXuid
+    alias:
+    - GameStateAPI::GetHudPlayerXuid
+  - name: GameStateAPI_GetPlayerTeamName
+    alias:
+    - GameStateAPI::GetPlayerTeamName
+  - name: GameStateAPI_GetPlayerTeamNumber
+    alias:
+    - GameStateAPI::GetPlayerTeamNumber
+  - name: GameStateAPI_GetCoachingTeamNumber
+    alias:
+    - GameStateAPI::GetCoachingTeamNumber
+  - name: GameStateAPI_GetAssociatedTeamNumber
+    alias:
+    - GameStateAPI::GetAssociatedTeamNumber
+  - name: GameStateAPI_IsPlayerConnected
+    alias:
+    - GameStateAPI::IsPlayerConnected
+  - name: GameStateAPI_IsPlayerAlive
+    alias:
+    - GameStateAPI::IsPlayerAlive
+  - name: GameStateAPI_GetPlayerPing
+    alias:
+    - GameStateAPI::GetPlayerPing
+  - name: GameStateAPI_GetPlayerKills
+    alias:
+    - GameStateAPI::GetPlayerKills
+  - name: GameStateAPI_GetPlayerRoundKills
+    alias:
+    - GameStateAPI::GetPlayerRoundKills
+  - name: GameStateAPI_GetPlayerAssists
+    alias:
+    - GameStateAPI::GetPlayerAssists
+  - name: GameStateAPI_GetPlayerDeaths
+    alias:
+    - GameStateAPI::GetPlayerDeaths
+  - name: GameStateAPI_GetPlayerMVPs
+    alias:
+    - GameStateAPI::GetPlayerMVPs
+  - name: GameStateAPI_GetPlayerMoney
+    alias:
+    - GameStateAPI::GetPlayerMoney
+  - name: GameStateAPI_GetPlayerScore
+    alias:
+    - GameStateAPI::GetPlayerScore
+  - name: GameStateAPI_GetPlayerClanTag
+    alias:
+    - GameStateAPI::GetPlayerClanTag
+  - name: GameStateAPI_GetPlayerActiveCoinRank
+    alias:
+    - GameStateAPI::GetPlayerActiveCoinRank
+  - name: GameStateAPI_GetPlayerCompetitiveRankType
+    alias:
+    - GameStateAPI::GetPlayerCompetitiveRankType
+  - name: GameStateAPI_GetPlayerCompetitiveRanking
+    alias:
+    - GameStateAPI::GetPlayerCompetitiveRanking
+  - name: GameStateAPI_GetPlayerCompetitiveWins
+    alias:
+    - GameStateAPI::GetPlayerCompetitiveWins
+  - name: GameStateAPI_GetPlayerPremierRankStatsObject
+    alias:
+    - GameStateAPI::GetPlayerPremierRankStatsObject
+  - name: GameStateAPI_GetPlayerDisplayFlairItem
+    alias:
+    - GameStateAPI::GetPlayerDisplayFlairItem
+  - name: GameStateAPI_GetPlayerStatus
+    alias:
+    - GameStateAPI::GetPlayerStatus
+  - name: GameStateAPI_IsFakePlayer
+    alias:
+    - GameStateAPI::IsFakePlayer
+  - name: GameStateAPI_GetPlayerActiveWeaponItemId
+    alias:
+    - GameStateAPI::GetPlayerActiveWeaponItemId
+  - name: GameStateAPI_IsXuidValid
+    alias:
+    - GameStateAPI::IsXuidValid
+  - name: GameStateAPI_GetPlayerVoiceVolume
+    alias:
+    - GameStateAPI::GetPlayerVoiceVolume
+  - name: GameStateAPI_SetPlayerVoiceVolume
+    alias:
+    - GameStateAPI::SetPlayerVoiceVolume
+  - name: GameStateAPI_GetMapsInMapGroup
+    alias:
+    - GameStateAPI::GetMapsInMapGroup
+  - name: GameStateAPI_GetMapDisplayNameToken
+    alias:
+    - GameStateAPI::GetMapDisplayNameToken
+  - name: GameStateAPI_GetMapsInCurrentMapGroup
+    alias:
+    - GameStateAPI::GetMapsInCurrentMapGroup
+  - name: GameStateAPI_GetPlayerLifetime
+    alias:
+    - GameStateAPI::GetPlayerLifetime
+  - name: GameStateAPI_GetPlayerColor
+    alias:
+    - GameStateAPI::GetPlayerColor
+  - name: GameStateAPI_GetPlayerXpLevel
+    alias:
+    - GameStateAPI::GetPlayerXpLevel
+  - name: GameStateAPI_GetPlayerXpTrailLevel
+    alias:
+    - GameStateAPI::GetPlayerXpTrailLevel
+  - name: GameStateAPI_GetPlayerCommendsLeader
+    alias:
+    - GameStateAPI::GetPlayerCommendsLeader
+  - name: GameStateAPI_GetPlayerCommendsTeacher
+    alias:
+    - GameStateAPI::GetPlayerCommendsTeacher
+  - name: GameStateAPI_GetPlayerCommendsFriendly
+    alias:
+    - GameStateAPI::GetPlayerCommendsFriendly
+  - name: GameStateAPI_HasCommunicationAbuseMute
+    alias:
+    - GameStateAPI::HasCommunicationAbuseMute
+  - name: GameStateAPI_HasCommunicationBan
+    alias:
+    - GameStateAPI::HasCommunicationBan
+  - name: GameStateAPI_ShouldShowHudElements
+    alias:
+    - GameStateAPI::ShouldShowHudElements
+  - name: GameStateAPI_IsQueuedMatchmaking
+    alias:
+    - GameStateAPI::IsQueuedMatchmaking
+  - name: GameStateAPI_GetKickTargets
+    alias:
+    - GameStateAPI::GetKickTargets
+  - name: GameStateAPI_GetPlayerCharacterItemID
+    alias:
+    - GameStateAPI::GetPlayerCharacterItemID
+  - name: GameStateAPI_GetCharacterDefaultCheerByXuid
+    alias:
+    - GameStateAPI::GetCharacterDefaultCheerByXuid
+  - name: GameStateAPI_GetCharacterDefaultDefeatByXuid
+    alias:
+    - GameStateAPI::GetCharacterDefaultDefeatByXuid
+  - name: GameStateAPI_ArePlayersEnemies
+    alias:
+    - GameStateAPI::ArePlayersEnemies
+  - name: GameStateAPI_GetCSGOGameUIStateName
+    alias:
+    - GameStateAPI::GetCSGOGameUIStateName
+  - name: GameStateAPI_IsLocalPlayerPlayingMatch
+    alias:
+    - GameStateAPI::IsLocalPlayerPlayingMatch
+  - name: GameStateAPI_IsConnectedOrConnectingToServer
+    alias:
+    - GameStateAPI::IsConnectedOrConnectingToServer
+  - name: GameStateAPI_AreTeamsPlayingSwitchedSides
+    alias:
+    - GameStateAPI::AreTeamsPlayingSwitchedSides
+  - name: GameStateAPI_AreTeamsPlayingSwitchedSidesInRound
+    alias:
+    - GameStateAPI::AreTeamsPlayingSwitchedSidesInRound
+  - name: GameStateAPI_IsReportCategoryEnabledForSelectedPlayer
+    alias:
+    - GameStateAPI::IsReportCategoryEnabledForSelectedPlayer
+  - name: GameStateAPI_SubmitPlayerReport
+    alias:
+    - GameStateAPI::SubmitPlayerReport
+  - name: GameStateAPI_SubmitServerReport
+    alias:
+    - GameStateAPI::SubmitServerReport
+  - name: GameStateAPI_QueryServersForCommendation
+    alias:
+    - GameStateAPI::QueryServersForCommendation
+  - name: GameStateAPI_GetCommendationTokensAvailable
+    alias:
+    - GameStateAPI::GetCommendationTokensAvailable
+  - name: GameStateAPI_GetMyCommendationsJSOForUser
+    alias:
+    - GameStateAPI::GetMyCommendationsJSOForUser
+  - name: GameStateAPI_SubmitCommendation
+    alias:
+    - GameStateAPI::SubmitCommendation
+  - name: GameStateAPI_IsSelectedPlayerMuted
+    alias:
+    - GameStateAPI::IsSelectedPlayerMuted
+  - name: GameStateAPI_ToggleMute
+    alias:
+    - GameStateAPI::ToggleMute
+  - name: GameStateAPI_GetCrosshairCode
+    alias:
+    - GameStateAPI::GetCrosshairCode
+  - name: GameStateAPI_IsDemoOrHltv
+    alias:
+    - GameStateAPI::IsDemoOrHltv
+  - name: GameStateAPI_IsOverwatch
+    alias:
+    - GameStateAPI::IsOverwatch
+  - name: GameStateAPI_IsLocalPlayerWatchingOwnDemo
+    alias:
+    - GameStateAPI::IsLocalPlayerWatchingOwnDemo
+  - name: GameStateAPI_IsLocalPlayerHLTV
+    alias:
+    - GameStateAPI::IsLocalPlayerHLTV
+  - name: GameStateAPI_IsHLTVAutodirectorOn
+    alias:
+    - GameStateAPI::IsHLTVAutodirectorOn
+  - name: GameStateAPI_SetCasterIsCameraman
+    alias:
+    - GameStateAPI::SetCasterIsCameraman
+  - name: GameStateAPI_SetCasterIsHeard
+    alias:
+    - GameStateAPI::SetCasterIsHeard
+  - name: GameStateAPI_SetCasterControlsXray
+    alias:
+    - GameStateAPI::SetCasterControlsXray
+  - name: GameStateAPI_SetCasterControlsUI
+    alias:
+    - GameStateAPI::SetCasterControlsUI
+  - name: GameStateAPI_GetServerName
+    alias:
+    - GameStateAPI::GetServerName
+  - name: GameStateAPI_GetMapName
+    alias:
+    - GameStateAPI::GetMapName
+  - name: GameStateAPI_GetTournamentEventStage
+    alias:
+    - GameStateAPI::GetTournamentEventStage
+  - name: GameStateAPI_GetGameModeInternalName
+    alias:
+    - GameStateAPI::GetGameModeInternalName
+  - name: GameStateAPI_GetGameModeImagePath
+    alias:
+    - GameStateAPI::GetGameModeImagePath
+  - name: GameStateAPI_GetGameModeName
+    alias:
+    - GameStateAPI::GetGameModeName
+  - name: GameStateAPI_GetViewerCount
+    alias:
+    - GameStateAPI::GetViewerCount
+  - name: GameStateAPI_GetMapBSPName
+    alias:
+    - GameStateAPI::GetMapBSPName
+  - name: GameStateAPI_IsQueuedMatchmakingMode_Team
+    alias:
+    - GameStateAPI::IsQueuedMatchmakingMode_Team
+  - name: GameStateAPI_HasHalfTime
+    alias:
+    - GameStateAPI::HasHalfTime
+  - name: GameStateAPI_GetPlayerModel
+    alias:
+    - GameStateAPI::GetPlayerModel
+  - name: GameStateAPI_GetAllPlayersMatchDataJSO
+    alias:
+    - GameStateAPI::GetAllPlayersMatchDataJSO
+  - name: GameStateAPI_GetPlayerDataJSO
+    alias:
+    - GameStateAPI::GetPlayerDataJSO
+  - name: GameStateAPI_GetTimeDataJSO
+    alias:
+    - GameStateAPI::GetTimeDataJSO
+  - name: GameStateAPI_GetScoreDataJSO
+    alias:
+    - GameStateAPI::GetScoreDataJSO
+  - name: GameStateAPI_GetPlayerStatsJSO
+    alias:
+    - GameStateAPI::GetPlayerStatsJSO
+  - name: GameStateAPI_GetMatchInfoJSO
+    alias:
+    - GameStateAPI::GetMatchInfoJSO
+  - name: GameStateAPI_GetMatchEndWinDataJSO
+    alias:
+    - GameStateAPI::GetMatchEndWinDataJSO
+  - name: GameStateAPI_GetAccoladeLocalizationString
+    alias:
+    - GameStateAPI::GetAccoladeLocalizationString
+  - name: GameStateAPI_GetTeamClanName
+    alias:
+    - GameStateAPI::GetTeamClanName
+  - name: GameStateAPI_GetTeamLogoImagePath
+    alias:
+    - GameStateAPI::GetTeamLogoImagePath
+  - name: GameStateAPI_GetTeamFlagImagePath
+    alias:
+    - GameStateAPI::GetTeamFlagImagePath
+  - name: GameStateAPI_GetTeamTotalPlayerCount
+    alias:
+    - GameStateAPI::GetTeamTotalPlayerCount
+  - name: GameStateAPI_GetTeamLivingPlayerCount
+    alias:
+    - GameStateAPI::GetTeamLivingPlayerCount
+  - name: GameStateAPI_GetTeamNextRoundLossBonus
+    alias:
+    - GameStateAPI::GetTeamNextRoundLossBonus
+  - name: GameStateAPI_GetActiveQuestID
+    alias:
+    - GameStateAPI::GetActiveQuestID
+  - name: GameStateAPI_GetAnnotationsViewingLevel
+    alias:
+    - GameStateAPI::GetAnnotationsViewingLevel
+  - name: GameStateAPI_BIsLocalServerHost
+    alias:
+    - GameStateAPI::BIsLocalServerHost
+- name: server
+  symbols:
+  - name: CSource2Server_GetAllServerClasses
+    alias:
+    - CSource2Server::GetAllServerClasses
+  - name: CSource2Server_GetActiveWorldName
+    alias:
+    - CSource2Server::GetActiveWorldName
+  - name: CSource2Server_ShouldTimeoutClient
+    alias:
+    - CSource2Server::ShouldTimeoutClient
+  - name: CSource2Server_OnStreamEntitiesFromFileCompleted
+    alias:
+    - CSource2Server::OnStreamEntitiesFromFileCompleted
+  - name: CSource2Server_PreWorldUpdate
+    alias:
+    - CSource2Server::PreWorldUpdate
+  - name: CSource2Server_UpdateWhenNotInGame
+    alias:
+    - CSource2Server::UpdateWhenNotInGame
+  - name: CGameSystemReallocatingFactory_CSource2EntitySystem_Init
+    alias:
+    - CGameSystemReallocatingFactory<CSource2EntitySystem>::Init
+  - name: CGameSystemReallocatingFactory_CSource2EntitySystem_CreateGameSystem
+    alias:
+    - CGameSystemReallocatingFactory<CSource2EntitySystem>::CreateGameSystem
+  - name: IGameSystemFactory_Init
+    alias:
+    - IGameSystemFactory::Init
+  - name: IGameSystemFactory_Shutdown
+    alias:
+    - IGameSystemFactory::Shutdown
+  - name: IGameSystemFactory_SetGlobalPtr
+    alias:
+    - IGameSystemFactory::SetGlobalPtr
+  - name: CGameSystemReallocatingFactory_CSpawnGroupMgrGameSystem_DestroyGameSystem
+    alias:
+    - CGameSystemReallocatingFactory<CSpawnGroupMgrGameSystem>::Deallocate
+  - name: IGameSystem_SetGameSystemGlobalPtrs
+    alias:
+    - IGameSystem::SetGameSystemGlobalPtrs
+  - name: IGameSystem_vdtor
+    alias:
+    - IGameSystem::~IGameSystem
+  - name: IGameSystem_OnGameInit
+    alias:
+    - IGameSystem::GameInit
+  - name: CGameRules_GetChatPrefix
+    alias:
+    - CGameRules::GetChatPrefix
+  - name: CMultiplayRules_ctor
+    alias:
+    - CMultiplayRules::CMultiplayRules
+  - name: CGameMoney_OnMoneySpent
+    alias:
+    - CGameMoney::OnMoneySpent
+  - name: CGameMoney_m_DataMap
+    alias:
+    - CGameMoney::m_DataMap
+  - name: CGameMoney_GetDataDescMap
+    alias:
+    - CGameMoney::GetDataDescMap
+  - name: CCSPlayer_UseServices_OnUseImpl
+    alias:
+    - CCSPlayer_UseServices::OnUseImpl
+  - name: CCSPlayer_UseServices_OnUse
+    alias:
+    - CCSPlayer_UseServices::OnUse
+  - name: CCSPlayer_MovementServices_ProcessMovement
+    alias:
+    - CCSPlayer_MovementServices::ProcessMovement
+    - ProcessMovement
+  - name: CCSPlayer_MovementServices_CheckMovingGround
+    alias:
+    - CCSPlayer_MovementServices::CheckMovingGround
+    - CheckMovingGround
+  - name: CCSPlayer_MovementServices_WalkMove
+    alias:
+    - CCSPlayer_MovementServices::WalkMove
+    - WalkMove
+  - name: CCSPlayer_MovementServices_FullWalkMove
+    alias:
+    - CCSPlayer_MovementServices::FullWalkMove
+    - FullWalkMove
+  - name: CCSPlayer_MovementServices_CheckVelocity
+    alias:
+    - CCSPlayer_MovementServices::CheckVelocity
+    - CheckVelocity
+  - name: CCSPlayer_MovementServices_WaterMove
+    alias:
+    - CCSPlayer_MovementServices::WaterMove
+    - WaterMove
+  - name: CCSPlayer_MovementServices_FullWalkMove_SpeedClamp
+    alias:
+    - ServerMovementUnlock
+  - name: CCSPlayer_MovementServices_CheckJumpButton
+    alias:
+    - CCSPlayer_MovementServices::CheckJumpButton
+  - name: CCSPlayer_MovementServices_CheckJumpButton_WaterPatch
+    alias:
+    - CheckJumpButtonWater
+    - FixWaterFloorJump
+  - name: CPlayer_MovementServices_PlayWaterStepSound
+    alias:
+    - CPlayer_MovementServices::PlayWaterStepSound
+  - name: CPlayer_MovementServices_ForceButtons
+    alias:
+    - CPlayer_MovementServices::ForceButtons
+  - name: CPlayer_MovementServices_ForceButtonState
+    alias:
+    - CPlayer_MovementServices::ForceButtonState
+  - name: CPlayer_MovementServices_s_pRunCommandPawn
+    alias:
+    - CPlayer_MovementServices::s_pRunCommandPawn
+  - name: CEntityInstance_m_pEntity
+    alias:
+    - CEntityInstance::m_pEntity
+  - name: CEntityInstance_m_hPrivateScope
+    alias:
+    - CEntityInstance::m_hPrivateScope
+  - name: CEntityInstance_m_CScriptComponent
+    alias:
+    - CEntityInstance::m_CScriptComponent
+  - name: CEntityInstance_m_pKeyValues
+    alias:
+    - CEntityInstance::m_pKeyValues
+  - name: CEntityInstance_m_iszPrivateVScripts
+    alias:
+    - CEntityInstance::m_iszPrivateVScripts
+  - name: CBaseEntity_OnRestore
+    alias:
+    - CBaseEntity::OnRestore
+  - name: CBaseEntity_UpdateOnRemove
+    alias:
+    - CBaseEntity::UpdateOnRemove
+  - name: CBaseEntity_ModifyOrAppendCriteria
+    alias:
+    - CBaseEntity::ModifyOrAppendCriteria
+  - name: CEntityInstance_OnRestore
+    alias:
+    - CEntityInstance::OnRestore
+  - name: CBaseEntity_ctor
+    alias:
+    - CBaseEntity::CBaseEntity
+  - name: CBaseEntity_dtor
+    alias:
+    - CBaseEntity::~CBaseEntity
+  - name: CBaseEntity_vdtor
+    alias:
+    - CBaseEntity::~CBaseEntity (virtual)
+  - name: CEntityInstance_vdtor
+    alias:
+    - CEntityInstance::~CEntityInstance (virtual)
+  - name: CEntityInstance_dtor
+    alias:
+    - CEntityInstance::~CEntityInstance
+  - name: CEntitySaveRestoreBlockHandler_PreSave
+    alias:
+    - CEntitySaveRestoreBlockHandler::PreSave
+  - name: CEntitySaveRestoreBlockHandler_SaveInternal
+    alias:
+    - CEntitySaveRestoreBlockHandler::SaveInternal
+  - name: CEntitySaveRestoreBlockHandler_Save
+    alias:
+    - CEntitySaveRestoreBlockHandler::Save
+  - name: CEntitySaveRestoreBlockHandler_Restore
+    alias:
+    - CEntitySaveRestoreBlockHandler::Restore
+  - name: CEntitySaveRestoreBlockHandler_DoRestoreEntity
+    alias:
+    - CEntitySaveRestoreBlockHandler::DoRestoreEntity
+  - name: CEntitySaveRestoreBlockHandler_RestoreEntity
+    alias:
+    - CEntitySaveRestoreBlockHandler::RestoreEntity
+  - name: CreateEntityTransitionList
+    alias:
+    - CreateEntityTransitionList
+  - name: CEntitySaveRestoreBlockHandler_WriteSaveHeaders
+    alias:
+    - CEntitySaveRestoreBlockHandler::WriteSaveHeaders
+  - name: CEntitySaveRestoreBlockHandler_ReadRestoreHeaders
+    alias:
+    - CEntitySaveRestoreBlockHandler::ReadRestoreHeaders
+  - name: CEntity2SaveRestore_StreamEntitiesFromFile
+    alias:
+    - CEntity2SaveRestore::StreamEntitiesFromFile
+  - name: CSaveRestoreBlockSet_PreRestore
+    alias:
+    - CSaveRestoreBlockSet::PreRestore
+  - name: CSaveRestoreBlockSet_PostRestore
+    alias:
+    - CSaveRestoreBlockSet::PostRestore
+  - name: CEntitySaveRestoreBlockHandler_PreRestore
+    alias:
+    - CEntitySaveRestoreBlockHandler::PreRestore
+  - name: CEntitySaveRestoreBlockHandler_PostRestore
+    alias:
+    - CEntitySaveRestoreBlockHandler::PostRestore
+  - name: CEntitySystem_ForceSetInPVSCallsIntoQueue
+    alias:
+    - CEntitySystem::ForceSetInPVSCallsIntoQueue
+  - name: CEntitySystem_ExecuteQueuedSetInPVS
+    alias:
+    - CEntitySystem::ExecuteQueuedSetInPVS
+  - name: CEntitySystem_m_nSuppressDormancyChangeCount
+    alias:
+    - CEntitySystem::m_nSuppressDormancyChangeCount
+  - name: CEntitySystem_m_nExecuteQueuedCreationDepth
+    alias:
+    - CEntitySystem::m_nExecuteQueuedCreationDepth
+  - name: CEntitySystem_m_queuedDormancyChanges
+    alias:
+    - CEntitySystem::m_queuedDormancyChanges
+  - name: CEntitySystem_SetInPVS
+    alias:
+    - CEntitySystem::SetInPVS
+  - name: CEntitySystem_OnSetDormant
+    alias:
+    - CEntitySystem::OnSetDormant
+  - name: CEntitySystem_BuildResourceManifestForEntity
+    alias:
+    - CEntitySystem::BuildResourceManifestForEntity
+  - name: CEntityInstance_ObjectCaps
+    alias:
+    - CEntityInstance::ObjectCaps
+  - name: CEntityInstance_Save
+    alias:
+    - CEntityInstance::Save
+  - name: CEntityInstance_Restore
+    alias:
+    - CEntityInstance::Restore
+  - name: CEntitySaveRestoreBlockHandler_SaveInitEntities
+    alias:
+    - CEntitySaveRestoreBlockHandler::SaveInitEntities
+  - name: CEntityInstance_OnSave
+    alias:
+    - CEntityInstance::OnSave
+  - name: CEntityInstance_RequiredEdictIndex
+    alias:
+    - CEntityInstance::RequiredEdictIndex
+  - name: PolymorphicHelper_t__SetPolymorphicPointer
+    alias:
+    - PolymorphicHelper_t::SetPolymorphicPointer
+  - name: CEntityInstance_AddChangeAccessorPathPolymorphic
+    alias:
+    - CEntityInstance::AddChangeAccessorPathPolymorphic
+  - name: CEntityInstance_AssignChangeAccessorPathIdsPolymorphic
+    alias:
+    - CEntityInstance::AssignChangeAccessorPathIdsPolymorphic
+  - name: CEntityInstance_AddChangeAccessorPath
+    alias:
+    - CEntityInstance::AddChangeAccessorPath
+  - name: CBaseEntity_AddChangeAccessorPath
+    alias:
+    - CBaseEntity::AddChangeAccessorPath
+  - name: CEntityInstance_AssignChangeAccessorPathIds
+    alias:
+    - CEntityInstance::AssignChangeAccessorPathIds
+  - name: CEntityInstance_GetChangeAccessorPathInfo_2
+    alias:
+    - CEntityInstance::GetChangeAccessorPathInfo_2
+  - name: CBaseEntity_GetChangeAccessorPathInfo_2
+    alias:
+    - CBaseEntity::GetChangeAccessorPathInfo_2
+  - name: CBaseEntity_GetChangeAccessorPathInfo_1
+    alias:
+    - CBaseEntity::GetChangeAccessorPathInfo_1
+  - name: CBasePlayerPawn_PrePhysicsSimulate
+    alias:
+    - CBasePlayerPawn::PrePhysicsSimulate
+  - name: CBasePlayerPawn_PhysicsSimulate
+    alias:
+    - CBasePlayerPawn::PhysicsSimulate
+  - name: CMomentaryRotButton_Use
+    alias:
+    - CMomentaryRotButton::Use
+  - name: CBaseEntity_TakeDamageOld
+    alias:
+    - CBaseEntity::TakeDamageOld
+  - name: CBaseEntity_OnTakeDamage
+    alias:
+    - CBasePlayerPawn::OnTakeDamage
+  - name: CBasePlayerPawn_OnTakeDamage_Alive
+    alias:
+    - CBasePlayerPawn::OnTakeDamage_Alive
+  - name: CBasePlayerPawn_OnTakeDamage_Dying
+    alias:
+    - CBasePlayerPawn::OnTakeDamage_Dying
+  - name: CBasePlayerPawn_OnTakeDamage_Dead
+    alias:
+    - CBasePlayerPawn::OnTakeDamage_Dead
+  - name: DecalPlacementInfo_ctor
+    alias:
+    - DecalPlacementInfo::DecalPlacementInfo
+  - name: CBaseModelEntity_GetBoneTransform
+    alias:
+    - CBaseModelEntity::GetBoneTransform
+  - name: CBaseModelEntity_DamageDecal
+    alias:
+    - CBaseModelEntity::DamageDecal
+  - name: CBreakable_DamageDecal
+    alias:
+    - CBreakable::DamageDecal
+  - name: CBasePlayerPawn_OnTakeDamage
+    alias:
+    - CBasePlayerPawn::OnTakeDamage
+  - name: CCSPlayerPawn_OnTakeDamage_Alive
+    alias:
+    - CCSPlayerPawn::OnTakeDamage_Alive
+  - name: CCSPlayerPawn_CreatePlayerPawnServices
+    alias:
+    - CCSPlayerPawn::CreatePlayerPawnServices
+  - name: CCSPlayerPawn_OnTakeDamage_Dying
+    alias:
+    - CCSPlayerPawn::OnTakeDamage_Dying
+  - name: CCSPlayerPawn_OnTakeDamage_Dead
+    alias:
+    - CCSPlayerPawn::OnTakeDamage_Dead
+  - name: CFlashbangProjectile_Spawn
+    alias:
+    - CFlashbangProjectile::Spawn
+  - name: CFlashbangProjectile_Detonate
+    alias:
+    - CFlashbangProjectile::Detonate
+  - name: CSmokeGrenadeProjectile_Detonate
+    alias:
+    - CSmokeGrenadeProjectile::Detonate
+  - name: CSmokeGrenadeProjectile_Create
+    alias:
+    - CSmokeGrenadeProjectile::Create
+  - name: CSmokeGrenadeProjectile_m_SmokeVolume
+    alias:
+    - CSmokeGrenadeProjectile::m_SmokeVolume
+  - name: SmokeVolume_BuildSmokeSimulation
+    alias:
+    - SmokeVolume::BuildSmokeSimulation
+  - name: SmokeVolume_BuildSmokeSimulation_Initialize
+    alias:
+    - sub_1402310
+  - name: SmokeVolume_m_vecCenterOrigin
+    alias:
+    - SmokeVolume::m_vecCenterOrigin
+  - name: SmokeVolume_m_pStorage
+    alias:
+    - SmokeVolume::m_pStorage
+  - name: SmokeVolume_m_flStartTime
+    alias:
+    - SmokeVolume::m_flStartTime
+  - name: SmokeVolume_GetSmokeDensityInLine_Lambda1_operator_call
+    alias:
+    - SmokeVolume::GetSmokeDensityInLine::<lambda_1>::operator()
+  - name: SmokeVolume_m_nFrame
+    alias:
+    - SmokeVolume::m_nFrame
+  - name: CEntitySystem_QueueDestroyEntity
+    alias:
+    - CEntitySystem::QueueDestroyEntity
+  - name: CEntitySystem_ExecuteQueuedDeletion
+    alias:
+    - CEntitySystem::ExecuteQueuedDeletion
+  - name: CEntitySystem_m_nExecuteQueuedDeletionDepth
+    alias:
+    - CEntitySystem::m_nExecuteQueuedDeletionDepth
+  - name: CBaseModelEntity_SetModel
+    alias:
+    - CBaseModelEntity::SetModel
+  - name: CBaseModelEntity_SetRenderAttribute
+    alias:
+    - CBaseModelEntity::SetRenderAttribute
+  - name: CBaseEntity_GetScriptDescInternal
+    alias:
+    - CBaseEntity::GetScriptDescInternal
+  - name: CBaseModelEntity_GetScriptDescInternal
+    alias:
+    - CBaseModelEntity::GetScriptDescInternal
+  - name: CBaseModelEntity_GetModelScale
+    alias:
+    - CBaseModelEntity::GetModelScale
+  - name: CBaseModelEntity_Script_SetModelScale
+    alias:
+    - CBaseModelEntity::Script_SetModelScale
+  - name: CBaseModelEntity_ScriptLookupAttachment
+    alias:
+    - CBaseModelEntity::ScriptLookupAttachment
+  - name: CBaseModelEntity_ScriptGetAttachmentOrigin
+    alias:
+    - CBaseModelEntity::ScriptGetAttachmentOrigin
+  - name: CBaseModelEntity_ScriptGetAttachmentAngles
+    alias:
+    - CBaseModelEntity::ScriptGetAttachmentAngles
+  - name: CBaseModelEntity_ScriptGetAttachmentForward
+    alias:
+    - CBaseModelEntity::ScriptGetAttachmentForward
+  - name: CBaseModelEntity_ScriptSetSize
+    alias:
+    - CBaseModelEntity::ScriptSetSize
+  - name: CBaseModelEntity_ScriptSetModel
+    alias:
+    - CBaseModelEntity::ScriptSetModel
+  - name: ScriptBinding_CBaseModelEntity_SetModel
+    alias:
+    - CS_Script_SetModel
+  - name: CBaseModelEntity_ScriptGetRenderAlpha
+    alias:
+    - CBaseModelEntity::ScriptGetRenderAlpha
+  - name: CBaseModelEntity_ScriptSetRenderAlpha
+    alias:
+    - CBaseModelEntity::ScriptSetRenderAlpha
+  - name: CBaseModelEntity_ScriptSetRenderMode
+    alias:
+    - CBaseModelEntity::ScriptSetRenderMode
+  - name: CBaseModelEntity_ScriptSetRenderColor
+    alias:
+    - CBaseModelEntity::ScriptSetRenderColor
+  - name: CBaseModelEntity_ScriptGetRenderColor
+    alias:
+    - CBaseModelEntity::ScriptGetRenderColor
+  - name: CBaseModelEntity_ScriptSetMaterialGroup
+    alias:
+    - CBaseModelEntity::ScriptSetMaterialGroup
+  - name: CBaseModelEntity_ScriptSetMaterialGroupHash
+    alias:
+    - CBaseModelEntity::ScriptSetMaterialGroupHash
+  - name: CBaseModelEntity_ScriptGetMaterialGroupHash
+    alias:
+    - CBaseModelEntity::ScriptGetMaterialGroupHash
+  - name: CBaseModelEntity_ScriptSetSingleMeshGroup
+    alias:
+    - CBaseModelEntity::ScriptSetSingleMeshGroup
+  - name: CBaseModelEntity_ScriptSetMeshGroupMask
+    alias:
+    - CBaseModelEntity::ScriptSetMeshGroupMask
+  - name: CBaseModelEntity_ScriptGetMeshGroupMask
+    alias:
+    - CBaseModelEntity::ScriptGetMeshGroupMask
+  - name: CBaseModelEntity_ScriptSetBodygroupByName
+    alias:
+    - CBaseModelEntity::ScriptSetBodygroupByName
+  - name: CBaseModelEntity_Script_SetBodygroup
+    alias:
+    - CBaseModelEntity::Script_SetBodygroup
+  - name: CBaseModelEntity_Script_SetSkin
+    alias:
+    - CBaseModelEntity::Script_SetSkin
+  - name: CEntityInstance_NetworkUpdateState_thunk
+    alias:
+    - CEntityInstance::NetworkUpdateState_thunk
+  - name: CBaseEntity_SetGravityScale
+    alias:
+    - CBaseEntity::SetGravityScale
+  - name: CTriggerGravity_GravityTouch
+    alias:
+    - CTriggerGravity::GravityTouch
+  - name: CTriggerGravity_GetTouchFunction
+    alias:
+    - CTriggerGravity::GetTouchFunction
+  - name: CBasePlayerController_HandleCommand_JoinTeam
+    alias:
+    - CBasePlayerController::HandleCommand_JoinTeam
+  - name: CBasePlayerController_SetPlayerName
+    alias:
+    - CBasePlayerController::SetPlayerName
+  - name: CBasePlayerController_ProcessUsercmds
+    alias:
+    - ProcessUsercmds
+  - name: CBasePlayerController_SetPawn
+    alias:
+    - CBasePlayerController::SetPawn
+  - name: CBasePlayerController_GetPawn
+    alias:
+    - CBasePlayerController::GetPawn
+  - name: CBasePlayerController_Connect
+    alias:
+    - CBasePlayerController::Connect
+  - name: CBasePlayerController_SetConnectedState
+    alias:
+    - CBasePlayerController::SetConnectedState
+  - name: CSource2GameClients_ClientSettingsChanged
+    alias:
+    - CSource2GameClients::ClientSettingsChanged
+  - name: CSource2GameClients_ClientSetConVarUserInfoSet
+    alias:
+    - CSource2GameClients::ClientSetConVarUserInfoSet
+  - name: CSource2GameClients_ClientSetupVisibility
+    alias:
+    - CSource2GameClients::ClientSetupVisibility
+  - name: CSource2GameClients_ClientDisconnect
+    alias:
+    - CSource2GameClients::ClientDisconnect
+  - name: CSource2GameClients_ClientPutInServer
+    alias:
+    - CSource2GameClients::ClientPutInServer
+  - name: CSource2GameClients_ClientConnect
+    alias:
+    - CSource2GameClients::ClientConnect
+  - name: CSource2GameClients_ClientActive
+    alias:
+    - CSource2GameClients::ClientActive
+  - name: CSource2GameClients_ClientFullyConnect
+    alias:
+    - CSource2GameClients::ClientFullyConnect
+  - name: CSource2GameClients_ClientCommand
+    alias:
+    - CSource2GameClients::ClientCommand
+  - name: CSource2GameClients_ProcessUsercmds
+    alias:
+    - CSource2GameClients::ProcessUsercmds
+  - name: CSource2GameClients_GetBugReportInfo
+    alias:
+    - CSource2GameClients::GetBugReportInfo
+  - name: CSource2GameClients_ClientDiagnostic
+    alias:
+    - CSource2GameClients::ClientDiagnostic
+  - name: CSource2GameClients_SendHLTVStatusMessage
+    alias:
+    - CSource2GameClients::SendHLTVStatusMessage
+  - name: CSource2GameClients_OnClientConnected
+    alias:
+    - CSource2GameClients::OnClientConnected
+  - name: CGameRules_FindPickerEntity
+    alias:
+    - CGameRules::FindPickerEntity
+  - name: CCSGameRules_FindPickerEntity
+    alias:
+    - CCSGameRules::FindPickerEntity
+  - name: CCSGameRules_TerminateRound
+    alias:
+    - CCSGameRules::TerminateRound
+    - CGameRules::TerminateRound
+    - CGameRules_TerminateRound
+  - name: CCSGameRules_GoToIntermission
+    alias:
+    - CCSGameRules::GoToIntermission
+  - name: CEntityInstance_AcceptInput
+    alias:
+    - CEntityInstance::AcceptInput
+    - AcceptInput
+  - name: CEntityIdentity_AcceptInput
+    alias:
+    - CEntityIdentity::AcceptInput
+  - name: CEntityIdentity_AcceptInputInternal
+    alias:
+    - CEntityIdentity::AcceptInputInternal
+  - name: CEntityInstance_ScriptAcceptInput
+    alias:
+    - CEntityInstance::ScriptAcceptInput
+  - name: CEntityIdentity_SetEntityName
+    alias:
+    - CEntityIdentity::SetEntityName
+  - name: CEntitySystem_RemoveEntityFromNameMap
+    alias:
+    - CEntitySystem::RemoveEntityFromNameMap
+  - name: CEntitySystem_AddEntityToNameMap
+    alias:
+    - CEntitySystem::AddEntityToNameMap
+  - name: ScriptBinding_Entity_SetEntityName
+    alias:
+    - Entity::SetEntityName
+  - name: CBtActionCoordinatedBuy_Update
+    alias:
+    - CBtActionCoordinatedBuy::Update
+  - name: CCSPlayer_ItemServices_CanAcquire
+    alias:
+    - CCSPlayer_ItemServices::CanAcquire
+  - name: CCSPlayer_ItemServices_GiveDefaultItems
+    alias:
+    - CCSPlayer_ItemServices::GiveDefaultItems
+  - name: CCSPlayer_ItemServices_GiveNamedItem
+    alias:
+    - CCSPlayer_ItemServices::GiveNamedItem
+  - name: CCSPlayer_ItemServices_GiveNamedItemBool
+    alias:
+    - CCSPlayer_ItemServices::GiveNamedItemBool
+  - name: CCSPlayer_WeaponServices_CanUse
+    alias:
+    - CCSPlayer_WeaponServices::CanUse
+  - name: CCSPlayer_WeaponServices_PickupItem
+    alias:
+    - CCSPlayer_WeaponServices::PickupItem
+  - name: CCSPlayer_WeaponServices_EquipWeapon
+    alias:
+    - CCSPlayer_WeaponServices::EquipWeapon
+  - name: CCSPlayer_WeaponServices_Weapon_GetSlot
+    alias:
+    - CCSPlayer_WeaponServices_Weapon_GetSlot
+  - name: CCSPlayerController_ChangeTeam
+    alias:
+    - CCSPlayerController::ChangeTeam
+  - name: CCSPlayerController_GetThinkFunction
+    alias:
+    - CCSPlayerController::GetThinkFunction
+  - name: CCSPlayerController_PlayerForceTeamThink
+    alias:
+    - PlayerForceTeamThink
+    - CCSPlayerController::PlayerForceTeamThink
+  - name: CCSPlayerController_ResetForceTeamThink
+    alias:
+    - ResetForceTeamThink
+    - CCSPlayerController::ResetForceTeamThink
+  - name: CCSPlayerController_ResourceDataThink
+    alias:
+    - ResourceDataThink
+    - CCSPlayerController::ResourceDataThink
+  - name: CCSPlayerController_InventoryUpdateThink
+    alias:
+    - InventoryUpdateThink
+    - CCSPlayerController::InventoryUpdateThink
+  - name: g_CCSPlayerController_PlayerForceTeamThink
+    alias:
+    - g_CCSPlayerController::PlayerForceTeamThink
+  - name: g_CCSPlayerController_ResetForceTeamThink
+    alias:
+    - g_CCSPlayerController::ResetForceTeamThink
+  - name: g_CCSPlayerController_ResourceDataThink
+    alias:
+    - g_CCSPlayerController::ResourceDataThink
+  - name: g_CCSPlayerController_InventoryUpdateThink
+    alias:
+    - g_CCSPlayerController::InventoryUpdateThink
+  - name: CCSGameRules__sm_mapGcBanInformation
+    alias:
+    - CCSGameRules::sm_mapGcBanInformation
+  - name: CCSGameRules_BeginRound
+    alias:
+    - CCSGameRules::BeginRound
+  - name: CCSGameRules_PlayerSpawn
+    alias:
+    - CCSGameRules::PlayerSpawn
+  - name: CCSPlayerController_Respawn
+    alias:
+    - CCSPlayerController::Respawn
+  - name: CCSPlayerController_Connect
+    alias:
+    - CCSPlayerController::Connect
+  - name: CCSPlayerController_Disconnect
+    alias:
+    - CCSPlayerController::Disconnect
+  - name: CCSPlayerController_SwitchTeam
+    alias:
+    - CCSPlayerController::SwitchTeam
+  - name: CCSPlayerPawnBase_OnSetDormant
+    alias:
+    - CCSPlayerPawnBase::OnSetDormant
+  - name: CCSPlayerPawnBase_CheckForIdle
+    alias:
+    - CCSPlayerPawnBase::CheckForIdle
+  - name: CCSPlayerPawnBase_CheckForIdleInternal
+    alias:
+    - CCSPlayerPawnBase::CheckForIdleInternal
+  - name: CCSPlayerPawn_PostThink
+    alias:
+    - CCSPlayerPawnBase::PostThink
+    - CCSPlayerPawn::PostThink
+    - CCSPlayerPawnBase_PostThink
+    - CCSPlayerPawn_PostThink
+    - PostThink
+  - name: CCSPlayerPawn_OnSwitchWeapons
+    alias:
+    - CCSPlayerPawn::OnSwitchWeapons
+  - name: CCSPlayerPawn_ProcessSuicideAsKillReward
+    alias:
+    - CCSPlayerPawn::ProcessSuicideAsKillReward
+  - name: CGameRules_ClientSettingsChanged
+    alias:
+    - CGameRules::ClientSettingsChanged
+  - name: CGameRules_SetGamePaused
+    alias:
+    - CGameRules::SetGamePaused
+  - name: CGameRulesGameSystem_OnGameInit
+    alias:
+    - CGameRulesGameSystem::GameInit
+  - name: CGameRulesGameSystem_OnGameShutdown
+    alias:
+    - CGameRulesGameSystem::GameShutdown
+  - name: IGameSystem_OnGameShutdown
+    alias:
+    - IGameSystem::GameShutdown
+  - name: IGameSystem_OnGamePostInit
+    alias:
+    - IGameSystem::GamePostInit
+  - name: IGameSystem_OnGamePreShutdown
+    alias:
+    - IGameSystem::GamePreShutdown
+  - name: CMultiplayRules_ClientDisconnected
+    alias:
+    - CMultiplayRules::ClientDisconnected
+  - name: CSource2Server_Init
+    alias:
+    - CSource2Server::Init
+  - name: CSource2Server_ApplyGameSettings
+    alias:
+    - CSource2Server::ApplyGameSettings
+  - name: CSource2Server_GetEntityReport
+    alias:
+    - CSource2Server::GetEntityReport
+  - name: CSource2Server_BroadcastServerFrameTime
+    alias:
+    - CSource2Server::BroadcastServerFrameTime
+  - name: CSource2Server_WriteSignonMessages
+    alias:
+    - CSource2Server::WriteSignonMessages
+  - name: CSource2Server_GameCreateNetworkStringTables
+    alias:
+    - CSource2Server::GameCreateNetworkStringTables
+  - name: CSource2Server_GetMatchmakingGameData
+    alias:
+    - CSource2Server::GetMatchmakingGameData
+  - name: CSource2Server_GameServerSteamAPIActivated
+    alias:
+    - CSource2Server::GameServerSteamAPIActivated
+  - name: CSource2Server_GameServerSteamAPIDeactivated
+    alias:
+    - CSource2Server::GameServerSteamAPIDeactivated
+  - name: CSource2Server_OnHostNameChanged
+    alias:
+    - CSource2Server::OnHostNameChanged
+  - name: CSource2Server_GetLevelsFromSaveFile
+    alias:
+    - CSource2Server::GetLevelsFromSaveFile
+  - name: CSource2Server_ServerConVarChanged
+    alias:
+    - CSource2Server::ServerConVarChanged
+  - name: CSource2Server_Save
+    alias:
+    - CSource2Server::Save
+  - name: CSource2Server_Connect
+    alias:
+    - CSource2Server::Connect
+  - name: CSource2Server_PreShutdown
+    alias:
+    - CSource2Server::PreShutdown
+  - name: IAppSystem_Connect
+    alias:
+    - IAppSystem::Connect
+  - name: IAppSystem_PreShutdown
+    alias:
+    - IAppSystem::PreShutdown
+  - name: IVEngineServer2_ServerCommand
+    alias:
+    - IVEngineServer2::ServerCommand
+  - name: IVEngineServer2_IsDedicatedServer
+    alias:
+    - IVEngineServer2::IsDedicatedServer
+  - name: IVEngineServer2_GetServerGlobals
+    alias:
+    - IVEngineServer2::GetServerGlobals
+  - name: IVEngineServer2_GetAchievementMgr
+    alias:
+    - IVEngineServer2::GetAchievementMgr
+  - name: IVEngineServer2_IsLogEnabled
+    alias:
+    - IVEngineServer2::IsLogEnabled
+  - name: CSource2Server_Shutdown
+    alias:
+    - CSource2Server::Shutdown
+  - name: CGameEventManager_Shutdown
+    alias:
+    - CGameEventManager::Shutdown
+  - name: CLoopModeRegistry_UnregisterLoopModes
+    alias:
+    - CLoopModeRegistry::UnregisterLoopModes
+  - name: CEngineServiceRegistry_UnregisterEngineServices
+    alias:
+    - CEngineServiceRegistry::UnregisterEngineServices
+  - name: IEngineServiceMgr_UnregisterLoopMode
+    alias:
+    - IEngineServiceMgr::UnregisterLoopMode
+  - name: IEngineServiceMgr_UnregisterEngineService
+    alias:
+    - IEngineServiceMgr::UnregisterEngineService
+  - name: CSource2Server_GameFrame
+    alias:
+    - CSource2Server::GameFrame
+  - name: CGameEventManager_Init
+    alias:
+    - CGameEventManager::Init
+  - name: CTakeDamageInfo_HitGroupInfo
+    alias:
+    - CTakeDamageInfo::HitGroupInfo
+    - CTakeDamageInfo::HitGroup
+    - CTakeDamageInfo_HitGroup
+  - name: CEntitySystem_RegisterEntityClass
+    alias:
+    - CEntitySystem::RegisterEntityClass
+  - name: CEntitySystem_CreateEntityByName
+    alias:
+    - CEntitySystem::CreateEntityByName
+  - name: CEntitySystem_CreateEntity
+    alias:
+    - CEntitySystem::CreateEntity
+  - name: CEntitySystem_AddEntityToEntityDataBase
+    alias:
+    - CEntitySystem::AddEntityToEntityDataBase
+  - name: CEntitySystem_OnAddEntity
+    alias:
+    - CEntitySystem::OnAddEntity
+  - name: CEntitySystem_OnEntityParentChanged
+    alias:
+    - CEntitySystem::OnEntityParentChanged
+  - name: CEntitySystem_PrecacheEntity
+    alias:
+    - CEntitySystem::PrecacheEntity
+  - name: CEntitySystem_InvokePrecacheCallback
+    alias:
+    - CEntitySystem::InvokePrecacheCallback
+  - name: CEntitySystem_DestroyEntity
+    alias:
+    - CEntitySystem::DestroyEntity
+  - name: CConcreteEntityList_AllocEntity
+    alias:
+    - CConcreteEntityList::AllocEntity
+  - name: CEntitySystem_ConstructEntity
+    alias:
+    - CEntitySystem::ConstructEntity
+  - name: CEntitySystem_DoConstructEntity
+    alias:
+    - CEntitySystem::DoConstructEntity
+  - name: CEntitySystem_GetSpawnGroupWorldId
+    alias:
+    - CEntitySystem::GetSpawnGroupWorldId
+  - name: CEntitySystem_FindClassByDesignName
+    alias:
+    - CEntitySystem::FindClassByDesignName
+  - name: CEntitySystem_m_EntityList
+    alias:
+    - CEntitySystem::m_EntityList
+  - name: CEntitySystem_m_entityNames
+    alias:
+    - CEntitySystem::m_entityNames
+  - name: CEntitySystem_m_entityComponentHelpers
+    alias:
+    - CEntitySystem::m_entityComponentHelpers
+  - name: CEntitySystem_m_DataDescKeyUnserializers
+    alias:
+    - CEntitySystem::m_DataDescKeyUnserializers
+  - name: CEntitySystem_m_EntityPostSpawnCallback
+    alias:
+    - CEntitySystem::m_EntityPostSpawnCallback
+  - name: CEntityIdentity_FreeAttributes
+    alias:
+    - CEntityIdentity::FreeAttributes
+  - name: CConcreteEntityList_FreeEntity
+    alias:
+    - CConcreteEntityList::FreeEntity
+  - name: UTIL_CreateEntityByName
+    alias:
+    - CreateEntityByName
+  - name: CBaseEntity_DispatchSpawn
+    alias:
+    - CBaseEntity::DispatchSpawn
+    - DispatchSpawn
+  - name: CEntitySystem_QueueSpawnEntity
+    alias:
+    - CEntitySystem::QueueSpawnEntity
+  - name: CEntitySystem_HelperExecuteQueuedSpawn
+    alias:
+    - CEntitySystem::HelperExecuteQueuedSpawn
+  - name: CEntitySystem_SortEntities
+    alias:
+    - CEntitySystem::SortEntities
+  - name: CGameEntitySystem_SortEntities
+    alias:
+    - CGameEntitySystem::SortEntities
+  - name: CEntitySystem_InstallCreationWrapperCallbacks
+    alias:
+    - CEntitySystem::InstallCreationWrapperCallbacks
+  - name: CEntitySystem_ExecuteQueuedCreation
+    alias:
+    - CEntitySystem::ExecuteQueuedCreation
+  - name: CEntitySystem_ExecuteQueuedActivates
+    alias:
+    - CEntitySystem::ExecuteQueuedActivates
+  - name: CEntitySystem_ExecuteQueuedPostDataUpdateAndActivates
+    alias:
+    - CEntitySystem::ExecuteQueuedPostDataUpdateAndActivates
+  - name: CEntitySystem_Activate
+    alias:
+    - CEntitySystem::Activate
+  - name: CEntitySystem_PostDataUpdate
+    alias:
+    - CEntitySystem::PostDataUpdate
+  - name: CBaseEntity_NetworkStateChangedLog
+    alias:
+    - CBaseEntity::NetworkStateChangedLog
+  - name: CBaseEntity_NetworkStateChanged
+    alias:
+    - CBaseEntity::NetworkStateChanged
+  - name: CBaseEntity_FullEdictChanged
+    alias:
+    - CBaseEntity::FullEdictChanged
+  - name: CBaseEntity_m_NetworkTransmitComponent
+    alias:
+    - CBaseEntity::m_NetworkTransmitComponent
+  - name: CNetworkTransmitComponent_StateChanged
+    alias:
+    - CNetworkTransmitComponent::StateChanged
+  - name: CNetworkTransmitComponent_m_nStateFlags
+    alias:
+    - CNetworkTransmitComponent::m_nStateFlags
+  - name: CInferno_InfernoThink
+    alias:
+    - CInferno::InfernoThink
+  - name: CPhysExplosion_Activate
+    alias:
+    - CPhysExplosion::Activate
+  - name: CPhysExplosion_Explode
+    alias:
+    - CPhysExplosion::Explode
+  - name: UTIL_SayTextFilter2
+    alias:
+    - UTIL_SayText2Filter
+  - name: CCSWeaponBase_ItemPostFrame_ProcessReloadAction
+    alias:
+    - CCSWeaponBase::ItemPostFrame::ProcessReloadAction
+  - name: CCSPlayer_WeaponServices_HandleDropWeapon
+    alias:
+    - CCSPlayer_WeaponServices::HandleDropWeapon
+  - name: CCSPlayer_UseServices_BumpWeapon
+    alias:
+    - CCSPlayer_UseServices::BumpWeapon
+  - name: CCSPlayerPawn_HandleDropWeapon
+    alias:
+    - CCSPlayerPawn::HandleDropWeapon
+  - name: CCSPlayerPawn_ClientCommand
+    alias:
+    - CCSPlayerPawn::ClientCommand
+  - name: CCSPlayerPawn_SprayPaint
+    alias:
+    - CCSPlayerPawn::SprayPaint
+  - name: CEntitySpawner_CPlayerSprayDecal_Spawn
+    alias:
+    - CEntitySpawner<CPlayerSprayDecal>::Spawn
+  - name: CEntityKeyValuesAllocator_GetTempBuffer
+    alias:
+    - CEntityKeyValuesAllocator::GetTempBuffer
+  - name: CEntityKeyValues_LoadFromContext
+    alias:
+    - CEntityKeyValues::LoadFromContext
+  - name: CEntityKeyValues_Initialized
+    alias:
+    - CEntityKeyValues::Initialized
+  - name: CEntitySystem_m_nEntityKeyValuesAllocatorRefCount
+    alias:
+    - CEntitySystem::m_nEntityKeyValuesAllocatorRefCount
+  - name: CEntitySystem_AddRefKeyValues
+    alias:
+    - CEntitySystem::AddRefKeyValues
+  - name: CEntitySystem_ReleaseKeyValues
+    alias:
+    - CEntitySystem::ReleaseKeyValues
+  - name: CCSPlayerController_HandleCommandDrop
+    alias:
+    - CCSPlayerController::HandleCommandDrop
+  - name: IGameSystem_InitAllSystems
+    alias:
+    - IGameSystem::InitAllSystems
+  - name: IGameSystem_LoopInitAllSystems
+    alias:
+    - IGameSystem::LoopInitAllSystems
+  - name: IGameSystem_LoopPostInitAllSystems
+    alias:
+    - IGameSystem::LoopPostInitAllSystems
+  - name: IGameSystem_PostInit
+    alias:
+    - IGameSystem::PostInit
+  - name: IGameSystemFactory_PostInit
+    alias:
+    - IGameSystemFactory::PostInit
+  - name: IGameSystemFactory_GetStaticGameSystem
+    alias:
+    - IGameSystemFactory::GetStaticGameSystem
+  - name: IGameSystem_InitAllSystems_pFirst
+    alias:
+    - IGameSystem::InitAllSystems::pFirst
+    - IGameSystem::InitAllSystems->pFirst
+  - name: IGameSystem_LoopPostInitAllSystems_pEventDispatcher
+    alias:
+    - IGameSystem::LoopPostInitAllSystems::pEventDispatcher
+    - IGameSystem::LoopPostInitAllSystems->pEventDispatcher
+  - name: IGameSystem_LoopDestroyAllSystems_s_GameSystems
+    alias:
+    - IGameSystem::LoopDestroyAllSystems::s_GameSystems
+    - IGameSystem::LoopDestroyAllSystems->s_GameSystems
+  - name: CSource2GameEntities_CheckTransmit
+    alias:
+    - CSource2GameEntities::CheckTransmit
+    - ISource2GameEntities::CheckTransmit
+    - ISource2GameEntities_CheckTransmit
+    - CheckTransmit
+  - name: CSource2GameEntities_ShouldClientReceiveStringTableUserData
+    alias:
+    - CSource2GameEntities::ShouldClientReceiveStringTableUserData
+    - ISource2GameEntities::ShouldClientReceiveStringTableUserData
+    - ISource2GameEntities_ShouldClientReceiveStringTableUserData
+    - ShouldClientReceiveStringTableUserData
+  - name: INetworkGameServer_IsBackgroundMap
+    alias:
+    - INetworkGameServer::IsBackgroundMap
+  - name: ILoopModeGameSharedState_IsBackgroundMap
+    alias:
+    - ILoopModeGameSharedState::IsBackgroundMap
+  - name: CNetworkGameServerBase_IsBackgroundMap
+    alias:
+    - CNetworkGameServerBase::IsBackgroundMap
+  - name: CBaseEntity_EmitSoundFilter
+    alias:
+    - CBaseEntity::EmitSoundFilter
+  - name: CBaseEntity_ScriptInputKill
+    alias:
+    - CBaseEntity::ScriptInputKill
+  - name: CBaseEntity_ScriptGetForward
+    alias:
+    - CBaseEntity::ScriptGetForward
+  - name: CBaseEntity_ScriptGetRight
+    alias:
+    - CBaseEntity::ScriptGetRight
+  - name: CBaseEntity_ScriptGetLeft
+    alias:
+    - CBaseEntity::ScriptGetLeft
+  - name: CBaseEntity_ScriptGetUp
+    alias:
+    - CBaseEntity::ScriptGetUp
+  - name: CBaseEntity_ScriptGetModelName
+    alias:
+    - CBaseEntity::ScriptGetModelName
+  - name: CBaseEntity_ScriptGetMoveParent
+    alias:
+    - CBaseEntity::ScriptGetMoveParent
+  - name: CBaseEntity_ScriptGetRootMoveParent
+    alias:
+    - CBaseEntity::ScriptGetRootMoveParent
+  - name: CBaseEntity_ScriptFirstMoveChild
+    alias:
+    - CBaseEntity::ScriptFirstMoveChild
+  - name: CBaseEntity_ScriptNextMovePeer
+    alias:
+    - CBaseEntity::ScriptNextMovePeer
+  - name: CBaseEntity_ScriptGetOwnerEntity
+    alias:
+    - CBaseEntity::ScriptGetOwnerEntity
+  - name: CBaseEntity_Script_GetChildren
+    alias:
+    - CBaseEntity::Script_GetChildren
+  - name: CBaseEntity_ScriptSetParent
+    alias:
+    - CBaseEntity::ScriptSetParent
+  - name: CBaseEntity_ScriptEyePosition
+    alias:
+    - CBaseEntity::ScriptEyePosition
+  - name: CBaseEntity_ScriptSetAngles
+    alias:
+    - CBaseEntity::ScriptSetAngles
+  - name: CBaseEntity_ScriptSetAbsAngles
+    alias:
+    - CBaseEntity::ScriptSetAbsAngles
+  - name: CBaseEntity_ScriptGetAngles
+    alias:
+    - CBaseEntity::ScriptGetAngles
+  - name: CBaseEntity_ScriptEyeAngles
+    alias:
+    - CBaseEntity::ScriptEyeAngles
+  - name: CBaseEntity_ScriptSetOrigin
+    alias:
+    - CBaseEntity::ScriptSetOrigin
+  - name: CBaseEntity_ScriptSetLocalAngles
+    alias:
+    - CBaseEntity::ScriptSetLocalAngles
+  - name: CBaseEntity_ScriptGetLocalAngles
+    alias:
+    - CBaseEntity::ScriptGetLocalAngles
+  - name: CBaseEntity_ScriptSetLocalOrigin
+    alias:
+    - CBaseEntity::ScriptSetLocalOrigin
+  - name: CBaseEntity_ScriptGetLocalOrigin
+    alias:
+    - CBaseEntity::ScriptGetLocalOrigin
+  - name: CBaseEntity_ScriptTransformPointEntityToWorld
+    alias:
+    - CBaseEntity::ScriptTransformPointEntityToWorld
+  - name: CBaseEntity_ScriptTransformPointWorldToEntity
+    alias:
+    - CBaseEntity::ScriptTransformPointWorldToEntity
+  - name: CBaseEntity_ScriptSetForward
+    alias:
+    - CBaseEntity::ScriptSetForward
+  - name: CBaseEntity_ScriptGetBoundingMins
+    alias:
+    - CBaseEntity::ScriptGetBoundingMins
+  - name: CBaseEntity_ScriptGetBoundingMaxs
+    alias:
+    - CBaseEntity::ScriptGetBoundingMaxs
+  - name: CBaseEntity_ScriptGetBounds
+    alias:
+    - CBaseEntity::ScriptGetBounds
+  - name: CBaseEntity_ScriptGetLocalAngularVelocity_OBSOLETE
+    alias:
+    - CBaseEntity::ScriptGetLocalAngularVelocity_OBSOLETE
+  - name: CBaseEntity_ScriptSetLocalAngularVelocity_OBSOLETE
+    alias:
+    - CBaseEntity::ScriptSetLocalAngularVelocity_OBSOLETE
+  - name: CBaseEntity_ScriptAddEffects
+    alias:
+    - CBaseEntity::ScriptAddEffects
+  - name: CBaseEntity_ScriptRemoveEffects
+    alias:
+    - CBaseEntity::ScriptRemoveEffects
+  - name: CBaseEntity_ScriptSetAttributeFloatValue
+    alias:
+    - CBaseEntity::ScriptSetAttributeFloatValue
+  - name: CBaseEntity_ScriptGetAttributeFloatValue
+    alias:
+    - CBaseEntity::ScriptGetAttributeFloatValue
+  - name: CBaseEntity_ScriptSetAttributeIntValue
+    alias:
+    - CBaseEntity::ScriptSetAttributeIntValue
+  - name: CBaseEntity_ScriptGetAttributeIntValue
+    alias:
+    - CBaseEntity::ScriptGetAttributeIntValue
+  - name: CBaseEntity_ScriptHasAttribute
+    alias:
+    - CBaseEntity::ScriptHasAttribute
+  - name: CBaseEntity_ScriptDeleteAttribute
+    alias:
+    - CBaseEntity::ScriptDeleteAttribute
+  - name: CBaseEntity_GetScriptOwnerEntity
+    alias:
+    - CBaseEntity::GetScriptOwnerEntity
+  - name: CBaseEntity_SetScriptOwnerEntity
+    alias:
+    - CBaseEntity::SetScriptOwnerEntity
+  - name: CBaseEntity_ScriptSetEntityName
+    alias:
+    - CBaseEntity::ScriptSetEntityName
+  - name: CBaseEntity_ScriptGetMass
+    alias:
+    - CBaseEntity::ScriptGetMass
+  - name: CBaseEntity_ScriptSetMass
+    alias:
+    - CBaseEntity::ScriptSetMass
+  - name: CBaseEntity_ScriptGetSpawnGroupHandle
+    alias:
+    - CBaseEntity::ScriptGetSpawnGroupHandle
+  - name: CBaseEntity_GetAbsAngles
+    alias:
+    - CBaseEntity::GetAbsAngles
+  - name: CBaseEntity_Script_GetTeamNumber
+    alias:
+    - CBaseEntity::Script_GetTeamNumber
+  - name: CBaseEntity_Script_FollowEntity
+    alias:
+    - CBaseEntity::Script_FollowEntity
+  - name: CBaseEntity_Script_FollowEntityMerge
+    alias:
+    - CBaseEntity::Script_FollowEntityMerge
+  - name: CBaseEntity_Script_Trigger
+    alias:
+    - CBaseEntity::Script_Trigger
+  - name: CBaseEntity_Script_SetContextThink
+    alias:
+    - CBaseEntity::Script_SetContextThink
+  - name: CBaseEntity_AddContextForScript
+    alias:
+    - CBaseEntity::AddContextForScript
+  - name: CBaseEntity_AddContextForScriptNumeric
+    alias:
+    - CBaseEntity::AddContextForScriptNumeric
+  - name: CBaseEntity_GetContextForScript
+    alias:
+    - CBaseEntity::GetContextForScript
+  - name: CBaseEntity_ScriptGatherCriteria
+    alias:
+    - CBaseEntity::ScriptGatherCriteria
+  - name: CBaseEntity_Script_TakeDamage
+    alias:
+    - CBaseEntity::Script_TakeDamage
+  - name: CBaseEntity_SetAbsVelocity
+    alias:
+    - CBaseEntity::SetAbsVelocity
+  - name: CBaseEntity_GetAbsVelocity
+    alias:
+    - CBaseEntity::GetAbsVelocity
+  - name: CBaseEntity_Script_ApplyLocalAngularVelocityImpulse
+    alias:
+    - CBaseEntity::Script_ApplyLocalAngularVelocityImpulse
+  - name: CBaseEntity_GetLocalAngularVelocity_OBSOLETE
+    alias:
+    - CBaseEntity::GetLocalAngularVelocity_OBSOLETE
+  - name: CBaseEntity_ScriptEmitSoundParams
+    alias:
+    - CBaseEntity::ScriptEmitSoundParams
+    - CBaseEntity::EmitSoundParams
+    - CBaseEntity_EmitSoundParams
+  - name: CBaseEntity_ScriptStopSound
+    alias:
+    - CBaseEntity::ScriptStopSound
+  - name: CBaseEntity_ScriptSoundDuration
+    alias:
+    - CBaseEntity::ScriptSoundDuration
+  - name: CBaseEntity_ScriptGetAbsOrigin
+    alias:
+    - CBaseEntity::ScriptGetAbsOrigin
+  - name: CBaseEntity_OnSetDormant
+    alias:
+    - CBaseEntity::OnSetDormant
+  - name: CBaseEntity_Precache
+    alias:
+    - CBaseEntity::Precache
+    - Precache
+  - name: CCSPlayerController_AddedToEntityDatabase
+    alias:
+    - CCSPlayerController::AddedToEntityDatabase
+  - name: CEnvEntityIgniter_Precache
+    alias:
+    - CEnvEntityIgniter::Precache
+  - name: CEnvShake_Spawn
+    alias:
+    - CEnvShake::Spawn
+  - name: CBaseEntity_SetMoveType
+    alias:
+    - CBaseEntity::SetMoveType
+  - name: CBasePlayerPawn_CommitSuicide
+    alias:
+    - CBasePlayerPawn::CommitSuicide
+    - CommitSuicide
+  - name: CBaseCombatCharacter_OnKilled
+    alias:
+    - CBaseCombatCharacter::OnKilled
+  - name: CCSPlayerPawn_Event_KilledOther
+    alias:
+    - CCSPlayerPawn::Event_KilledOther
+  - name: CCSPlayerPawn_Event_Killed
+    alias:
+    - CCSPlayerPawn::Event_Killed
+  - name: CBasePlayerPawn_Event_Killed
+    alias:
+    - CBasePlayerPawn::Event_Killed
+  - name: ScriptBinding_CSPlayerPawn_DestroyWeapon
+    alias:
+    - CSPlayerPawn::DestroyWeapon
+  - name: CBasePlayerPawn_RemovePlayerItem
+    alias:
+    - CBasePlayerPawn::RemovePlayerItem
+  - name: CBasePlayerPawn_DropActivePlayerWeapon
+    alias:
+    - CBasePlayerPawn::DropActivePlayerWeapon
+  - name: CBasePlayerPawn_GetEyePosition
+    alias:
+    - CBasePlayerPawn::GetEyePosition
+  - name: CBaseEntity_GetEyePosition
+    alias:
+    - CBaseEntity::GetEyePosition
+  - name: CCSBotManager_BotPlaceCommand
+    alias:
+    - CCSBotManager::BotPlace
+  - name: CBasePlayerPawn_EyeVectors
+    alias:
+    - CBasePlayerPawn::EyeVectors
+  - name: CBasePlayerPawn_GetEyeAngles
+    alias:
+    - CBasePlayerPawn::GetEyeAngles
+  - name: CBaseEntity_GetEyeAngles
+    alias:
+    - CBaseEntity::GetEyeAngles
+  - name: CCSBot_Upkeep
+    alias:
+    - CCSBot::Upkeep
+  - name: CCSBot_SetState
+    alias:
+    - CCSBot::SetState
+  - name: CCSBot_UpdatePathMovement
+    alias:
+    - CCSBot::UpdatePathMovement
+  - name: CCSBot_PrintIfWatched
+    alias:
+    - CCSBot::PrintIfWatched
+  - name: CHostage_Follow
+    alias:
+    - CHostage::Follow
+  - name: CHostage_DropHostage
+    alias:
+    - CHostage::DropHostage
+  - name: HideState_OnUpdate
+    alias:
+    - HideState::OnUpdate
+  - name: CCSBot_Attack
+    alias:
+    - CCSBot::Attack
+  - name: CCSBot_MoveTo
+    alias:
+    - CCSBot::MoveTo
+  - name: CCSBot_InhibitLookAround
+    alias:
+    - CCSBot::InhibitLookAround
+  - name: CCSBot_SetDisposition
+    alias:
+    - CCSBot::SetDisposition
+  - name: CCSBot_Idle
+    alias:
+    - CCSBot::Idle
+  - name: CCSBot_ComputePath
+    alias:
+    - CCSBot::ComputePath
+  - name: CBaseEntity_IsAlive
+    alias:
+    - CBaseEntity::IsAlive
+  - name: CBaseEntity_SetOwner
+    alias:
+    - CBaseEntity::SetOwner
+  - name: CBaseEntity_CollisionRulesChanged
+    alias:
+    - CBaseEntity::CollisionRulesChanged
+    - CollisionRulesChanged
+  - name: CBaseEntity_Use
+    alias:
+    - CBaseEntity::Use
+  - name: CGameSceneNode_PostSpawnKeyValues
+    alias:
+    - CGameSceneNode::PostSpawnKeyValues
+  - name: CBaseEntity_Spawn
+    alias:
+    - CBaseEntity::Spawn
+    - Spawn
+  - name: CBaseEntity_SpawnRadius
+    alias:
+    - CBaseEntity::SpawnRadius
+  - name: CCSPlayer_ItemServices_DropActivePlayerWeapon
+    alias:
+    - CCSPlayer_ItemServices::DropActivePlayerWeapon
+  - name: CCSPlayer_WeaponServices_DropWeapon
+    alias:
+    - CCSPlayer_WeaponServices::DropWeapon
+  - name: CBasePlayerWeapon_Shoot_Secondary
+    alias:
+    - CBasePlayerWeapon::Shoot_Secondary
+  - name: CCSPlayer_ItemServices_RemoveWeapons
+    alias:
+    - CCSPlayer_ItemServices::RemoveWeapons
+  - name: CCSPlayer_WeaponServices_SelectItem
+    alias:
+    - CCSPlayer_WeaponServices::SelectItem
+  - name: CEntFireOutputAutoCompletionFunctor_FireOutput
+    alias:
+    - CEntFireOutputAutoCompletionFunctor::FireOutput
+  - name: CEntityInstance_FindOutputsByName
+    alias:
+    - CEntityInstance::FindOutputsByName
+  - name: CEntityInstance_ScriptEntityIO
+    alias:
+    - CEntityInstance::ScriptEntityIO
+  - name: CEntityIOOutput_FireOutputInternal
+    alias:
+    - CEntityIOOutput::FireOutputInternal
+  - name: CEntitySystem_AddEntityIOEvent
+    alias:
+    - CEntitySystem::AddEntityIOEvent
+  - name: CEntitySystem_AddEntityIOEvent2
+    alias:
+    - CEntitySystem::AddEntityIOEvent2
+  - name: CEntitySystem_AddEntityIOEventBuildStruct
+    alias:
+    - CEntitySystem::AddEntityIOEventBuildStruct
+  - name: CEntitySystem_AddEntityIOEventToQueue
+    alias:
+    - CEntitySystem::AddEntityIOEventToQueue
+  - name: CEntitySystem_m_EventQueue
+    alias:
+    - CEntitySystem::m_EventQueue
+  - name: CGameEntitySystem_FindEntityByClassName
+    alias:
+    - CGameEntitySystem::FindEntityByClassName
+  - name: CGameEntitySystem_FindEntityByName
+    alias:
+    - CGameEntitySystem::FindEntityByName
+  - name: CChicken_Event_Killed
+    alias:
+    - CChicken::Event_Killed
+  - name: CBaseEntity_EmitSound
+    alias:
+    - CBaseEntity::EmitSound
+  - name: CBaseModelEntity_FindBone
+    alias:
+    - CBaseModelEntity::FindBone
+  - name: CGameEntitySystem_OnAddEntity
+    alias:
+    - CGameEntitySystem::OnAddEntity
+  - name: CGameEntitySystem_BuildResourceManifest_ManifestNameOrGroupName
+    alias:
+    - CGameEntitySystem::BuildResourceManifest_ManifestNameOrGroupName
+  - name: CGameEntitySystem_BuildResourceManifest_KeyValuesVectors
+    alias:
+    - CGameEntitySystem::BuildResourceManifest_KeyValuesVectors
+  - name: CGameEntitySystem_FindEntityProcedural
+    alias:
+    - CGameEntitySystem::FindEntityProcedural
+  - name: CGameEntitySystem_Spawn
+    alias:
+    - CGameEntitySystem::Spawn
+  - name: CEntitySystem_Spawn
+    alias:
+    - CEntitySystem::Spawn
+  - name: CBodyGameSystem_SpawnDependencyIsland
+    alias:
+    - CBodyGameSystem::SpawnDependencyIsland
+  - name: CGameEntitySystem_CheckGlobalState
+    alias:
+    - CGameEntitySystem::CheckGlobalState
+  - name: IGameSystem_OnBuildGameSessionManifest
+    alias:
+    - IGameSystem::BuildGameSessionManifest
+  - name: IGameSystem_OnServerPreEntityThink
+    alias:
+    - IGameSystem::OnServerPreEntityThink
+  - name: IGameSystem_OnServerPostEntityThink
+    alias:
+    - IGameSystem::OnServerPostEntityThink
+  - name: IGameSystem_OnServerPreClientUpdate
+    alias:
+    - IGameSystem::ServerPreClientUpdate
+  - name: IGameSystem_OnServerAdvanceTick
+    alias:
+    - IGameSystem::ServerAdvanceTick
+  - name: IGameSystem_OnServerGamePostSimulate
+    alias:
+    - IGameSystem::ServerGamePostSimulate
+  - name: IGameSystem_OnServerPostAdvanceTick
+    alias:
+    - IGameSystem::ServerPostAdvanceTick
+  - name: IGameSystem_OnServerPreBeginAsyncPostTickWork
+    alias:
+    - IGameSystem::OnServerPreBeginAsyncPostTickWork
+  - name: IGameSystem_OnServerBeginAsyncPostTickWork
+    alias:
+    - IGameSystem::OnServerBeginAsyncPostTickWork
+  - name: IGameSystem_OnServerPreEndAsyncPostTickWork
+    alias:
+    - IGameSystem::OnServerPreEndAsyncPostTickWork
+  - name: IGameSystem_OnServerPostEndAsyncPostTickWork
+    alias:
+    - IGameSystem::OnServerPostEndAsyncPostTickWork
+  - name: IGameSystem_OnSaveGame
+    alias:
+    - IGameSystem::OnSaveGame
+  - name: IGameSystem_OnRestoreGame
+    alias:
+    - IGameSystem::OnRestoreGame
+  - name: IGameSystem_OnOutOfGameFrameBoundary
+    alias:
+    - IGameSystem::OnOutOfGameFrameBoundary
+  - name: CSource2GameClients_StartHLTVServer
+    alias:
+    - CSource2GameClients::StartHLTVServer
+  - name: LegacyGameEventListener
+    alias:
+    - GetLegacyGameEventListener
+  - name: CPhysicsGameSystem_ProcessContactEvents
+    alias:
+    - CPhysicsGameSystem::ProcessContactEvents
+  - name: CBaseEntity_VPhysicsCollision
+    alias:
+    - CBaseEntity::VPhysicsCollision
+  - name: CBaseEntity_VPhysicsStartTouch
+    alias:
+    - CBaseEntity::VPhysicsStartTouch
+  - name: CBaseEntity_PhysicsTouch
+    alias:
+    - CBaseEntity::PhysicsTouch
+  - name: CBaseEntity_VPhysicsEndTouch
+    alias:
+    - CBaseEntity::VPhysicsEndTouch
+  - name: CBaseEntity_StartTouch
+    alias:
+    - CBaseEntity::StartTouch
+    - StartTouch
+  - name: CBaseEntity_Touch
+    alias:
+    - CBaseEntity::Touch
+    - Touch
+  - name: CBaseEntity_EndTouch
+    alias:
+    - CBaseEntity::EndTouch
+    - EndTouch
+  - name: IVPhys2World_GetTouchingList
+    alias:
+    - IVPhys2World::GetTouchingList
+    - CVPhys2World::GetTouchingList
+  - name: CTriggerPush_Touch
+    alias:
+    - CTriggerPush::Touch
+    - TriggerPush_Touch
+  - name: CPhysBox_Use
+    alias:
+    - CPhysBox::Use
+  - name: CBaseEntity_SetGroundEntity
+    alias:
+    - SetGroundEntity
+  - name: CBaseEntity_GetHammerUniqueId
+    alias:
+    - CBaseEntity::GetHammerUniqueId
+    - GetHammerUniqueId
+  - name: CBaseEntity_IsPlayerPawn
+    alias:
+    - CBaseEntity::IsPlayerPawn
+    - IsEntityPawn
+    - IsPlayerPawn
+  - name: CBaseEntity_IsPlayerController
+    alias:
+    - CBaseEntity::IsPlayerController
+    - IsEntityController
+    - IsPlayerController
+  - name: CBaseTrigger_StartTouch
+    alias:
+    - CBaseTrigger::StartTouch
+  - name: CBaseTrigger_EndTouch
+    alias:
+    - CBaseTrigger::EndTouch
+  - name: CBaseTrigger_PassesTriggerFilters
+    alias:
+    - CBaseTrigger::PassesTriggerFilters
+    - PassesTriggerFilters
+  - name: CBaseAnimGraph_GetAnimationController
+    alias:
+    - CBaseAnimGraph::GetAnimationController
+  - name: CBaseAnimGraph_m_skeletonInstance
+    alias:
+    - CBaseAnimGraph::m_skeletonInstance
+  - name: CGameSceneNode_PreInstanceSpawn
+    alias:
+    - CGameSceneNode::PreInstanceSpawn
+  - name: CGameSceneNode_GetSkeletonInstance
+    alias:
+    - CGameSceneNode::GetSkeletonInstance
+  - name: CSkeletonInstance_m_animationController
+    alias:
+    - CSkeletonInstance::m_animationController
+  - name: CSkeletonInstance_PostDataUpdate
+    alias:
+    - CSkeletonInstance::PostDataUpdate
+  - name: CGameSceneNode_PostDataUpdate
+    alias:
+    - CGameSceneNode::PostDataUpdate
+  - name: CGameSceneNode_UpdateEntityForHierarchyChange
+    alias:
+    - CGameSceneNode::UpdateEntityForHierarchyChange
+  - name: CPointTeleportAPI_TeleportEntityInternal
+    alias:
+    - CPointTeleportAPI::TeleportEntityInternal
+  - name: CBaseEntity_Teleport
+    alias:
+    - CBaseEntity::Teleport
+  - name: CPointTeleport_Activate
+    alias:
+    - CPointTeleport::Activate
+  - name: CBaseEntity_Activate
+    alias:
+    - CBaseEntity::Activate
+    - Activate
+  - name: CBaseEntity_DrawDebugTextOverlays
+    alias:
+    - CBaseEntity::DrawDebugTextOverlays
+  - name: CRagdollProp_DrawEntityDebugOverlays
+    alias:
+    - CRagdollProp::DrawEntityDebugOverlays
+  - name: CBaseEntity_ReloadPrivateScripts
+    alias:
+    - CBaseEntity::ReloadPrivateScripts
+  - name: CCheckTransmitInfo_m_nPlayerSlot
+    alias:
+    - CCheckTransmitInfo::m_nPlayerSlot
+    - CheckTransmitPlayerSlot
+  - name: CCheckTransmitInfo_m_bFullUpdate
+    alias:
+    - CCheckTransmitInfo::m_bFullUpdate
+  - name: CDedicatedServerWorkshopManager_SwitchToWorkshopMapGroup
+    alias:
+    - CDedicatedServerWorkshopManager::SwitchToWorkshopMapGroup
+  - name: IGameTypes_CreateWorkshopMapGroup
+    alias:
+    - IGameTypes::CreateWorkshopMapGroup
+  - name: CEngineServer_UnloadSpawnGroup
+    alias:
+    - CEngineServer::UnloadSpawnGroup
+  - name: INetworkServerService_SetGameSpawnGroupMgr
+    alias:
+    - INetworkServerService::SetGameSpawnGroupMgr
+  - name: INetworkServerService_AddServerPrerequisites
+    alias:
+    - INetworkServerService::AddServerPrerequisites
+  - name: INetworkServerService_SetFinalSimulationTickThisFrame
+    alias:
+    - INetworkServerService::SetFinalSimulationTickThisFrame
+  - name: CSpawnGroupMgrGameSystem_GetSpawnGroups
+    alias:
+    - CSpawnGroupMgrGameSystem::GetSpawnGroups
+    - GetSpawnGroups
+  - name: CSpawnGroupMgrGameSystem_DumpSpawnGroups
+    alias:
+    - CSpawnGroupMgrGameSystem::DumpSpawnGroups
+    - DumpSpawnGroups
+  - name: CSpawnGroupMgrGameSystem_SpawnGroupSpawnEntitiesInternal
+    alias:
+    - CSpawnGroupMgrGameSystem::SpawnGroupSpawnEntitiesInternal
+    - SpawnGroupSpawnEntitiesInternal
+  - name: IGameSystem_OnPreSpawnGroupLoad
+    alias:
+    - IGameSystem::OnPreSpawnGroupLoad
+  - name: IGameSystem_OnPostSpawnGroupLoad
+    alias:
+    - IGameSystem::OnPostSpawnGroupLoad
+  - name: CSpawnGroupMgrGameSystem_SpawnGroupShutdown
+    alias:
+    - CSpawnGroupMgrGameSystem::SpawnGroupShutdown
+    - SpawnGroupShutdown
+  - name: CSpawnGroupMgrGameSystem_SpawnGroupActuallyShutdown
+    alias:
+    - CSpawnGroupMgrGameSystem::SpawnGroupActuallyShutdown
+    - SpawnGroupActuallyShutdown
+  - name: IGameSystem_OnPreSpawnGroupUnload
+    alias:
+    - IGameSystem::OnPreSpawnGroupUnload
+  - name: IGameSystem_OnPostSpawnGroupUnload
+    alias:
+    - IGameSystem::OnPostSpawnGroupUnload
+  - name: CLoadingSpawnGroup_CreateEntityToSpawn
+    alias:
+    - CLoadingSpawnGroup::CreateEntityToSpawn
+  - name: CSpawnGroupMgrGameSystem_OnSpawnGroupPrecache
+    alias:
+    - CSpawnGroupMgrGameSystem::OnSpawnGroupPrecache
+    - SpawnGroupPrecache
+  - name: CSpawnGroupMgrGameSystem_AllocateSpawnGroup
+    alias:
+    - CSpawnGroupMgrGameSystem::AllocateSpawnGroup
+  - name: CSpawnGroupMgrGameSystem_ReleaseSpawnGroup
+    alias:
+    - CSpawnGroupMgrGameSystem::ReleaseSpawnGroup
+  - name: CSpawnGroupMgrGameSystem_SpawnGroupInit
+    alias:
+    - CSpawnGroupMgrGameSystem::SpawnGroupInit
+  - name: CSpawnGroupMgrGameSystem_CreateLoadingSpawnGroup
+    alias:
+    - CSpawnGroupMgrGameSystem::CreateLoadingSpawnGroup
+  - name: CSpawnGroupMgrGameSystem_CreateLoadingSpawnGroupForSaveFile
+    alias:
+    - CSpawnGroupMgrGameSystem::CreateLoadingSpawnGroupForSaveFile
+  - name: CSpawnGroupMgrGameSystem_SpawnGroupSpawnEntities
+    alias:
+    - CSpawnGroupMgrGameSystem::SpawnGroupSpawnEntities
+  - name: CSpawnGroupMgrGameSystem_SetActiveSpawnGroup
+    alias:
+    - CSpawnGroupMgrGameSystem::SetActiveSpawnGroup
+  - name: IVEngineServer2_MakeSpawnGroupActive
+    alias:
+    - IVEngineServer2::MakeSpawnGroupActive
+  - name: CSpawnGroupMgrGameSystem_UnloadSpawnGroup
+    alias:
+    - CSpawnGroupMgrGameSystem::UnloadSpawnGroup
+  - name: CSpawnGroupMgrGameSystem_SaveGame_Start
+    alias:
+    - CSpawnGroupMgrGameSystem::SaveGame_Start
+  - name: IGameSystem_OnSpawnGroupPrecache
+    alias:
+    - IGameSystem::OnSpawnGroupPrecache
+  - name: IGameSystem_OnSpawnGroupUncache
+    alias:
+    - IGameSystem::OnSpawnGroupUncache
+  - name: CBaseFilter_InputTestActivator
+    alias:
+    - CBaseFilter::InputTestActivator
+  - name: CGamePlayerEquip_InputTriggerForAllPlayers
+    alias:
+    - CGamePlayerEquip::InputTriggerForAllPlayers
+  - name: CGamePlayerEquip_InputTriggerForActivatedPlayer
+    alias:
+    - CGamePlayerEquip::InputTriggerForActivatedPlayer
+  - name: CNavMesh_GetNearestNavArea
+    alias:
+    - CNavMesh::GetNearestNavArea
+  - name: CCSBotManager_AddBot
+    alias:
+    - CCSBotManager::AddBot
+  - name: BotAdd_CommandHandler
+    alias:
+    - CCSBotManager::BotAddCommand
+  - name: BotKill_CommandHandler
+    alias:
+    - CCSBotManager::BotKillCommand
+  - name: EntInfo_CommandHandler
+    alias:
+    - CC_Ent_Info
+  - name: CEntitySystem_DestroyEntityImmediate
+    alias:
+    - CEntitySystem::DestroyEntityImmediate
+  - name: CEntitySystem_OnRemoveEntityFromDatabase
+    alias:
+    - CEntitySystem::OnRemoveEntityFromDatabase
+  - name: CEntitySystem_DoDestructEntity
+    alias:
+    - CEntitySystem::DoDestructEntity
+  - name: CEntitySystem_UpdateOnRemove
+    alias:
+    - CEntitySystem::UpdateOnRemove
+  - name: ClientPrintToController
+    alias:
+    - ClientPrint
+  - name: CCSBotManager_AddBot_BotNavIgnore
+    alias:
+    - BotNavIgnore
+  - name: CEnvHudHint_API_ShowHudHint
+    alias:
+    - CEnvHudHint_API::ShowHudHint
+  - name: UTIL_GetPlayerControllerForEntity
+    alias:
+    - UTIL_GetPlayerControllerForEntity
+  - name: CEntitySystem_ctor
+    alias:
+    - CEntitySystem::CEntitySystem
+  - name: CGameEntitySystem_ctor
+    alias:
+    - CGameEntitySystem::CGameEntitySystem
+  - name: CEntitySystem_RegisterAccessor
+    alias:
+    - CEntitySystem::RegisterAccessor
+  - name: CEntitySystem_Init
+    alias:
+    - CEntitySystem::Init
+  - name: CEntitySystem_ProcessEntityRegistration
+    alias:
+    - CEntitySystem::ProcessEntityRegistration
+  - name: CEntitySystem_PostCreateEntitySystem
+    alias:
+    - CEntitySystem::PostCreateEntitySystem
+  - name: CSource2EntitySystem_StaticInit
+    alias:
+    - CSource2EntitySystem::StaticInit
+  - name: CSpawnGroupEntityFilterRegistrar_RegisterSpawnGroupEntityFilters
+    alias:
+    - CSpawnGroupEntityFilterRegistrar::RegisterSpawnGroupEntityFilters
+  - name: CGameEntitySystem_m_spawnGroupEntityFilters
+    alias:
+    - CGameEntitySystem::m_spawnGroupEntityFilters
+  - name: CGameEntitySystem_m_pEntity2Networkables
+    alias:
+    - CGameEntitySystem::m_pEntity2Networkables
+  - name: CEntity2NetworkClasses_ServerClass_InitEntity2NetworkClasses
+    alias:
+    - CEntity2NetworkClasses<ServerClass>::InitEntity2NetworkClasses
+  - name: CEntitySystem_m_Symbols
+    alias:
+    - CEntitySystem::m_Symbols
+  - name: CEntitySystem_m_pNetworkFieldChangedEventQueue
+    alias:
+    - CEntitySystem::m_pNetworkFieldChangedEventQueue
+  - name: CEntitySystem_m_pNetworkFieldScratchData
+    alias:
+    - CEntitySystem::m_pNetworkFieldScratchData
+  - name: CEntitySystem_m_pFieldChangeLimitSpew
+    alias:
+    - CEntitySystem::m_pFieldChangeLimitSpew
+  - name: CEntitySystem_m_ComponentUnserializerInfoAllocator
+    alias:
+    - CEntitySystem::m_ComponentUnserializerInfoAllocator
+  - name: CEntitySystem_m_EntityMaterialAttributes
+    alias:
+    - CEntitySystem::m_EntityMaterialAttributes
+  - name: CEntitySystem_m_flChangeCallbackSpewThreshold
+    alias:
+    - CEntitySystem::m_flChangeCallbackSpewThreshold
+  - name: CEntitySystem_ClearEntityDatabase
+    alias:
+    - CEntitySystem::ClearEntityDatabase
+  - name: INetworkMessages_SetNetworkSerializationContextData
+    alias:
+    - INetworkMessages::SetNetworkSerializationContextData
+  - name: CFlattenedSerializers_CreateFieldChangedEventQueue
+    alias:
+    - CFlattenedSerializers::CreateFieldChangedEventQueue
+  - name: INetworkMessages_RegisterSchemaTypeOverride
+    alias:
+    - INetworkMessages::RegisterSchemaTypeOverride
+  - name: CSceneEntity_GetScriptDesc
+    alias:
+    - CSceneEntity::GetScriptDesc
+  - name: CEntityInstance_GetScriptDesc
+    alias:
+    - CEntityInstance::GetScriptDesc
+  - name: CEntityInstance_Spawn
+    alias:
+    - CEntityInstance::Spawn
+  - name: CEntityInstance_Activate
+    alias:
+    - CEntityInstance::Activate
+  - name: CEntityInstance_Precache
+    alias:
+    - CEntityInstance::Precache
+  - name: CEntityInstance_GetDataDescMap
+    alias:
+    - CEntityInstance::GetDataDescMap
+  - name: CEntityInstance_ReloadPrivateScripts
+    alias:
+    - CEntityInstance::ReloadPrivateScripts
+  - name: CEntityInstance_ValidatePrivateScriptScope
+    alias:
+    - CEntityInstance::ValidatePrivateScriptScope
+  - name: CEntityInstance_NetworkStateChanged
+    alias:
+    - CEntityInstance::NetworkStateChanged
+  - name: CEntityInstance_FullEdictChanged
+    alias:
+    - CEntityInstance::FullEdictChanged
+  - name: CEntityInstance_NetworkUpdateState
+    alias:
+    - CEntityInstance::NetworkUpdateState
+  - name: CEntityInstance_NetworkStateChangedLog
+    alias:
+    - CEntityInstance::NetworkStateChangedLog
+  - name: CEntityInstance_DrawDebugTextOverlays
+    alias:
+    - CEntityInstance::DrawDebugTextOverlays
+  - name: CEntityInstance_DrawEntityDebugOverlays
+    alias:
+    - CEntityInstance::DrawEntityDebugOverlays
+  - name: CEntityInstance_PostDataUpdateDelta
+    alias:
+    - CEntityInstance::PostDataUpdateDelta
+  - name: CEntityInstance_PreDataUpdate
+    alias:
+    - CEntityInstance::PreDataUpdate
+  - name: CEntityInstance_PostDataUpdate
+    alias:
+    - CEntityInstance::PostDataUpdate
+  - name: CEntityInstance_PostDataUpdatePreserve
+    alias:
+    - CEntityInstance::PostDataUpdatePreserve
+  - name: CEntityInstance_Connect
+    alias:
+    - CEntityInstance::Connect
+  - name: CEntityInstance_UpdateOnRemove
+    alias:
+    - CEntityInstance::UpdateOnRemove
+  - name: CEntityInstance_Disconnect
+    alias:
+    - CEntityInstance::Disconnect
+  - name: CEntityInstance_AddedToEntityDatabase
+    alias:
+    - CEntityInstance::AddedToEntityDatabase
+  - name: CEntityInstance_OnSetDormant
+    alias:
+    - CEntityInstance::OnSetDormant
+  - name: CEntityInstance_Schema_DynamicBinding
+    alias:
+    - CEntityInstance::Schema_DynamicBinding
+  - name: CEntitySystem_OnRemoveEntity
+    alias:
+    - CEntitySystem::OnRemoveEntity
+  - name: CEntityComponentHelperT_Free
+    alias:
+    - CEntityComponentHelperT::Free
+  - name: CScriptedSequence_SynchronizeSequence
+    alias:
+    - CScriptedSequence::SynchronizeSequence
+  - name: CNetworkUtlVectorEmbedded_NetworkStateChanged_m_vecRenderAttributes
+    alias:
+    - CNetworkUtlVectorEmbedded<CRenderAttribute>::NetworkStateChanged_m_vecRenderAttributes
+  - name: CNetworkUtlVectorEmbedded_NetworkStateChanged_m_perRoundStats
+    alias:
+    - CNetworkUtlVectorEmbedded<CSPerRoundStats_t>::NetworkStateChanged_m_perRoundStats
+  - name: CUtlVectorEmbeddedNetworkVar_CSPerRoundStats_t_NetworkVar_m_perRoundStats_SetCount
+    alias:
+    - CUtlVectorEmbeddedNetworkVar<CSPerRoundStats_t, NetworkVar>::SetCount
+  - name: CNetworkUtlVectorEmbedded_TryLateResolve_m_vecRenderAttributes
+    alias:
+    - CNetworkUtlVectorEmbedded<CRenderAttribute>::TryLateResolve
+  - name: INetworkMessages_GetLoggingChannel
+    alias:
+    - INetworkMessages::GetLoggingChannel
+  - name: CPhysicsEntitySolver_PhysEnableEntityCollisions
+    alias:
+    - CPhysicsEntitySolver::PhysEnableEntityCollisions
+  - name: CLoopModeGame_StaticInit
+    alias:
+    - CLoopModeGame::StaticInit
+  - name: CLoopModeGame_ctor
+    alias:
+    - CLoopModeGame::CLoopModeGame
+  - name: CLoopModeFactory_CLoopModeGame_Init
+    alias:
+    - CLoopModeFactory<CLoopModeGame>::Init
+  - name: CLoopModeFactory_CLoopModeGame_CreateLoopMode
+    alias:
+    - CLoopModeFactory<CLoopModeGame>::CreateLoopMode
+  - name: CLoopModeFactory_CLoopModeGame_Shutdown
+    alias:
+    - CLoopModeFactory<CLoopModeGame>::Shutdown
+  - name: CLoopModeGame_OnLoopActivate
+    alias:
+    - CLoopModeGame::OnLoopActivate
+  - name: ILoopMode_OnLoopActivate
+    alias:
+    - ILoopMode::OnLoopActivate
+  - name: CLoopModeGame_AddViewsToSceneSystem
+    alias:
+    - CLoopModeGame::AddViewsToSceneSystem
+  - name: ILoopMode_AddViewsToSceneSystem
+    alias:
+    - ILoopMode::AddViewsToSceneSystem
+  - name: CLoopModeGame_LoopInitInternal
+    alias:
+    - CLoopModeGame::LoopInitInternal
+  - name: CLoopModeGame_LoopInit
+    alias:
+    - CLoopModeGame::LoopInit
+  - name: ILoopMode_LoopInit
+    alias:
+    - ILoopMode::LoopInit
+  - name: ILoopMode_LoopShutdown
+    alias:
+    - ILoopMode::LoopShutdown
+  - name: CLoopModeGame_RegisterEventMapInternal
+    alias:
+    - CLoopModeGame::RegisterEventMapInternal
+  - name: CLoopModeGame_RegisterEventMap
+    alias:
+    - CLoopModeGame::RegisterEventMap
+  - name: CLoopModeGame_dtor
+    alias:
+    - CLoopModeGame::~CLoopModeGame
+  - name: CLoopModeGame_OnServerAdvanceTick
+    alias:
+    - CLoopModeGame::OnServerAdvanceTick
+  - name: CLoopModeGame_OnServerBeginSimulate
+    alias:
+    - CLoopModeGame::OnServerBeginSimulate
+  - name: CLoopModeGame_OnServerPostSimulate
+    alias:
+    - CLoopModeGame::OnServerPostSimulate
+  - name: CLoopModeGame_OnServerPostAdvanceTick
+    alias:
+    - CLoopModeGame::OnServerPostAdvanceTick
+  - name: CLoopModeGame_OnServerBeginAsyncPostTickWork
+    alias:
+    - CLoopModeGame::OnServerBeginAsyncPostTickWork
+  - name: CLoopModeGame_OnServerEndAsyncPostTickWork
+    alias:
+    - CLoopModeGame::OnServerEndAsyncPostTickWork
+  - name: CLoopModeGame_OnFrameBoundary
+    alias:
+    - CLoopModeGame::OnFrameBoundary
+  - name: CLoopModeGame_ReceivedServerInfo
+    alias:
+    - CLoopModeGame::ReceivedServerInfo
+  - name: CLoopModeGame_SetWorldSession
+    alias:
+    - CLoopModeGame::SetWorldSession
+  - name: CLoopModeGame_SetGameSystemState
+    alias:
+    - CLoopModeGame::SetGameSystemState
+  - name: IGameSystem_DestroyAllGameSystems
+    alias:
+    - IGameSystem::DestroyAllGameSystems
+  - name: IGameSystem_ShutdownAllSystems
+    alias:
+    - IGameSystem::ShutdownAllSystems
+  - name: IGameSystem_LoopDestroyAllSystems
+    alias:
+    - IGameSystem::LoopDestroyAllSystems
+  - name: IGameSystem_LoopPreShutdownAllSystems
+    alias:
+    - IGameSystem::LoopPreShutdownAllSystems
+  - name: CLoopModeGame_Shutdown
+    alias:
+    - CLoopModeGame::Shutdown
+  - name: CLoopModeGame_LoopShutdown
+    alias:
+    - CLoopModeGame::LoopShutdown
+  - name: CLoopModeGame_ShutdownServer
+    alias:
+    - CLoopModeGame::ShutdownServer
+  - name: CLoopModeGame_OnLoopDeactivate
+    alias:
+    - CLoopModeGame::OnLoopDeactivate
+  - name: ILoopMode_OnLoopDeactivate
+    alias:
+    - ILoopMode::OnLoopDeactivate
+  - name: CPlayerCommandQueue_ctor
+    alias:
+    - CPlayerCommandQueue::CPlayerCommandQueue
+  - name: CBasePlayerController_IsFakeClient
+    alias:
+    - CBasePlayerController::IsFakeClient
+    - IsFakeClient
+  - name: INetworkGameServer_GetClientConnectionType
+    alias:
+    - INetworkGameServer::GetClientConnectionType
+  - name: IGameResourceService_SetEntityResourceManifestHandler
+    alias:
+    - IGameResourceService::SetEntityResourceManifestHandler
+  - name: CNetworkSerializerBindingBuildFilter_GetFieldPriority
+    alias:
+    - CNetworkSerializerBindingBuildFilter::GetFieldPriority
+  - name: CEntitySystem_FindComponentTypeByName
+    alias:
+    - CEntitySystem::FindComponentTypeByName
+- name: networksystem
+  symbols:
+  - name: INetworkMessages_GetFieldChangeCallbackOrderCount
+    alias:
+    - INetworkMessages::GetFieldChangeCallbackOrderCount
+  - name: INetworkMessages_GetFieldChangeCallbackPriorities
+    alias:
+    - INetworkMessages::GetFieldChangeCallbackPriorities

--- a/memory/gamesymbol_metadata.md
+++ b/memory/gamesymbol_metadata.md
@@ -1,0 +1,63 @@
+---
+title: gamesymbol_metadata
+type: note
+permalink: cs2-vibesignatures/gamesymbol-metadata
+---
+
+# gamesymbols/<GAMEVER>.metadata.yaml — field scope decision
+
+## Decision
+
+When releasing `gamesymbols/<GAMEVER>.yaml`, also emit a bound, immutable
+`gamesymbols/<GAMEVER>.metadata.yaml` (or `.json`) carrying the subset of
+`configs/<GAMEVER>.yaml` fields that are **present in config, absent from the
+snapshot, and actually consumed by the pages app**.
+
+Field-scope rule: include a config field in metadata IFF it is all three of
+
+1. present in `configs/<GAMEVER>.yaml`, AND
+2. NOT already in `gamesymbols/<GAMEVER>.yaml`, AND
+3. consumed by `pages/` at build time.
+
+## Scan result (current state)
+
+Pages consumes exactly one thing from config: the **alias map**
+(`module/symbol -> alias[]`). No other config field reaches the pages app.
+
+Full config -> pages data path:
+
+- `pages/gameSymbolsPlugin.ts` `loadDataset` reads `configs/<GAMEVER>.yaml`
+  and calls `buildConfigAliasIndex`.
+- `buildConfigAliasIndex` (gameSymbolsPlugin.ts:98) reads only
+  `modules[].name`, `modules[].symbols[].name`, and `modules[].symbols[].alias`;
+  it emits `ConfigAliasIndex { aliases: Map<"module/name", string[]> }`.
+- `attachAliasesToDataset` (gameSymbolsPlugin.ts:127) writes those into
+  `record.aliases`.
+- Frontend `GameSymbolRecord.aliases` (pages/src/features/symbols/types.ts:37)
+  is the only config-sourced record field; every other record field
+  (id / module / artifact / symbolName / platform / kind / payload) comes from
+  `normalizeGameSymbolSnapshot`.
+
+Config fields NOT consumed by pages (thus excluded from metadata): `skills`,
+`path_windows`, `path_linux`, `category`, `struct`, `member`, `cpp_tests`,
+`description`, `expected_input`, `expected_output`, `max_retries`, `prerequisite`.
+
+## Companion decisions
+
+- **Metadata is NOT listed in `index.json`.** It is a build-time join input
+  only; after the join the aliases live inside the snapshot asset
+  (`gamesymbols/<ver>.<sha>.json`), so the frontend index needs no awareness of
+  metadata.
+- Metadata is emitted alongside the snapshot during release build
+  (trigger-release-build) from `--analysis-config`, and freezes together with
+  the snapshot. Config's everyday PR edits (`feat(preprocessor): add ...`) do
+  not retroactively touch a published snapshot/metadata.
+- The release allow-list (`build-on-self-runner.yml`, `$allowedSnapshot`
+  check) must be extended to admit the metadata path, otherwise publication is
+  rejected.
+
+## Publishing model reminder
+
+`gamesymbols/<GAMEVER>.yaml` is generated only on release build and overwritten
+per release; `configs/<GAMEVER>.yaml` iterates freely between releases.
+Metadata follows the snapshot's release/freeze cadence, not the config's.

--- a/memory/gamesymbol_metadata.md
+++ b/memory/gamesymbol_metadata.md
@@ -55,6 +55,9 @@ Config fields NOT consumed by pages (thus excluded from metadata): `skills`,
 - The release allow-list (`build-on-self-runner.yml`, `$allowedSnapshot`
   check) must be extended to admit the metadata path, otherwise publication is
   rejected.
+- The release tracked-output inventory includes and requires the metadata path,
+  so staging, output-PR validation, and promotion bind its exact bytes together
+  with the snapshot and versioned gamedata.
 
 ## Publishing model reminder
 

--- a/pages/gameSymbolsPlugin.ts
+++ b/pages/gameSymbolsPlugin.ts
@@ -81,8 +81,8 @@ export interface EncodedGameSymbolAsset {
 interface CachedDataset {
   mtimeMs: number
   size: number
-  configMtimeMs: number
-  configSize: number
+  metadataMtimeMs: number
+  metadataSize: number
   dataset: GameSymbolDataset
 }
 
@@ -321,7 +321,7 @@ export function createGameSymbolIndex(assets: EncodedGameSymbolAsset[]): GameSym
   }
 }
 
-export function gameSymbolsPlugin(symbolsDirectory: string, configsDirectory?: string): Plugin {
+export function gameSymbolsPlugin(symbolsDirectory: string): Plugin {
   const cache = new Map<string, CachedDataset>()
 
   async function snapshotFiles(): Promise<string[]> {
@@ -336,41 +336,39 @@ export function gameSymbolsPlugin(symbolsDirectory: string, configsDirectory?: s
     const fileName = basename(filePath)
     const match = SNAPSHOT_FILE_PATTERN.exec(fileName)
     if (!match) throw new Error(`Invalid gamesymbol snapshot filename: ${fileName}`)
-    const configPath = configsDirectory ? join(configsDirectory, `${match[1]}.yaml`) : undefined
+    const metadataPath = join(symbolsDirectory, `${match[1]}.metadata.yaml`)
 
-    let configStat = { mtimeMs: 0, size: 0 }
-    if (configPath) {
-      try {
-        const cs = await stat(configPath)
-        configStat = { mtimeMs: cs.mtimeMs, size: cs.size }
-      } catch {
-        configStat = { mtimeMs: 0, size: 0 }
-      }
+    let metadataStat = { mtimeMs: 0, size: 0 }
+    try {
+      const ms = await stat(metadataPath)
+      metadataStat = { mtimeMs: ms.mtimeMs, size: ms.size }
+    } catch {
+      metadataStat = { mtimeMs: 0, size: 0 }
     }
 
     const cached = cache.get(filePath)
     if (
       cached?.mtimeMs === fileStat.mtimeMs && cached.size === fileStat.size
-      && cached.configMtimeMs === configStat.mtimeMs && cached.configSize === configStat.size
+      && cached.metadataMtimeMs === metadataStat.mtimeMs && cached.metadataSize === metadataStat.size
     ) return cached.dataset
 
     const raw = parse(await readFile(filePath, 'utf8')) as unknown
     let dataset = normalizeGameSymbolSnapshot(raw, match[1], filePath)
 
-    if (configPath && (configStat.mtimeMs !== 0 || configStat.size !== 0)) {
+    if (metadataStat.mtimeMs !== 0 || metadataStat.size !== 0) {
       try {
-        const configRaw = parse(await readFile(configPath, 'utf8')) as unknown
-        dataset = attachAliasesToDataset(dataset, buildConfigAliasIndex(configRaw, configPath))
+        const metadataRaw = parse(await readFile(metadataPath, 'utf8')) as unknown
+        dataset = attachAliasesToDataset(dataset, buildConfigAliasIndex(metadataRaw, metadataPath))
       } catch {
-        // config missing/invalid is non-fatal: keep unaliased dataset
+        // metadata missing/invalid is non-fatal: keep unaliased dataset
       }
     }
 
     cache.set(filePath, {
       mtimeMs: fileStat.mtimeMs,
       size: fileStat.size,
-      configMtimeMs: configStat.mtimeMs,
-      configSize: configStat.size,
+      metadataMtimeMs: metadataStat.mtimeMs,
+      metadataSize: metadataStat.size,
       dataset,
     })
     return dataset
@@ -400,7 +398,6 @@ export function gameSymbolsPlugin(symbolsDirectory: string, configsDirectory?: s
     name: 'gamesymbol-assets',
     configureServer(server) {
       server.watcher.add(symbolsDirectory)
-      if (configsDirectory) server.watcher.add(configsDirectory)
       server.middlewares.use(async (request, response, next) => {
         const pathname = new URL(request.url ?? '/', 'http://localhost').pathname
         if (pathname.endsWith('/gamesymbols/index.json')) {
@@ -433,12 +430,10 @@ export function gameSymbolsPlugin(symbolsDirectory: string, configsDirectory?: s
     async buildStart() {
       const files = await snapshotFiles()
       files.forEach((filePath) => this.addWatchFile(filePath))
-      if (configsDirectory) {
-        files.forEach((filePath) => {
-          const match = SNAPSHOT_FILE_PATTERN.exec(basename(filePath))
-          if (match) this.addWatchFile(join(configsDirectory, `${match[1]}.yaml`))
-        })
-      }
+      files.forEach((filePath) => {
+        const match = SNAPSHOT_FILE_PATTERN.exec(basename(filePath))
+        if (match) this.addWatchFile(join(symbolsDirectory, `${match[1]}.metadata.yaml`))
+      })
     },
     async generateBundle() {
       const files = await snapshotFiles()

--- a/pages/vite.config.ts
+++ b/pages/vite.config.ts
@@ -5,6 +5,6 @@ import { gameSymbolsPlugin } from './gameSymbolsPlugin'
 
 // https://vite.dev/config/
 export default defineConfig({
-  plugins: [react(), gameSymbolsPlugin(fileURLToPath(new URL('../gamesymbols', import.meta.url)), fileURLToPath(new URL('../configs', import.meta.url)))],
+  plugins: [react(), gameSymbolsPlugin(fileURLToPath(new URL('../gamesymbols', import.meta.url)))],
   base: '/CS2_VibeSignatures/',
 })

--- a/pr_validation_version.py
+++ b/pr_validation_version.py
@@ -13,7 +13,7 @@ from pathlib import Path, PurePosixPath
 from trusted_yaml import load_yaml_file
 
 
-SNAPSHOT_PATTERN = re.compile(r"^gamesymbols/[^/]+\.yaml$")
+SNAPSHOT_PATTERN = re.compile(r"^gamesymbols/\d{4,10}[a-z]?\.yaml$")
 SHA_PATTERN = re.compile(r"^[0-9a-fA-F]{40}$")
 
 

--- a/pr_validation_version.py
+++ b/pr_validation_version.py
@@ -99,7 +99,7 @@ def resolve_validation_selection(repo_root: Path, base_ref: str) -> ValidationSe
     if len(tracked) > 1 and f"gamesymbols/{pr_gamever}.yaml" not in tracked:
         latest_change = _git_lines(
             repo_root,
-            ["log", "-1", "--format=%H", "--name-only", "--first-parent", base_ref, "--", "gamesymbols"],
+            ["log", "-1", "--format=%H", "--name-only", "--first-parent", base_ref, "--", *tracked],
         )
         if len(latest_change) < 2 or not SHA_PATTERN.fullmatch(latest_change[0]):
             raise PrValidationVersionError("failed to locate the latest base snapshot publication")

--- a/release_workflow_lib/hashing.py
+++ b/release_workflow_lib/hashing.py
@@ -166,11 +166,14 @@ def _git_index_inventory(repo_root: Path, pathspecs: list[str]) -> list[dict]:
 def tracked_output_inventory(repo_root: Path, gamever: str) -> list[dict]:
     repo_root = Path(repo_root)
     snapshot = f"gamesymbols/{gamever}.yaml"
+    metadata = f"gamesymbols/{gamever}.metadata.yaml"
     gamedata = f"gamedata/{gamever}"
-    inventory = _git_index_inventory(repo_root, [snapshot, gamedata])
+    inventory = _git_index_inventory(repo_root, [snapshot, metadata, gamedata])
     paths = {item["path"] for item in inventory}
     if snapshot not in paths:
         raise ReleaseWorkflowError(f"required tracked output is missing from the Git index: {snapshot}")
+    if metadata not in paths:
+        raise ReleaseWorkflowError(f"required tracked output is missing from the Git index: {metadata}")
     if not any(path.startswith(gamedata + "/") for path in paths):
         raise ReleaseWorkflowError(f"required tracked output is missing from the Git index: {gamedata}")
     return inventory

--- a/release_workflow_lib/hashing.py
+++ b/release_workflow_lib/hashing.py
@@ -180,6 +180,7 @@ def allowed_output_path(path: str, gamever: str) -> bool:
     path = normalized_relative_path(path)
     return path in {
         f"gamesymbols/{gamever}.yaml",
+        f"gamesymbols/{gamever}.metadata.yaml",
         f"release-manifests/{gamever}.json",
     } or path.startswith(f"gamedata/{gamever}/")
 

--- a/tests/run_test_suite.py
+++ b/tests/run_test_suite.py
@@ -69,6 +69,7 @@ UNIT_MODULES = frozenset(
         "test_gamedata_candidate",
         "test_gamedata_utils",
         "test_gamesymbol_candidate",
+        "test_gamesymbol_metadata",
         "test_gamesymbol_pr_cli",
         "test_gamesymbol_pr_reference_validation",
         "test_gamesymbol_pr_validation",

--- a/tests/test_gamesymbol_metadata.py
+++ b/tests/test_gamesymbol_metadata.py
@@ -1,0 +1,108 @@
+import unittest
+from pathlib import Path
+from tempfile import TemporaryDirectory
+
+import yaml
+
+from gamesymbol_metadata import (
+    MetadataGenerationError,
+    extract_alias_subset,
+    generate_metadata,
+    normalize_alias_list,
+)
+
+
+class TestNormalizeAliasList(unittest.TestCase):
+    def test_none_is_empty(self) -> None:
+        self.assertEqual([], normalize_alias_list(None))
+
+    def test_string_becomes_single_element_list(self) -> None:
+        self.assertEqual(["Foo::Bar"], normalize_alias_list("Foo::Bar"))
+
+    def test_list_filters_non_strings_and_empty(self) -> None:
+        self.assertEqual(["a", "c"], normalize_alias_list(["a", "", 3, None, "c"]))
+
+    def test_non_list_non_string_is_empty(self) -> None:
+        self.assertEqual([], normalize_alias_list(42))
+
+
+class TestExtractAliasSubset(unittest.TestCase):
+    def test_extracts_only_aliased_symbols(self) -> None:
+        raw = {
+            "modules": [
+                {
+                    "name": "engine",
+                    "path_windows": "game/bin/win64/engine.dll",
+                    "skills": [{"name": "find-a"}],
+                    "symbols": [
+                        {"name": "FuncA", "category": "func", "alias": ["FuncA::Real"]},
+                        {"name": "FuncB", "category": "func"},
+                    ],
+                },
+                {"name": "no_symbols", "skills": [{"name": "find-b"}]},
+            ]
+        }
+        self.assertEqual(
+            {"modules": [{"name": "engine", "symbols": [{"name": "FuncA", "alias": ["FuncA::Real"]}]}]},
+            extract_alias_subset(raw),
+        )
+
+    def test_ignores_invalid_entries(self) -> None:
+        raw = {
+            "modules": [
+                {"name": ""},
+                "not-a-mapping",
+                {
+                    "name": "engine",
+                    "symbols": [{"name": "A", "alias": ["x"]}, {"name": ""}, "bad"],
+                },
+            ]
+        }
+        self.assertEqual(
+            {"modules": [{"name": "engine", "symbols": [{"name": "A", "alias": ["x"]}]}]},
+            extract_alias_subset(raw),
+        )
+
+    def test_missing_modules_is_empty(self) -> None:
+        self.assertEqual({"modules": []}, extract_alias_subset({}))
+
+    def test_string_alias_normalized_to_list(self) -> None:
+        raw = {"modules": [{"name": "m", "symbols": [{"name": "s", "alias": "SingleAlias"}]}]}
+        self.assertEqual(
+            {"modules": [{"name": "m", "symbols": [{"name": "s", "alias": ["SingleAlias"]}]}]},
+            extract_alias_subset(raw),
+        )
+
+
+class TestGenerateMetadata(unittest.TestCase):
+    def test_writes_parseable_metadata(self) -> None:
+        with TemporaryDirectory() as temp_dir:
+            root = Path(temp_dir)
+            config = root / "config.yaml"
+            config.write_text(
+                yaml.safe_dump(
+                    {"modules": [{"name": "engine", "symbols": [{"name": "FuncA", "alias": ["Real"]}]}]},
+                    sort_keys=False,
+                ),
+                encoding="utf-8",
+            )
+            output = root / "gamesymbols" / "1.metadata.yaml"
+            generate_metadata("1", config, output)
+            parsed = yaml.safe_load(output.read_text(encoding="utf-8"))
+            self.assertEqual(
+                {"modules": [{"name": "engine", "symbols": [{"name": "FuncA", "alias": ["Real"]}]}]},
+                parsed,
+            )
+
+    def test_rejects_non_mapping_config(self) -> None:
+        with TemporaryDirectory() as temp_dir:
+            root = Path(temp_dir)
+            config = root / "config.yaml"
+            config.write_text("- just\n- a\n- list\n", encoding="utf-8")
+            output = root / "1.metadata.yaml"
+            with self.assertRaises(MetadataGenerationError):
+                generate_metadata("1", config, output)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_pr_validation_version.py
+++ b/tests/test_pr_validation_version.py
@@ -70,7 +70,17 @@ class TestPrValidationVersion(unittest.TestCase):
         self.assertEqual("gamesymbols/14179.yaml", selection.base_snapshot_path)
         self.assertEqual("2" * 40, selection.base_snapshot_commit)
         self.assertEqual(
-            ["log", "-1", "--format=%H", "--name-only", "--first-parent", "3" * 40, "--", "gamesymbols"],
+            [
+                "log",
+                "-1",
+                "--format=%H",
+                "--name-only",
+                "--first-parent",
+                "3" * 40,
+                "--",
+                "gamesymbols/14178.yaml",
+                "gamesymbols/14179.yaml",
+            ],
             git_lines.call_args_list[1].args[1],
         )
         self.assertEqual(

--- a/tests/test_pr_validation_version.py
+++ b/tests/test_pr_validation_version.py
@@ -7,6 +7,10 @@ from pr_validation_version import PrValidationVersionError, select_validation_ga
 
 
 class TestPrValidationVersion(unittest.TestCase):
+    def test_snapshot_pattern_excludes_metadata_companion(self) -> None:
+        self.assertIsNotNone(pr_validation_version.SNAPSHOT_PATTERN.fullmatch("gamesymbols/14176.yaml"))
+        self.assertIsNone(pr_validation_version.SNAPSHOT_PATTERN.fullmatch("gamesymbols/14176.metadata.yaml"))
+
     def test_bootstrap_uses_pr_gamever(self) -> None:
         self.assertEqual("14180", select_validation_gamever("14180", [], []))
 

--- a/tests/test_release_workflow.py
+++ b/tests/test_release_workflow.py
@@ -490,6 +490,7 @@ class TestReleaseWorkflow(unittest.TestCase):
         validate_output_paths(
             [
                 "gamesymbols/14170.yaml",
+                "gamesymbols/14170.metadata.yaml",
                 "gamedata/14170/module/output.json",
                 "release-manifests/14170.json",
             ],

--- a/tests/test_release_workflow.py
+++ b/tests/test_release_workflow.py
@@ -53,6 +53,7 @@ class ReleaseFixture:
         self.bin_source = self.repo / "bin" / self.gamever
         self.candidate = root / "candidate.yaml"
         self.analysis_config = self.repo / "configs" / f"{self.gamever}.yaml"
+        self.metadata = self.repo / "gamesymbols" / f"{self.gamever}.metadata.yaml"
         self.gamedata_candidate_root = root / "gamedata-candidate"
         self.gamedata_session = self.gamedata_candidate_root / "session.json"
         (self.repo / "gamesymbols").mkdir(parents=True)
@@ -87,6 +88,7 @@ class ReleaseFixture:
             )
         )
         (self.repo / "gamesymbols" / f"{self.gamever}.yaml").write_bytes(snapshot)
+        self.metadata.write_text("modules: []\n", encoding="utf-8")
         self.candidate.write_bytes(snapshot)
         (generator / "gamedata.py").write_text(
             "from pathlib import Path\n"
@@ -454,6 +456,36 @@ class TestReleaseWorkflow(unittest.TestCase):
                     build_id=fixture.build_id,
                     pr_head_sha=fixture.head_sha,
                 )
+
+    def test_tampered_metadata_is_rejected_when_finalizing(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            fixture = ReleaseFixture(Path(tmp))
+            pending = fixture.stage()
+            metadata_path = fixture.metadata.relative_to(fixture.repo).as_posix()
+            self.assertIn(metadata_path, {item["path"] for item in pending["tracked_files"]})
+            fixture.metadata.write_text(
+                "modules:\n  - name: server\n    symbols:\n      - name: Test\n        alias: [Server::Test]\n",
+                encoding="utf-8",
+            )
+            fixture.git("add", "--", metadata_path)
+
+            with self.assertRaisesRegex(ReleaseWorkflowError, "tracked output manifest hash mismatch"):
+                finalize_stage(
+                    repo_root=fixture.repo,
+                    staging_root=fixture.staging,
+                    gamever=fixture.gamever,
+                    build_id=fixture.build_id,
+                    pr_head_sha=fixture.head_sha,
+                )
+
+    def test_stage_requires_metadata_in_git_index(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            fixture = ReleaseFixture(Path(tmp))
+            metadata_path = fixture.metadata.relative_to(fixture.repo).as_posix()
+            fixture.git("rm", "--cached", "--", metadata_path)
+
+            with self.assertRaisesRegex(ReleaseWorkflowError, f"required tracked output is missing.*{fixture.gamever}"):
+                fixture.stage()
 
     def test_untracked_other_version_is_excluded_from_tracked_manifest(self) -> None:
         with tempfile.TemporaryDirectory() as tmp:


### PR DESCRIPTION
## Summary

Emit an immutable `gamesymbols/<GAMEVER>.metadata.yaml` companion alongside each game-symbol snapshot during release. It carries the per-symbol alias map the Pages app consumes at build time, so Pages no longer reads `configs/<GAMEVER>.yaml`.

## Motivation

- `configs/<GAMEVER>.yaml` is the full IDA analysis config; Pages only consumed its `modules[].symbols[].alias` subset.
- Joining aliases from the live config at build time mixed a release-frozen snapshot with possibly newer config state, which could drift between releases.
- Freezing aliases into a release-time metadata companion keeps snapshot + aliases consistent and decouples Pages from `configs/**`.

## Changes

- **`gamesymbol_metadata.py`** (new): extracts the alias subset (`modules[].name` + `symbols[].name` + `symbols[].alias`) and writes the companion.
- **`build-on-self-runner.yml`**: emits metadata on publish and admits it through the release output allow-list.
- **`pages/gameSymbolsPlugin.ts` + `vite.config.ts`**: join aliases from `gamesymbols/<GAMEVER>.metadata.yaml` instead of `configs/<GAMEVER>.yaml`.
- **`deploy-pages.yml`**: drop `configs/**` from Pages trigger paths.
- **`pr_validation_version.py`**: exclude `*.metadata.yaml` from snapshot detection.
- **`release_workflow_lib/hashing.py`**: allow the metadata companion as a generated output path.
- **`promote-release-after-output-merge.yml`**: archive the metadata companion with the release.
- **Backfill**: generate metadata for all 12 existing snapshots (14167–14176).

## Validation

- Python suites: unit 1091, repository-contract 92, release-integration 45 — all pass.
- Pages: `npm test` (37), `npm run lint`, `npm run build` — all pass.
- Verified built Pages assets join aliases from metadata (e.g. `ISceneSystem_GetWorldsInfo` → `ISceneSystem::GetWorldsInfo`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)