### PR TITLE
feat(gamedata): add download button to gamedata viewer

### DIFF
--- a/pages/src/features/gamedata/ExploreGameDataPage.tsx
+++ b/pages/src/features/gamedata/ExploreGameDataPage.tsx
@@ -1,5 +1,6 @@
+import { DownloadOutlined } from '@ant-design/icons'
 import { useQuery } from '@tanstack/react-query'
-import { Alert, Card, Checkbox, Select, Space, Spin, Tag, Tooltip, Typography } from 'antd'
+import { Alert, Button, Card, Checkbox, Select, Space, Spin, Tag, Tooltip, Typography } from 'antd'
 import { useMemo, useState } from 'react'
 import { useTranslation } from 'react-i18next'
 import { getGameDataFile, getGameDataIndex, getGameDataMetadata } from './data'
@@ -52,6 +53,20 @@ export function ExploreGameDataPage() {
     if (file.metadata?.schemaVersion !== 2) setDiffEnabled(false)
   }
 
+  function downloadSelectedFile() {
+    if (!selectedFile || !fileQuery.data) return
+    const type = selectedFile.language === 'json' || selectedFile.language === 'jsonc' ? 'application/json' : 'text/plain'
+    const blob = new Blob([fileQuery.data], { type })
+    const url = URL.createObjectURL(blob)
+    const anchor = document.createElement('a')
+    anchor.href = url
+    anchor.download = selectedFile.fileName
+    document.body.appendChild(anchor)
+    anchor.click()
+    anchor.remove()
+    URL.revokeObjectURL(url)
+  }
+
   const diffControl = (
     <Checkbox
       checked={Boolean(diffEnabled && canDiff)}
@@ -101,6 +116,14 @@ export function ExploreGameDataPage() {
             className="gamedata-viewer-card"
             extra={selectedFile && (
               <Space wrap size="small">
+                <Button
+                  size="small"
+                  icon={<DownloadOutlined />}
+                  disabled={!fileQuery.data}
+                  onClick={downloadSelectedFile}
+                >
+                  {t('gamedata.download')}
+                </Button>
                 {selectedFile.metadata && (
                   <>
                     <Tag color="blue">{t('gamedata.coveredCount', {

--- a/pages/src/i18n/index.ts
+++ b/pages/src/i18n/index.ts
@@ -38,7 +38,7 @@ const resources = {
       },
       gamedata: {
         title: 'Game Data', subtitle: 'Browse generated plugin gamedata by game version and inspect our upstream changes.', gameVersion: 'Game version', versionMetadata: '{{count}} files · {{metadata}} with diff metadata',
-        treeTitle: 'Plugin files', viewerTitle: 'Gamedata viewer', viewDiff: 'View diff', coveredCount: '{{covered}} / {{total}} covered', updatedCount: '{{updated}} updated',
+        treeTitle: 'Plugin files', viewerTitle: 'Gamedata viewer', viewDiff: 'View diff', download: 'Download', coveredCount: '{{covered}} / {{total}} covered', updatedCount: '{{updated}} updated',
         coveredLegend: 'Covered by our snapshot', updatedLegend: 'Updated from upstream', noMetadata: 'This version or file has no schema-v2 diff metadata.', noFiles: 'No gamedata files in this version.',
         loading: 'Loading gamedata…', indexError: 'Unable to load the gamedata version index', fileError: 'Unable to load this gamedata file', metadataError: 'Unable to load diff metadata',
         unanchoredChanges: '{{count}} deleted changes have no line in the final file.', viewerAria: 'Read-only gamedata viewer for {{file}}',
@@ -76,7 +76,7 @@ const resources = {
       },
       gamedata: {
         title: '游戏数据', subtitle: '按游戏版本浏览各插件的 gamedata，并查看我们相对上游所做的修改。', gameVersion: '游戏版本', versionMetadata: '{{count}} 个文件 · {{metadata}} 个带 Diff 元数据',
-        treeTitle: '插件文件', viewerTitle: 'Gamedata 查看器', viewDiff: '查看 Diff', coveredCount: '覆盖 {{covered}} / {{total}}', updatedCount: '更新 {{updated}}',
+        treeTitle: '插件文件', viewerTitle: 'Gamedata 查看器', viewDiff: '查看 Diff', download: '下载', coveredCount: '覆盖 {{covered}} / {{total}}', updatedCount: '更新 {{updated}}',
         coveredLegend: '由我们的快照覆盖', updatedLegend: '相对上游已更新', noMetadata: '当前版本或文件没有 schema v2 Diff 元数据。', noFiles: '当前版本没有 gamedata 文件。',
         loading: '正在加载游戏数据…', indexError: '无法加载游戏数据版本索引', fileError: '无法加载当前 gamedata 文件', metadataError: '无法加载 Diff 元数据',
         unanchoredChanges: '{{count}} 个删除项在最终文件中没有可高亮行。', viewerAria: '{{file}} 的只读 gamedata 查看器',
@@ -114,7 +114,7 @@ const resources = {
       },
       gamedata: {
         title: '遊戲資料', subtitle: '依遊戲版本瀏覽各外掛的 gamedata，並查看我們相對上游所做的修改。', gameVersion: '遊戲版本', versionMetadata: '{{count}} 個檔案 · {{metadata}} 個含 Diff 中繼資料',
-        treeTitle: '外掛檔案', viewerTitle: 'Gamedata 檢視器', viewDiff: '查看 Diff', coveredCount: '覆蓋 {{covered}} / {{total}}', updatedCount: '更新 {{updated}}',
+        treeTitle: '外掛檔案', viewerTitle: 'Gamedata 檢視器', viewDiff: '查看 Diff', download: '下載', coveredCount: '覆蓋 {{covered}} / {{total}}', updatedCount: '更新 {{updated}}',
         coveredLegend: '由我們的快照覆蓋', updatedLegend: '相對上游已更新', noMetadata: '目前版本或檔案沒有 schema v2 Diff 中繼資料。', noFiles: '目前版本沒有 gamedata 檔案。',
         loading: '正在載入遊戲資料…', indexError: '無法載入遊戲資料版本索引', fileError: '無法載入目前 gamedata 檔案', metadataError: '無法載入 Diff 中繼資料',
         unanchoredChanges: '{{count}} 個刪除項目在最終檔案中沒有可標示行。', viewerAria: '{{file}} 的唯讀 gamedata 檢視器',


### PR DESCRIPTION
## Summary

给 gamedata 页面的查看器卡片新增「下载」按钮，点击即可下载当前文件的原始内容。

- 在卡片 `extra` 区域加入 Download 按钮（内容加载完成前禁用）
- 复用已通过 SHA-256 校验的文件内容生成 Blob 触发浏览器下载
- 新增 `gamedata.download` 文案（en / zh-CN / zh-TW）

## Validation

- `tsc -b` 通过
- gamedata + i18n 测试 9 passed
- eslint 无告警

🤖 Generated with [Claude Code](https://claude.com/claude-code)