### PR TITLE
feat(pages): add light mode with header theme toggle

### DIFF
--- a/pages/index.html
+++ b/pages/index.html
@@ -1,10 +1,20 @@
 <!doctype html>
-<html lang="en">
+<html lang="en" data-theme="dark">
   <head>
     <meta charset="UTF-8" />
     <link rel="icon" type="image/svg+xml" href="/vite.svg" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>CS2 VibeSignatures Process Dashboard</title>
+    <script>
+      (function () {
+        try {
+          var theme = localStorage.getItem('cs2vibe.theme')
+          document.documentElement.setAttribute('data-theme', theme === 'light' ? 'light' : 'dark')
+        } catch (error) {
+          document.documentElement.setAttribute('data-theme', 'dark')
+        }
+      })()
+    </script>
   </head>
   <body>
     <div id="root"></div>

--- a/pages/src/App.css
+++ b/pages/src/App.css
@@ -1,6 +1,7 @@
 .app-layout { min-height: 100vh; background: transparent; }
-.app-header { position: sticky; top: 0; z-index: 20; display: flex; align-items: center; justify-content: space-between; gap: 24px; padding-inline: clamp(16px, 4vw, 48px); border-bottom: 1px solid var(--panel-border); background: rgba(8, 13, 24, 0.88); backdrop-filter: blur(16px); }
-.app-brand { display: flex; align-items: center; gap: 10px; color: #f8fafc; font-size: 17px; }
+.app-header { position: sticky; top: 0; z-index: 20; display: flex; align-items: center; justify-content: space-between; gap: 24px; padding-inline: clamp(16px, 4vw, 48px); border-bottom: 1px solid var(--panel-border); background: var(--header-bg); backdrop-filter: blur(16px); }
+.app-brand { display: flex; align-items: center; gap: 10px; color: var(--brand-color); font-size: 17px; }
+.app-brand .ant-typography { color: inherit; }
 .app-nav { align-self: stretch; margin-right: auto; }
 .app-nav .ant-tabs-nav { height: 100%; margin: 0; }
 .app-nav .ant-tabs-content-holder { display: none; }
@@ -19,7 +20,7 @@
 .table-card .ant-card-body { padding: 0; }
 .load-more { padding: 18px; text-align: center; border-top: 1px solid var(--panel-border); }
 .connection-wrap { min-height: calc(100vh - 160px); display: grid; place-items: center; }
-.connection-card { width: min(680px, 100%); border-color: rgba(59, 130, 246, 0.3); background: linear-gradient(145deg, rgba(17, 24, 39, 0.96), rgba(11, 18, 32, 0.96)); box-shadow: 0 30px 80px rgba(0, 0, 0, 0.35); }
+.connection-card { width: min(680px, 100%); border-color: var(--connection-card-border); background: var(--connection-card-bg); box-shadow: var(--connection-card-shadow); }
 .settings-help { margin-top: 20px; }
 .page-spinner { min-height: 60vh; display: grid; place-items: center; }
 .run-header-grid { display: grid; grid-template-columns: minmax(0, 1fr) auto; gap: 32px; align-items: center; }
@@ -27,18 +28,18 @@
 .run-progress { display: flex; align-items: center; gap: 18px; max-width: 620px; }
 .run-error { margin-top: 18px; }
 .view-card .ant-card-body { padding-top: 8px; }
-.graph-canvas { position: relative; width: 100%; height: min(68vh, 760px); min-height: 520px; overflow: hidden; border: 1px solid var(--panel-border); border-radius: 10px; background: #0b1220; }
+.graph-canvas { position: relative; width: 100%; height: min(68vh, 760px); min-height: 520px; overflow: hidden; border: 1px solid var(--panel-border); border-radius: 10px; background: var(--graph-canvas-bg); }
 .graph-loading { position: absolute; top: 16px; right: 16px; z-index: 8; }
 .flow-node-label { display: flex; flex-direction: column; gap: 4px; text-align: left; overflow: hidden; }
-.flow-node-label strong { overflow: hidden; text-overflow: ellipsis; white-space: nowrap; color: #f8fafc; }
-.flow-node-label span { color: #a8b4c7; font-size: 12px; }
-.flow-node-description { display: -webkit-box; margin: 0; overflow: hidden; color: #dbeafe; font-size: 11px; line-height: 1.35; white-space: pre-wrap; overflow-wrap: anywhere; -webkit-box-orient: vertical; -webkit-line-clamp: 2; }
-.flow-node-label small { color: #60a5fa; font-size: 11px; }
+.flow-node-label strong { overflow: hidden; text-overflow: ellipsis; white-space: nowrap; color: var(--graph-node-fg); }
+.flow-node-label span { color: var(--graph-node-muted); font-size: 12px; }
+.flow-node-description { display: -webkit-box; margin: 0; overflow: hidden; color: var(--graph-node-description); font-size: 11px; line-height: 1.35; white-space: pre-wrap; overflow-wrap: anywhere; -webkit-box-orient: vertical; -webkit-line-clamp: 2; }
+.flow-node-label small { color: var(--graph-node-accent); font-size: 11px; }
 .react-flow__node { border-radius: 9px; }
 .flow-node-running { animation: flow-running 2.2s ease-in-out infinite; }
-.react-flow__controls, .react-flow__minimap { overflow: hidden; border: 1px solid var(--panel-border); border-radius: 8px; background: #111827; }
-.react-flow__controls-button { color: #dbeafe; background: #111827; border-bottom-color: var(--panel-border); }
-.json-block, .warning-block { max-height: 260px; margin: 0; padding: 12px; overflow: auto; border: 1px solid var(--panel-border); border-radius: 8px; color: #cbd5e1; background: #080d18; font: 12px/1.55 "Cascadia Code", Consolas, monospace; white-space: pre-wrap; overflow-wrap: anywhere; }
+.react-flow__controls, .react-flow__minimap { overflow: hidden; border: 1px solid var(--panel-border); border-radius: 8px; background: var(--graph-controls-bg); }
+.react-flow__controls-button { color: var(--graph-controls-fg); background: var(--graph-controls-bg); border-bottom-color: var(--panel-border); }
+.json-block, .warning-block { max-height: 260px; margin: 0; padding: 12px; overflow: auto; border: 1px solid var(--panel-border); border-radius: 8px; color: var(--code-fg); background: var(--code-bg); font: 12px/1.55 "Cascadia Code", Consolas, monospace; white-space: pre-wrap; overflow-wrap: anywhere; }
 .task-description { margin-bottom: 0 !important; white-space: pre-wrap; overflow-wrap: anywhere; }
 .status-running { box-shadow: 0 0 0 0 rgba(37, 99, 235, 0.55); animation: status-pulse 2s infinite; }
 .symbol-browser-grid, .gamedata-browser-grid { display: grid; grid-template-columns: minmax(320px, 2fr) minmax(0, 3fr); gap: 20px; align-items: start; }
@@ -55,16 +56,16 @@
 .gamedata-viewer-card .ant-card-body { padding: 0; }
 .gamedata-viewer { height: 680px; min-width: 0; overflow: hidden; }
 .gamedata-inline-alert { margin: 12px; }
-.gamedata-diff-legend { display: flex; gap: 18px; align-items: center; padding: 9px 14px; border-bottom: 1px solid var(--panel-border); color: #94a3b8; font-size: 12px; }
+.gamedata-diff-legend { display: flex; gap: 18px; align-items: center; padding: 9px 14px; border-bottom: 1px solid var(--panel-border); color: var(--legend-fg); font-size: 12px; }
 .gamedata-diff-legend span { display: inline-flex; gap: 7px; align-items: center; }
 .gamedata-diff-legend i { width: 12px; height: 12px; border-radius: 3px; }
 .gamedata-covered-swatch { background: rgba(37, 99, 235, 0.55); }
 .gamedata-updated-swatch { background: rgba(245, 158, 11, 0.65); }
 .cm-line.gamedata-line-covered { background: rgba(37, 99, 235, 0.16); box-shadow: inset 3px 0 #3b82f6; }
 .cm-line.gamedata-line-updated { background: rgba(245, 158, 11, 0.2); box-shadow: inset 3px 0 #f59e0b; }
-.cm-tooltip .gamedata-diff-tooltip { width: min(560px, 80vw); max-height: 320px; padding: 10px 12px; overflow: auto; color: #dbeafe; background: #111827; border: 1px solid rgba(148, 163, 184, 0.3); border-radius: 8px; box-shadow: 0 14px 32px rgba(0, 0, 0, 0.38); font: 12px/1.5 "Cascadia Code", Consolas, monospace; }
+.cm-tooltip .gamedata-diff-tooltip { width: min(560px, 80vw); max-height: 320px; padding: 10px 12px; overflow: auto; color: var(--tooltip-fg); background: var(--tooltip-bg); border: 1px solid var(--tooltip-border); border-radius: 8px; box-shadow: var(--tooltip-shadow); font: 12px/1.5 "Cascadia Code", Consolas, monospace; }
 .gamedata-diff-change + .gamedata-diff-change { margin-top: 10px; padding-top: 10px; border-top: 1px solid var(--panel-border); }
-.gamedata-diff-change strong { display: block; margin-bottom: 4px; color: #f8fafc; overflow-wrap: anywhere; }
+.gamedata-diff-change strong { display: block; margin-bottom: 4px; color: var(--heading-fg); overflow-wrap: anywhere; }
 .gamedata-diff-before, .gamedata-diff-after { white-space: pre-wrap; overflow-wrap: anywhere; }
 .gamedata-diff-before { color: #fca5a5; }
 .gamedata-diff-after { color: #86efac; }
@@ -98,7 +99,7 @@
 
 @media (max-width: 600px) {
   .app-brand .ant-typography { display: none; }
-  .api-summary .ant-btn { font-size: 0; }
+  .api-summary .ant-btn:not(.theme-toggle) { font-size: 0; }
   .api-summary .ant-btn .anticon { margin-inline-end: 0; font-size: 14px; }
   .page-title-row { align-items: stretch; flex-direction: column; }
   .symbol-version-controls { width: 100%; align-items: stretch; justify-content: flex-start; flex-direction: column; }

--- a/pages/src/App.tsx
+++ b/pages/src/App.tsx
@@ -8,6 +8,7 @@ import { useTranslation } from 'react-i18next'
 import { ApiProvider } from './app/ApiProvider'
 import { AppShell } from './app/AppShell'
 import { resolveLanguage } from './i18n'
+import { useTheme } from './theme/themeContext'
 import './App.css'
 
 const queryClient = new QueryClient({
@@ -20,12 +21,17 @@ const ANT_DESIGN_LOCALES = { en: enUS, 'zh-CN': zhCN, 'zh-TW': zhTW }
 
 export default function App() {
   const { i18n } = useTranslation()
+  const { theme: colorTheme } = useTheme()
   return (
     <ConfigProvider
       locale={ANT_DESIGN_LOCALES[resolveLanguage(i18n.resolvedLanguage)]}
       theme={{
-        algorithm: theme.darkAlgorithm,
-        token: { colorPrimary: '#3b82f6', borderRadius: 8, colorBgBase: '#080d18' },
+        algorithm: colorTheme === 'dark' ? theme.darkAlgorithm : theme.defaultAlgorithm,
+        token: {
+          colorPrimary: '#3b82f6',
+          borderRadius: 8,
+          colorBgBase: colorTheme === 'dark' ? '#080d18' : '#f3f6fb',
+        },
       }}
     >
       <AntApp>

--- a/pages/src/app/AppShell.tsx
+++ b/pages/src/app/AppShell.tsx
@@ -6,6 +6,7 @@ import { useTranslation } from 'react-i18next'
 import { ApiSettingsDrawer } from '../components/ApiSettingsDrawer'
 import { ConnectionGate } from '../components/ConnectionGate'
 import { APP_LANGUAGES, changeLanguage, resolveLanguage, type AppLanguage } from '../i18n'
+import { ThemeToggle } from '../theme/ThemeToggle'
 import { useApiConfig } from './apiContext'
 
 const { Header, Content } = Layout
@@ -69,6 +70,7 @@ export function AppShell() {
             }))}
             style={{ width: 158 }}
           />
+          <ThemeToggle />
         </Space>
       </Header>
       <Content className="app-content">

--- a/pages/src/features/gamedata/GameDataViewer.test.tsx
+++ b/pages/src/features/gamedata/GameDataViewer.test.tsx
@@ -1,5 +1,6 @@
 import { render, waitFor } from '@testing-library/react'
 import { describe, expect, it } from 'vitest'
+import { ThemeProvider } from '../../theme/ThemeProvider'
 import { GameDataViewer } from './GameDataViewer'
 import type { GameDataMetadata } from './types'
 
@@ -23,13 +24,15 @@ const metadata: GameDataMetadata = {
 describe('GameDataViewer', () => {
   it('renders a non-editable CodeMirror view with covered and updated line decorations', async () => {
     const { container, getByRole } = render(
-      <GameDataViewer
-        content={'{\n  "Covered": 1,\n  "Updated": 2\n}\n'}
-        language="jsonc"
-        metadata={metadata}
-        diffEnabled
-        ariaLabel="viewer"
-      />,
+      <ThemeProvider>
+        <GameDataViewer
+          content={'{\n  "Covered": 1,\n  "Updated": 2\n}\n'}
+          language="jsonc"
+          metadata={metadata}
+          diffEnabled
+          ariaLabel="viewer"
+        />
+      </ThemeProvider>,
     )
 
     expect(getByRole('region', { name: 'viewer' })).toBeInTheDocument()

--- a/pages/src/features/gamedata/GameDataViewer.tsx
+++ b/pages/src/features/gamedata/GameDataViewer.tsx
@@ -2,6 +2,7 @@ import { defaultHighlightStyle, syntaxHighlighting } from '@codemirror/language'
 import { EditorState, type Extension } from '@codemirror/state'
 import { Decoration, EditorView, hoverTooltip, lineNumbers, type DecorationSet } from '@codemirror/view'
 import { useEffect, useMemo, useRef } from 'react'
+import { useTheme } from '../../theme/themeContext'
 import { buildGameDataDiffLineModel, formatChangePath, formatChangeValue } from './diffModel'
 import { gameDataLanguageExtension } from './languages'
 import type { GameDataLanguage, GameDataMetadata } from './types'
@@ -61,6 +62,7 @@ function tooltipExtension(model: ReturnType<typeof buildGameDataDiffLineModel>):
 
 export function GameDataViewer({ content, language, metadata, diffEnabled, ariaLabel }: Props) {
   const host = useRef<HTMLDivElement>(null)
+  const { theme } = useTheme()
   const model = useMemo(
     () => buildGameDataDiffLineModel(diffEnabled ? metadata : undefined),
     [diffEnabled, metadata],
@@ -75,14 +77,14 @@ export function GameDataViewer({ content, language, metadata, diffEnabled, ariaL
       gameDataLanguageExtension(language),
       syntaxHighlighting(defaultHighlightStyle),
       EditorView.theme({
-        '&': { height: '100%', backgroundColor: '#080d18', color: '#dbeafe' },
+        '&': { height: '100%', backgroundColor: 'var(--editor-bg)', color: 'var(--editor-fg)' },
         '.cm-scroller': { overflow: 'auto', fontFamily: '"Cascadia Code", Consolas, monospace', fontSize: '12px' },
         '.cm-content': { minWidth: 'max-content', padding: '12px 0' },
         '.cm-line': { padding: '0 14px' },
-        '.cm-gutters': { backgroundColor: '#0b1220', color: '#64748b', borderRight: '1px solid rgba(148, 163, 184, 0.16)' },
+        '.cm-gutters': { backgroundColor: 'var(--editor-gutter-bg)', color: 'var(--editor-gutter-fg)', borderRight: '1px solid var(--panel-border)' },
         '.cm-activeLineGutter': { backgroundColor: 'transparent' },
         '&.cm-focused': { outline: 'none' },
-      }, { dark: true }),
+      }, { dark: theme === 'dark' }),
     ]
     const state = EditorState.create({ doc: content, extensions: baseExtensions })
     const extensions: Extension[] = [
@@ -95,7 +97,7 @@ export function GameDataViewer({ content, language, metadata, diffEnabled, ariaL
       parent: host.current,
     })
     return () => view.destroy()
-  }, [content, language, model])
+  }, [content, language, model, theme])
 
   return <div ref={host} className="gamedata-viewer" role="region" aria-label={ariaLabel} />
 }

--- a/pages/src/graph/GraphCanvas.tsx
+++ b/pages/src/graph/GraphCanvas.tsx
@@ -4,6 +4,7 @@ import { useEffect, useMemo, useState } from 'react'
 import { Background, Controls, MarkerType, MiniMap, ReactFlow, type Edge, type Node } from '@xyflow/react'
 import { useTranslation } from 'react-i18next'
 import { statusLabel } from '../components/status'
+import { useTheme } from '../theme/themeContext'
 import { layoutGraph, type NodePosition } from './layout'
 import type { VisualEdge, VisualGraph, VisualNode } from './model'
 
@@ -46,7 +47,7 @@ function flowNode(node: VisualNode, position: NodePosition | undefined, selected
     data: { label: nodeLabel(node, t) },
     selected: node.id === selectedId,
     className: node.status === 'running' ? 'flow-node-running' : undefined,
-    style: { border: `2px solid ${color}`, borderColor: color, background: '#111827', color: '#f8fafc', width: 220, minHeight: node.description ? 112 : 76, opacity: selectedId && !related.has(node.id) ? 0.3 : 1, boxShadow: node.id === selectedId ? `0 0 0 3px ${color}66` : undefined },
+    style: { border: `2px solid ${color}`, borderColor: color, background: 'var(--graph-node-bg)', color: 'var(--graph-node-fg)', width: 220, minHeight: node.description ? 112 : 76, opacity: selectedId && !related.has(node.id) ? 0.3 : 1, boxShadow: node.id === selectedId ? `0 0 0 3px ${color}66` : undefined },
   }
 }
 
@@ -74,6 +75,7 @@ export function GraphCanvas({ graph, selectedId, onSelect, onToggleExpand }: Pro
   const [positions, setPositions] = useState<Record<string, NodePosition>>({})
   const [loading, setLoading] = useState(false)
   const { t } = useTranslation()
+  const { theme } = useTheme()
   const topologyKey = useMemo(() => JSON.stringify({ n: graph.nodes.map((node) => node.id), e: graph.edges.filter((edge) => edge.layout).map((edge) => [edge.source, edge.target]) }), [graph])
 
   useEffect(() => {
@@ -101,6 +103,7 @@ export function GraphCanvas({ graph, selectedId, onSelect, onToggleExpand }: Pro
       <ReactFlow
         nodes={nodes}
         edges={edges}
+        colorMode={theme}
         fitView
         minZoom={0.1}
         maxZoom={1.8}
@@ -109,7 +112,7 @@ export function GraphCanvas({ graph, selectedId, onSelect, onToggleExpand }: Pro
       >
         <MiniMap pannable zoomable nodeColor={(node) => String(node.style?.borderColor || '#64748b')} />
         <Controls />
-        <Background gap={20} color="#273449" />
+        <Background gap={20} color="var(--graph-grid)" />
       </ReactFlow>
     </div>
   )

--- a/pages/src/i18n/index.ts
+++ b/pages/src/i18n/index.ts
@@ -10,6 +10,7 @@ const resources = {
   en: {
     translation: {
       language: { selector: 'Language', english: 'English', simplifiedChinese: 'Simplified Chinese', traditionalChinese: 'Traditional Chinese' },
+      theme: { toggle: 'Toggle color theme', switchToLight: 'Switch to light mode', switchToDark: 'Switch to dark mode' },
       common: { notAvailable: '—' },
       errors: { connectionFailed: 'Connection failed', invalidApiAddress: 'Invalid API address', apiHttpOnly: 'The API address only supports HTTP or HTTPS', apiAddressParts: 'The API address cannot include credentials, query parameters, or a fragment', requestFailed: 'Request failed', cannotConnectApi: 'Unable to connect to the API' },
       app: { pageTitle: 'CS2 VibeSignatures Process Dashboard', apiSettings: 'API settings', loadingPage: 'Loading page…' },
@@ -48,6 +49,7 @@ const resources = {
   'zh-CN': {
     translation: {
       language: { selector: '语言', english: 'English', simplifiedChinese: '简体中文', traditionalChinese: '繁體中文' },
+      theme: { toggle: '切换颜色主题', switchToLight: '切换到浅色模式', switchToDark: '切换到深色模式' },
       common: { notAvailable: '—' },
       errors: { connectionFailed: '连接失败', invalidApiAddress: 'API 地址无效', apiHttpOnly: 'API 地址只支持 HTTP 或 HTTPS', apiAddressParts: 'API 地址不能包含账号、密码、查询参数或锚点', requestFailed: '请求失败', cannotConnectApi: '无法连接 API' },
       app: { pageTitle: 'CS2 VibeSignatures 流程面板', apiSettings: 'API 设置', loadingPage: '正在加载页面…' },
@@ -86,6 +88,7 @@ const resources = {
   'zh-TW': {
     translation: {
       language: { selector: '語言', english: 'English', simplifiedChinese: '簡體中文', traditionalChinese: '繁體中文' },
+      theme: { toggle: '切換顏色主題', switchToLight: '切換到淺色模式', switchToDark: '切換到深色模式' },
       common: { notAvailable: '—' },
       errors: { connectionFailed: '連線失敗', invalidApiAddress: 'API 位址無效', apiHttpOnly: 'API 位址僅支援 HTTP 或 HTTPS', apiAddressParts: 'API 位址不能包含帳號、密碼、查詢參數或錨點', requestFailed: '請求失敗', cannotConnectApi: '無法連線至 API' },
       app: { pageTitle: 'CS2 VibeSignatures 流程儀表板', apiSettings: 'API 設定', loadingPage: '正在載入頁面…' },

--- a/pages/src/index.css
+++ b/pages/src/index.css
@@ -1,16 +1,80 @@
 :root {
   font-family: Inter, ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
-  color: #e5edf8;
-  background: #080d18;
   font-synthesis: none;
   text-rendering: optimizeLegibility;
   -webkit-font-smoothing: antialiased;
   --panel-border: rgba(148, 163, 184, 0.16);
+  --page-color: #e5edf8;
+  --page-bg-solid: #080d18;
+  --page-bg: radial-gradient(circle at 20% 0%, #14213a 0, #080d18 35%);
+  --header-bg: rgba(8, 13, 24, 0.88);
+  --brand-color: #f8fafc;
+  --connection-card-border: rgba(59, 130, 246, 0.3);
+  --connection-card-bg: linear-gradient(145deg, rgba(17, 24, 39, 0.96), rgba(11, 18, 32, 0.96));
+  --connection-card-shadow: 0 30px 80px rgba(0, 0, 0, 0.35);
+  --graph-canvas-bg: #0b1220;
+  --graph-node-bg: #111827;
+  --graph-node-fg: #f8fafc;
+  --graph-node-muted: #a8b4c7;
+  --graph-node-description: #dbeafe;
+  --graph-node-accent: #60a5fa;
+  --graph-controls-bg: #111827;
+  --graph-controls-fg: #dbeafe;
+  --graph-grid: #273449;
+  --code-bg: #080d18;
+  --code-fg: #cbd5e1;
+  --editor-bg: #080d18;
+  --editor-fg: #dbeafe;
+  --editor-gutter-bg: #0b1220;
+  --editor-gutter-fg: #64748b;
+  --tooltip-bg: #111827;
+  --tooltip-fg: #dbeafe;
+  --tooltip-border: rgba(148, 163, 184, 0.3);
+  --tooltip-shadow: 0 14px 32px rgba(0, 0, 0, 0.38);
+  --legend-fg: #94a3b8;
+  --heading-fg: #f8fafc;
+  color: var(--page-color);
+  background: var(--page-bg-solid);
+  color-scheme: dark;
+}
+
+html[data-theme="light"] {
+  --panel-border: rgba(15, 23, 42, 0.1);
+  --page-color: #1e293b;
+  --page-bg-solid: #f3f6fb;
+  --page-bg: radial-gradient(circle at 20% 0%, #d7e4f6 0, #f3f6fb 38%);
+  --header-bg: rgba(255, 255, 255, 0.9);
+  --brand-color: #0f172a;
+  --connection-card-border: rgba(37, 99, 235, 0.22);
+  --connection-card-bg: linear-gradient(145deg, #ffffff, #f1f5f9);
+  --connection-card-shadow: 0 30px 80px rgba(15, 23, 42, 0.12);
+  --graph-canvas-bg: #e8eef6;
+  --graph-node-bg: #ffffff;
+  --graph-node-fg: #0f172a;
+  --graph-node-muted: #64748b;
+  --graph-node-description: #334155;
+  --graph-node-accent: #2563eb;
+  --graph-controls-bg: #ffffff;
+  --graph-controls-fg: #1e293b;
+  --graph-grid: #cbd5e1;
+  --code-bg: #f8fafc;
+  --code-fg: #334155;
+  --editor-bg: #f8fafc;
+  --editor-fg: #0f172a;
+  --editor-gutter-bg: #eef2f7;
+  --editor-gutter-fg: #64748b;
+  --tooltip-bg: #ffffff;
+  --tooltip-fg: #0f172a;
+  --tooltip-border: rgba(15, 23, 42, 0.12);
+  --tooltip-shadow: 0 14px 32px rgba(15, 23, 42, 0.12);
+  --legend-fg: #64748b;
+  --heading-fg: #0f172a;
+  color-scheme: light;
 }
 
 * { box-sizing: border-box; }
 html, body, #root { min-width: 320px; min-height: 100%; margin: 0; }
-body { min-height: 100vh; background: radial-gradient(circle at 20% 0%, #14213a 0, #080d18 35%); }
+body { min-height: 100vh; background: var(--page-bg); }
 button, input { font: inherit; }
 
 @media (prefers-reduced-motion: reduce) {

--- a/pages/src/main.tsx
+++ b/pages/src/main.tsx
@@ -4,10 +4,14 @@ import 'antd/dist/reset.css'
 import '@xyflow/react/dist/style.css'
 import './index.css'
 import './i18n'
+import './theme'
 import App from './App'
+import { ThemeProvider } from './theme/ThemeProvider'
 
 createRoot(document.getElementById('root')!).render(
   <StrictMode>
-    <App />
+    <ThemeProvider>
+      <App />
+    </ThemeProvider>
   </StrictMode>,
 )

--- a/pages/src/test/setup.ts
+++ b/pages/src/test/setup.ts
@@ -2,6 +2,7 @@ import '@testing-library/jest-dom/vitest'
 import { afterAll, afterEach, beforeAll, beforeEach } from 'vitest'
 import { server } from './server'
 import i18n from '../i18n'
+import { applyTheme, THEME_STORAGE_KEY } from '../theme'
 
 class ResizeObserverStub {
   disconnect() {}
@@ -32,6 +33,10 @@ const nativeGetComputedStyle = window.getComputedStyle
 window.getComputedStyle = (element: Element) => nativeGetComputedStyle(element)
 
 beforeAll(() => server.listen({ onUnhandledRequest: 'error' }))
-beforeEach(async () => { await i18n.changeLanguage('zh-CN') })
+beforeEach(async () => {
+  await i18n.changeLanguage('zh-CN')
+  localStorage.removeItem(THEME_STORAGE_KEY)
+  applyTheme('dark')
+})
 afterEach(() => server.resetHandlers())
 afterAll(() => server.close())

--- a/pages/src/theme/ThemeProvider.tsx
+++ b/pages/src/theme/ThemeProvider.tsx
@@ -1,0 +1,28 @@
+import { useCallback, useLayoutEffect, useMemo, useState, type ReactNode } from 'react'
+import { applyTheme, persistTheme, readStoredTheme, resolveTheme, type AppTheme } from './index'
+import { ThemeContext } from './themeContext'
+
+export function ThemeProvider({ children }: { children: ReactNode }) {
+  const [theme, setThemeState] = useState<AppTheme>(readStoredTheme)
+
+  useLayoutEffect(() => {
+    applyTheme(theme)
+  }, [theme])
+
+  const setTheme = useCallback((next: AppTheme) => {
+    const resolved = resolveTheme(next)
+    persistTheme(resolved)
+    setThemeState(resolved)
+  }, [])
+
+  const toggleTheme = useCallback(() => {
+    setThemeState((current) => {
+      const next = current === 'dark' ? 'light' : 'dark'
+      persistTheme(next)
+      return next
+    })
+  }, [])
+
+  const value = useMemo(() => ({ theme, setTheme, toggleTheme }), [setTheme, theme, toggleTheme])
+  return <ThemeContext.Provider value={value}>{children}</ThemeContext.Provider>
+}

--- a/pages/src/theme/ThemeToggle.test.tsx
+++ b/pages/src/theme/ThemeToggle.test.tsx
@@ -1,0 +1,36 @@
+import { render, screen } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { describe, expect, it } from 'vitest'
+import i18n from '../i18n'
+import { THEME_STORAGE_KEY } from './index'
+import { ThemeProvider } from './ThemeProvider'
+import { ThemeToggle } from './ThemeToggle'
+
+function renderToggle() {
+  return render(
+    <ThemeProvider>
+      <ThemeToggle />
+    </ThemeProvider>,
+  )
+}
+
+describe('ThemeToggle', () => {
+  it('toggles between dark and light and persists the choice', async () => {
+    const user = userEvent.setup()
+    renderToggle()
+    expect(document.documentElement.dataset.theme).toBe('dark')
+    await user.click(screen.getByRole('button', { name: i18n.t('theme.switchToLight') }))
+    expect(document.documentElement.dataset.theme).toBe('light')
+    expect(localStorage.getItem(THEME_STORAGE_KEY)).toBe('light')
+    await user.click(screen.getByRole('button', { name: i18n.t('theme.switchToDark') }))
+    expect(document.documentElement.dataset.theme).toBe('dark')
+    expect(localStorage.getItem(THEME_STORAGE_KEY)).toBe('dark')
+  })
+
+  it('restores a stored light theme on mount', () => {
+    localStorage.setItem(THEME_STORAGE_KEY, 'light')
+    renderToggle()
+    expect(document.documentElement.dataset.theme).toBe('light')
+    expect(screen.getByRole('button', { name: i18n.t('theme.switchToDark') })).toBeInTheDocument()
+  })
+})

--- a/pages/src/theme/ThemeToggle.tsx
+++ b/pages/src/theme/ThemeToggle.tsx
@@ -1,0 +1,16 @@
+import { MoonOutlined, SunOutlined } from '@ant-design/icons'
+import { Button, Tooltip } from 'antd'
+import { useTranslation } from 'react-i18next'
+import { useTheme } from './themeContext'
+
+export function ThemeToggle() {
+  const { theme, toggleTheme } = useTheme()
+  const { t } = useTranslation()
+  const isDark = theme === 'dark'
+  const label = isDark ? t('theme.switchToLight') : t('theme.switchToDark')
+  return (
+    <Tooltip title={label}>
+      <Button className="theme-toggle" aria-label={label} icon={isDark ? <SunOutlined /> : <MoonOutlined />} onClick={toggleTheme} />
+    </Tooltip>
+  )
+}

--- a/pages/src/theme/index.test.ts
+++ b/pages/src/theme/index.test.ts
@@ -1,0 +1,24 @@
+import { afterEach, describe, expect, it } from 'vitest'
+import { applyTheme, persistTheme, readStoredTheme, resolveTheme, THEME_STORAGE_KEY } from './index'
+
+describe('theme', () => {
+  afterEach(() => {
+    localStorage.removeItem(THEME_STORAGE_KEY)
+    applyTheme('dark')
+  })
+
+  it('treats only light as light and everything else as dark', () => {
+    expect(resolveTheme('light')).toBe('light')
+    expect(resolveTheme('dark')).toBe('dark')
+    expect(resolveTheme('system')).toBe('dark')
+    expect(resolveTheme(null)).toBe('dark')
+  })
+
+  it('persists the selected theme and applies it to the document', () => {
+    persistTheme('light')
+    expect(localStorage.getItem(THEME_STORAGE_KEY)).toBe('light')
+    expect(document.documentElement.dataset.theme).toBe('light')
+    expect(document.documentElement.style.colorScheme).toBe('light')
+    expect(readStoredTheme()).toBe('light')
+  })
+})

--- a/pages/src/theme/index.ts
+++ b/pages/src/theme/index.ts
@@ -1,0 +1,29 @@
+export const THEME_STORAGE_KEY = 'cs2vibe.theme'
+export const APP_THEMES = ['dark', 'light'] as const
+export type AppTheme = (typeof APP_THEMES)[number]
+
+export function resolveTheme(value?: string | null): AppTheme {
+  return value === 'light' ? 'light' : 'dark'
+}
+
+export function readStoredTheme(): AppTheme {
+  try {
+    return resolveTheme(localStorage.getItem(THEME_STORAGE_KEY))
+  } catch {
+    return 'dark'
+  }
+}
+
+export function applyTheme(theme: AppTheme): void {
+  const resolved = resolveTheme(theme)
+  document.documentElement.dataset.theme = resolved
+  document.documentElement.style.colorScheme = resolved
+}
+
+export function persistTheme(theme: AppTheme): void {
+  const resolved = resolveTheme(theme)
+  localStorage.setItem(THEME_STORAGE_KEY, resolved)
+  applyTheme(resolved)
+}
+
+applyTheme(readStoredTheme())

--- a/pages/src/theme/themeContext.ts
+++ b/pages/src/theme/themeContext.ts
@@ -1,0 +1,16 @@
+import { createContext, useContext } from 'react'
+import type { AppTheme } from './index'
+
+export interface ThemeContextValue {
+  theme: AppTheme
+  setTheme(theme: AppTheme): void
+  toggleTheme(): void
+}
+
+export const ThemeContext = createContext<ThemeContextValue | null>(null)
+
+export function useTheme(): ThemeContextValue {
+  const value = useContext(ThemeContext)
+  if (!value) throw new Error('useTheme must be used within ThemeProvider')
+  return value
+}


### PR DESCRIPTION
﻿## Summary
- Add a light color theme for the Pages dashboard, with a top-right toggle that persists the choice in localStorage.
- Switch Ant Design, page chrome, CodeMirror gamedata viewer, and graph canvas colors through shared CSS variables.

## Validation
- `npm test` in `pages/`: 17 files, 52 tests passed
- `npm run lint` in `pages/`: passed
- `npx tsc -b` in `pages/`: passed
- Playwright against the Vite dev server (`http://127.0.0.1:5173/CS2_VibeSignatures/`): toggled dark/light on Explore Symbols, Game Data, and Analysis Runs; confirmed persistence after reload; checked desktop 1440 and mobile 390 viewports
