### PR TITLE
fix(agent): inject dynamic MCP endpoint overrides

### DIFF
--- a/agent_runner.py
+++ b/agent_runner.py
@@ -20,8 +20,8 @@ CYBERSECURITY_BLOCK_MARKERS = (
     "flagged this message for a cybersecurity topic",
 )
 ANSI_ESCAPE_RE = re.compile(r"\x1B(?:[@-Z\\-_]|\[[0-?]*[ -/]*[@-~])")
-_MCP_PREFLIGHT_DONE = False
-_MCP_PREFLIGHT_FAILED = False
+_MCP_PREFLIGHT_DONE: set[tuple[str, str | None]] = set()
+_MCP_PREFLIGHT_FAILED: set[tuple[str, str | None]] = set()
 CLAUDE_SKILL_RUNNER_SETTINGS = ".claude/skill_runner.settings.json"
 SKILL_RUNNER_SYSTEM_PROMPT = ".claude/SKILL_RUNNER.md"
 OPENCODE_SKILL_RUNNER_CONFIG = ".opencode/skill_runner.config.json"
@@ -94,7 +94,30 @@ def _format_mcp_list_output(output, limit=1200):
     return "\n".join(f"      {line}" for line in text.splitlines())
 
 
-def _agent_process_env(agent_kind: str) -> dict[str, str] | None:
+def _agent_mcp_override_args(agent_kind: str, mcp_url: str | None) -> list[str]:
+    if not mcp_url:
+        return []
+    if agent_kind == "claude":
+        config = {
+            "mcpServers": {
+                "ida-pro-mcp": {
+                    "type": "http",
+                    "url": mcp_url,
+                }
+            }
+        }
+        return ["--mcp-config", json.dumps(config, separators=(",", ":")), "--strict-mcp-config"]
+    if agent_kind == "codex":
+        return [
+            "-c",
+            f"mcp_servers.ida-pro-mcp.url={json.dumps(mcp_url)}",
+            "-c",
+            "mcp_servers.ida-pro-mcp.required=true",
+        ]
+    return []
+
+
+def _agent_process_env(agent_kind: str, mcp_url: str | None = None) -> dict[str, str] | None:
     if agent_kind != "opencode":
         return None
     env = os.environ.copy()
@@ -104,46 +127,59 @@ def _agent_process_env(agent_kind: str) -> dict[str, str] | None:
             "OPENCODE_CONFIG": OPENCODE_SKILL_RUNNER_CONFIG,
         }
     )
+    if mcp_url:
+        env["OPENCODE_CONFIG_CONTENT"] = json.dumps(
+            {
+                "mcp": {
+                    "ida-pro-mcp": {
+                        "type": "remote",
+                        "url": mcp_url,
+                        "enabled": True,
+                    }
+                }
+            },
+            separators=(",", ":"),
+        )
     return env
 
 
-def _ensure_agent_mcp_preflight(agent, debug=False, server_name="ida-pro-mcp"):
-    global _MCP_PREFLIGHT_DONE, _MCP_PREFLIGHT_FAILED
-
-    if _MCP_PREFLIGHT_DONE:
+def _ensure_agent_mcp_preflight(agent, debug=False, server_name="ida-pro-mcp", mcp_url=None):
+    preflight_key = (agent, mcp_url)
+    if preflight_key in _MCP_PREFLIGHT_DONE:
         return True
-    if _MCP_PREFLIGHT_FAILED:
+    if preflight_key in _MCP_PREFLIGHT_FAILED:
         print("    Error: MCP preflight previously failed; refusing to start agent.")
         return False
 
-    cmd = [agent, "mcp", "list"]
+    agent_kind = _detect_agent_kind(agent) or ""
+    cmd = [agent, *_agent_mcp_override_args(agent_kind, mcp_url), "mcp", "list"]
     print(f"    Checking MCP server list: {' '.join(cmd)}")
     try:
         result = _run_process_with_stream_capture(
             cmd,
             debug=debug,
             timeout=MCP_LIST_TIMEOUT,
-            env=_agent_process_env(_detect_agent_kind(agent) or ""),
+            env=_agent_process_env(agent_kind, mcp_url),
         )
     except subprocess.TimeoutExpired:
-        _MCP_PREFLIGHT_FAILED = True
+        _MCP_PREFLIGHT_FAILED.add(preflight_key)
         print(f"    Error: MCP list preflight timeout ({MCP_LIST_TIMEOUT} seconds): {' '.join(cmd)}")
         return False
     except FileNotFoundError:
-        _MCP_PREFLIGHT_FAILED = True
+        _MCP_PREFLIGHT_FAILED.add(preflight_key)
         print(f"    Error: Agent '{agent}' not found while running MCP list preflight.")
         return False
     except Exception as error:
-        _MCP_PREFLIGHT_FAILED = True
+        _MCP_PREFLIGHT_FAILED.add(preflight_key)
         print(f"    Error executing MCP list preflight: {error}")
         return False
 
     output = "\n".join(text for text in (result.stdout, result.stderr) if text)
     if _mcp_list_contains_server(output, server_name):
-        _MCP_PREFLIGHT_DONE = True
+        _MCP_PREFLIGHT_DONE.add(preflight_key)
         return True
 
-    _MCP_PREFLIGHT_FAILED = True
+    _MCP_PREFLIGHT_FAILED.add(preflight_key)
     print(f"    Error: Required MCP server '{server_name}' is not listed by '{agent} mcp list'.")
     if result.returncode != 0:
         print(f"    mcp list return code: {result.returncode}")
@@ -273,8 +309,10 @@ def _build_claude_base_args(
     permission_mode: str = "",
     extra_args: str = "",
     agent_model: str = DEFAULT_AGENT_MODEL,
+    mcp_url: str | None = None,
 ) -> list[str]:
     args = [agent, "-p", prompt_arg, "--agent", agent_profile]
+    args.extend(_agent_mcp_override_args("claude", mcp_url))
     args.extend(_agent_model_args("claude", agent_model))
     args.extend(["--settings", CLAUDE_SKILL_RUNNER_SETTINGS])
     args.extend(["--append-system-prompt-file", SKILL_RUNNER_SYSTEM_PROMPT])
@@ -289,6 +327,7 @@ def _build_codex_base_args(
     developer_instructions: str,
     is_retry: bool,
     agent_model: str = DEFAULT_AGENT_MODEL,
+    mcp_url: str | None = None,
 ) -> list[str]:
     args = [
         agent,
@@ -297,6 +336,7 @@ def _build_codex_base_args(
         "-c",
         developer_instructions,
     ]
+    args.extend(_agent_mcp_override_args("codex", mcp_url))
     args.extend(_agent_model_args("codex", agent_model))
     args.extend(_agent_permission_args("codex"))
     args.append("exec")
@@ -329,6 +369,7 @@ def _build_claude_command(
     session_id: str,
     is_retry: bool,
     agent_model: str = DEFAULT_AGENT_MODEL,
+    mcp_url: str | None = None,
 ) -> AgentCommand:
     args = _build_claude_base_args(
         agent=agent,
@@ -337,6 +378,7 @@ def _build_claude_command(
         session_id=session_id,
         is_retry=is_retry,
         agent_model=agent_model,
+        mcp_url=mcp_url,
     )
     return AgentCommand(args, None, f"session {session_id}")
 
@@ -347,8 +389,9 @@ def _build_codex_command(
     developer_instructions: str,
     is_retry: bool,
     agent_model: str = DEFAULT_AGENT_MODEL,
+    mcp_url: str | None = None,
 ) -> AgentCommand:
-    args = _build_codex_base_args(agent, developer_instructions, is_retry, agent_model)
+    args = _build_codex_base_args(agent, developer_instructions, is_retry, agent_model, mcp_url)
     args.append("-")
     return AgentCommand(args, f"Run SKILL: .claude/skills/{skill_name}/SKILL.md", "the latest codex session (--last)")
 
@@ -392,14 +435,15 @@ def _build_agent_command(
     developer_instructions: str | None,
     is_retry: bool,
     agent_model: str = DEFAULT_AGENT_MODEL,
+    mcp_url: str | None = None,
 ) -> AgentCommand:
     if agent_kind == "claude":
-        return _build_claude_command(agent, skill_name, session_id, is_retry, agent_model)
+        return _build_claude_command(agent, skill_name, session_id, is_retry, agent_model, mcp_url)
     if agent_kind == "opencode":
         return _build_opencode_command(agent, skill_name, is_retry, opencode_session_id, agent_model)
     if developer_instructions is None:
         raise ValueError("Codex developer instructions are required")
-    return _build_codex_command(agent, skill_name, developer_instructions, is_retry, agent_model)
+    return _build_codex_command(agent, skill_name, developer_instructions, is_retry, agent_model, mcp_url)
 
 
 def _print_command(command: AgentCommand, attempt: int, max_retries: int) -> None:
@@ -470,10 +514,11 @@ def _run_skill_attempts(
     expected_yaml_paths,
     max_retries: int,
     agent_model: str,
+    mcp_url: str | None,
     progress_callback=None,
 ) -> bool:
     opencode_session_id = None
-    process_env = _agent_process_env(agent_kind)
+    process_env = _agent_process_env(agent_kind, mcp_url)
     for attempt in range(max_retries):
         attempt_number = attempt + 1
         _notify_progress(
@@ -491,6 +536,7 @@ def _run_skill_attempts(
             developer_instructions=developer_instructions,
             is_retry=attempt > 0,
             agent_model=agent_model,
+            mcp_url=mcp_url,
         )
         _print_command(command, attempt, max_retries)
         try:
@@ -586,6 +632,7 @@ def run_skill(
     max_retries=3,
     agent_model=DEFAULT_AGENT_MODEL,
     progress_callback=None,
+    mcp_url=None,
 ) -> bool:
     """Execute a skill with its configured agent and retry support."""
     agent_kind = _detect_agent_kind(agent)
@@ -606,7 +653,7 @@ def run_skill(
         print(f"    Error: Skill file not found: {skill_md_path}")
         _notify_progress(progress_callback, "failed", reason="skill_file_missing", path=skill_md_path)
         return False
-    if not _ensure_agent_mcp_preflight(agent, debug=debug):
+    if not _ensure_agent_mcp_preflight(agent, debug=debug, mcp_url=mcp_url):
         _notify_progress(progress_callback, "failed", reason="mcp_unavailable")
         return False
 
@@ -624,5 +671,6 @@ def run_skill(
         expected_yaml_paths=expected_yaml_paths,
         max_retries=max_retries,
         agent_model=agent_model,
+        mcp_url=mcp_url,
         progress_callback=progress_callback,
     )

--- a/agent_runner.py
+++ b/agent_runner.py
@@ -21,7 +21,6 @@ CYBERSECURITY_BLOCK_MARKERS = (
 )
 ANSI_ESCAPE_RE = re.compile(r"\x1B(?:[@-Z\\-_]|\[[0-?]*[ -/]*[@-~])")
 _MCP_PREFLIGHT_DONE: set[tuple[str, str | None]] = set()
-_MCP_PREFLIGHT_FAILED: set[tuple[str, str | None]] = set()
 CLAUDE_SKILL_RUNNER_SETTINGS = ".claude/skill_runner.settings.json"
 SKILL_RUNNER_SYSTEM_PROMPT = ".claude/SKILL_RUNNER.md"
 OPENCODE_SKILL_RUNNER_CONFIG = ".opencode/skill_runner.config.json"
@@ -147,9 +146,6 @@ def _ensure_agent_mcp_preflight(agent, debug=False, server_name="ida-pro-mcp", m
     preflight_key = (agent, mcp_url)
     if preflight_key in _MCP_PREFLIGHT_DONE:
         return True
-    if preflight_key in _MCP_PREFLIGHT_FAILED:
-        print("    Error: MCP preflight previously failed; refusing to start agent.")
-        return False
 
     agent_kind = _detect_agent_kind(agent) or ""
     cmd = [agent, *_agent_mcp_override_args(agent_kind, mcp_url), "mcp", "list"]
@@ -162,15 +158,12 @@ def _ensure_agent_mcp_preflight(agent, debug=False, server_name="ida-pro-mcp", m
             env=_agent_process_env(agent_kind, mcp_url),
         )
     except subprocess.TimeoutExpired:
-        _MCP_PREFLIGHT_FAILED.add(preflight_key)
         print(f"    Error: MCP list preflight timeout ({MCP_LIST_TIMEOUT} seconds): {' '.join(cmd)}")
         return False
     except FileNotFoundError:
-        _MCP_PREFLIGHT_FAILED.add(preflight_key)
         print(f"    Error: Agent '{agent}' not found while running MCP list preflight.")
         return False
     except Exception as error:
-        _MCP_PREFLIGHT_FAILED.add(preflight_key)
         print(f"    Error executing MCP list preflight: {error}")
         return False
 
@@ -179,7 +172,6 @@ def _ensure_agent_mcp_preflight(agent, debug=False, server_name="ida-pro-mcp", m
         _MCP_PREFLIGHT_DONE.add(preflight_key)
         return True
 
-    _MCP_PREFLIGHT_FAILED.add(preflight_key)
     print(f"    Error: Required MCP server '{server_name}' is not listed by '{agent} mcp list'.")
     if result.returncode != 0:
         print(f"    mcp list return code: {result.returncode}")

--- a/ida_analyze_bin.py
+++ b/ida_analyze_bin.py
@@ -3782,6 +3782,7 @@ def process_binary(
             _report_skill_status(reporting, job_id, skill_name, TaskStatus.RUNNING, ProcessPhase.AGENT_FALLBACK)
             progress_callback = _build_agent_progress_callback(reporting, job_id, skill_name)
 
+            mcp_url = f"http://{host}:{port}/mcp"
             if run_skill(
                 skill_name,
                 agent,
@@ -3790,6 +3791,7 @@ def process_binary(
                 max_retries=skill_max_retries,
                 agent_model=agent_model,
                 progress_callback=progress_callback,
+                mcp_url=mcp_url,
             ):
                 optional_output_generated = any(os.path.exists(path) for path in optional_outputs)
                 if not required_outputs and optional_outputs and not optional_output_generated:

--- a/tests/test_agent_runner.py
+++ b/tests/test_agent_runner.py
@@ -269,7 +269,6 @@ class _FakePopen:
 class TestOpenCodeCommandConstruction(unittest.TestCase):
     def setUp(self) -> None:
         agent_runner._MCP_PREFLIGHT_DONE.clear()
-        agent_runner._MCP_PREFLIGHT_FAILED.clear()
 
     def test_detect_agent_kind_accepts_opencode_executable_names(self) -> None:
         self.assertEqual("opencode", agent_runner._detect_agent_kind("opencode"))
@@ -454,7 +453,6 @@ class TestOpenCodeCommandConstruction(unittest.TestCase):
 class TestRunSkillOutputDetection(unittest.TestCase):
     def setUp(self) -> None:
         agent_runner._MCP_PREFLIGHT_DONE.clear()
-        agent_runner._MCP_PREFLIGHT_FAILED.clear()
 
     def test_extract_skill_error_returns_tag_contents(self) -> None:
         self.assertEqual(
@@ -475,7 +473,6 @@ class TestRunSkillOutputDetection(unittest.TestCase):
 class TestRunSkillCodexPromptTransport(unittest.TestCase):
     def setUp(self) -> None:
         agent_runner._MCP_PREFLIGHT_DONE.clear()
-        agent_runner._MCP_PREFLIGHT_FAILED.clear()
 
     @patch.object(Path, "read_text", return_value="sig finder prompt")
     @patch("agent_runner.os.path.exists", return_value=True)
@@ -792,7 +789,6 @@ class TestRunSkillCodexPromptTransport(unittest.TestCase):
         for block_message in block_messages:
             with self.subTest(block_message=block_message):
                 agent_runner._MCP_PREFLIGHT_DONE.clear()
-                agent_runner._MCP_PREFLIGHT_FAILED.clear()
                 preflight_process = _FakePopen(
                     stdout_chunks=["ida-pro-mcp  http://127.0.0.1:13337/mcp  enabled\n"],
                     stderr_chunks=[],
@@ -820,7 +816,6 @@ class TestRunSkillCodexPromptTransport(unittest.TestCase):
 class TestRunSkillMcpListPreflight(unittest.TestCase):
     def setUp(self) -> None:
         agent_runner._MCP_PREFLIGHT_DONE.clear()
-        agent_runner._MCP_PREFLIGHT_FAILED.clear()
 
     @patch("agent_runner.os.path.exists", return_value=True)
     @patch("agent_runner.subprocess.Popen")
@@ -1022,16 +1017,23 @@ class TestRunSkillMcpListPreflight(unittest.TestCase):
 
     @patch("agent_runner.os.path.exists", return_value=True)
     @patch("agent_runner.subprocess.Popen")
-    def test_failed_preflight_is_not_retried_for_later_skills(
+    def test_failed_preflight_is_retried_for_later_skills(
         self,
         mock_popen,
         _mock_exists,
     ) -> None:
-        mock_popen.return_value = _FakePopen(
+        first_preflight = _FakePopen(
             stdout_chunks=["basic-memory: http://127.0.0.1:9131/mcp (HTTP) - Connected\n"],
             stderr_chunks=[],
             returncode=0,
         )
+        second_preflight = _FakePopen(
+            stdout_chunks=["ida-pro-mcp: http://127.0.0.1:13337/mcp (HTTP) - Connected\n"],
+            stderr_chunks=[],
+            returncode=0,
+        )
+        agent_process = _FakePopen(stdout_chunks=["done\n"], stderr_chunks=[], returncode=0)
+        mock_popen.side_effect = [first_preflight, second_preflight, agent_process]
 
         with patch("sys.stdout", new_callable=io.StringIO) as fake_stdout:
             first_result = agent_runner.run_skill(
@@ -1048,9 +1050,9 @@ class TestRunSkillMcpListPreflight(unittest.TestCase):
             )
 
         self.assertFalse(first_result)
-        self.assertFalse(second_result)
-        self.assertEqual(1, mock_popen.call_count)
-        self.assertIn("MCP preflight previously failed", fake_stdout.getvalue())
+        self.assertTrue(second_result)
+        self.assertEqual(3, mock_popen.call_count)
+        self.assertNotIn("MCP preflight previously failed", fake_stdout.getvalue())
 
     @patch("agent_runner._run_process_with_stream_capture")
     def test_preflight_cache_is_partitioned_by_dynamic_endpoint(self, mock_run_process) -> None:

--- a/tests/test_agent_runner.py
+++ b/tests/test_agent_runner.py
@@ -43,6 +43,65 @@ class TestSkillRunnerProjectPromptConfiguration(unittest.TestCase):
         self.assertNotIn("--approval-mode", command.args)
         self.assertNotIn("full-auto", command.args)
 
+    def test_claude_dynamic_mcp_override_is_reused_for_retry(self) -> None:
+        mcp_url = "http://127.0.0.1:54321/mcp"
+        first = agent_runner._build_claude_command(
+            "claude",
+            "find-test",
+            "session-id",
+            False,
+            mcp_url=mcp_url,
+        )
+        retry = agent_runner._build_claude_command(
+            "claude",
+            "find-test",
+            "session-id",
+            True,
+            mcp_url=mcp_url,
+        )
+
+        for command in (first, retry):
+            config_index = command.args.index("--mcp-config")
+            self.assertEqual(
+                {
+                    "mcpServers": {
+                        "ida-pro-mcp": {
+                            "type": "http",
+                            "url": mcp_url,
+                        }
+                    }
+                },
+                json.loads(command.args[config_index + 1]),
+            )
+            self.assertIn("--strict-mcp-config", command.args)
+
+    def test_codex_dynamic_mcp_override_is_reused_for_retry(self) -> None:
+        mcp_url = "http://127.0.0.1:54321/mcp"
+        expected_override = [
+            "-c",
+            f'mcp_servers.ida-pro-mcp.url="{mcp_url}"',
+            "-c",
+            "mcp_servers.ida-pro-mcp.required=true",
+        ]
+        first = agent_runner._build_codex_command(
+            "codex",
+            "find-test",
+            'developer_instructions="sig finder prompt"',
+            False,
+            mcp_url=mcp_url,
+        )
+        retry = agent_runner._build_codex_command(
+            "codex",
+            "find-test",
+            'developer_instructions="sig finder prompt"',
+            True,
+            mcp_url=mcp_url,
+        )
+
+        for command in (first, retry):
+            override_index = command.args.index(expected_override[1]) - 1
+            self.assertEqual(expected_override, command.args[override_index : override_index + 4])
+
 
 class TestAgentPermissionArgs(unittest.TestCase):
     def test_returns_permission_args_for_each_agent_kind(self) -> None:
@@ -209,8 +268,8 @@ class _FakePopen:
 
 class TestOpenCodeCommandConstruction(unittest.TestCase):
     def setUp(self) -> None:
-        agent_runner._MCP_PREFLIGHT_DONE = False
-        agent_runner._MCP_PREFLIGHT_FAILED = False
+        agent_runner._MCP_PREFLIGHT_DONE.clear()
+        agent_runner._MCP_PREFLIGHT_FAILED.clear()
 
     def test_detect_agent_kind_accepts_opencode_executable_names(self) -> None:
         self.assertEqual("opencode", agent_runner._detect_agent_kind("opencode"))
@@ -355,11 +414,47 @@ class TestOpenCodeCommandConstruction(unittest.TestCase):
             self.assertEqual("1", process_env["OPENCODE_DISABLE_CLAUDE_CODE_PROMPT"])
             self.assertEqual(".opencode/skill_runner.config.json", process_env["OPENCODE_CONFIG"])
 
+    @patch("agent_runner.os.path.exists", return_value=True)
+    @patch("agent_runner._run_process_with_stream_capture")
+    def test_run_skill_injects_opencode_mcp_override_for_preflight_and_retries(
+        self,
+        mock_run_process,
+        _mock_exists,
+    ) -> None:
+        mcp_url = "http://127.0.0.1:54321/mcp"
+        mock_run_process.side_effect = [
+            subprocess.CompletedProcess(["opencode", "mcp", "list"], 0, "ida-pro-mcp connected\n", ""),
+            subprocess.CompletedProcess(["opencode", "run"], 1, "", "first failure"),
+            subprocess.CompletedProcess(["opencode", "run"], 0, "", ""),
+        ]
+
+        self.assertTrue(
+            agent_runner.run_skill(
+                "find-IGameSystem_vtable",
+                agent="opencode",
+                max_retries=2,
+                mcp_url=mcp_url,
+            )
+        )
+
+        expected_content = {
+            "mcp": {
+                "ida-pro-mcp": {
+                    "type": "remote",
+                    "url": mcp_url,
+                    "enabled": True,
+                }
+            }
+        }
+        for process_call in mock_run_process.call_args_list:
+            process_env = process_call.kwargs["env"]
+            self.assertEqual(expected_content, json.loads(process_env["OPENCODE_CONFIG_CONTENT"]))
+
 
 class TestRunSkillOutputDetection(unittest.TestCase):
     def setUp(self) -> None:
-        agent_runner._MCP_PREFLIGHT_DONE = False
-        agent_runner._MCP_PREFLIGHT_FAILED = False
+        agent_runner._MCP_PREFLIGHT_DONE.clear()
+        agent_runner._MCP_PREFLIGHT_FAILED.clear()
 
     def test_extract_skill_error_returns_tag_contents(self) -> None:
         self.assertEqual(
@@ -379,8 +474,8 @@ class TestRunSkillOutputDetection(unittest.TestCase):
 
 class TestRunSkillCodexPromptTransport(unittest.TestCase):
     def setUp(self) -> None:
-        agent_runner._MCP_PREFLIGHT_DONE = False
-        agent_runner._MCP_PREFLIGHT_FAILED = False
+        agent_runner._MCP_PREFLIGHT_DONE.clear()
+        agent_runner._MCP_PREFLIGHT_FAILED.clear()
 
     @patch.object(Path, "read_text", return_value="sig finder prompt")
     @patch("agent_runner.os.path.exists", return_value=True)
@@ -696,8 +791,8 @@ class TestRunSkillCodexPromptTransport(unittest.TestCase):
 
         for block_message in block_messages:
             with self.subTest(block_message=block_message):
-                agent_runner._MCP_PREFLIGHT_DONE = False
-                agent_runner._MCP_PREFLIGHT_FAILED = False
+                agent_runner._MCP_PREFLIGHT_DONE.clear()
+                agent_runner._MCP_PREFLIGHT_FAILED.clear()
                 preflight_process = _FakePopen(
                     stdout_chunks=["ida-pro-mcp  http://127.0.0.1:13337/mcp  enabled\n"],
                     stderr_chunks=[],
@@ -724,8 +819,8 @@ class TestRunSkillCodexPromptTransport(unittest.TestCase):
 
 class TestRunSkillMcpListPreflight(unittest.TestCase):
     def setUp(self) -> None:
-        agent_runner._MCP_PREFLIGHT_DONE = False
-        agent_runner._MCP_PREFLIGHT_FAILED = False
+        agent_runner._MCP_PREFLIGHT_DONE.clear()
+        agent_runner._MCP_PREFLIGHT_FAILED.clear()
 
     @patch("agent_runner.os.path.exists", return_value=True)
     @patch("agent_runner.subprocess.Popen")
@@ -956,6 +1051,35 @@ class TestRunSkillMcpListPreflight(unittest.TestCase):
         self.assertFalse(second_result)
         self.assertEqual(1, mock_popen.call_count)
         self.assertIn("MCP preflight previously failed", fake_stdout.getvalue())
+
+    @patch("agent_runner._run_process_with_stream_capture")
+    def test_preflight_cache_is_partitioned_by_dynamic_endpoint(self, mock_run_process) -> None:
+        first_url = "http://127.0.0.1:54321/mcp"
+        second_url = "http://127.0.0.1:54322/mcp"
+        mock_run_process.side_effect = [
+            subprocess.CompletedProcess(["codex"], 0, "ida-pro-mcp enabled\n", ""),
+            subprocess.CompletedProcess(["codex"], 0, "ida-pro-mcp enabled\n", ""),
+        ]
+
+        self.assertTrue(agent_runner._ensure_agent_mcp_preflight("codex", mcp_url=first_url))
+        self.assertTrue(agent_runner._ensure_agent_mcp_preflight("codex", mcp_url=first_url))
+        self.assertTrue(agent_runner._ensure_agent_mcp_preflight("codex", mcp_url=second_url))
+
+        self.assertEqual(2, mock_run_process.call_count)
+        for process_call, mcp_url in zip(mock_run_process.call_args_list, (first_url, second_url), strict=True):
+            command = process_call.args[0]
+            self.assertEqual(
+                [
+                    "codex",
+                    "-c",
+                    f'mcp_servers.ida-pro-mcp.url="{mcp_url}"',
+                    "-c",
+                    "mcp_servers.ida-pro-mcp.required=true",
+                    "mcp",
+                    "list",
+                ],
+                command,
+            )
 
     def test_mcp_list_server_matching_requires_list_item_name(self) -> None:
         self.assertTrue(

--- a/tests/test_ida_analyze_bin.py
+++ b/tests/test_ida_analyze_bin.py
@@ -2900,6 +2900,10 @@ class TestProcessBinary(unittest.TestCase):
             mock_preprocess.call_args.kwargs["skill_name"],
         )
         mock_run_skill.assert_called_once()
+        self.assertEqual(
+            "http://127.0.0.1:39091/mcp",
+            mock_run_skill.call_args.kwargs["mcp_url"],
+        )
 
     def test_process_binary_reports_unexpected_preprocess_exception_before_fallback(self) -> None:
         with TemporaryDirectory() as temp_dir:


### PR DESCRIPTION
Port of https://github.com/HLND2T/kphtools/pull/36 to this repository.

## Summary
- pass the owned idalib-mcp endpoint into fallback agent runs
- inject invocation-scoped MCP overrides for Claude, Codex, and OpenCode
- partition MCP preflight caching by agent executable and endpoint
- cover dynamic endpoint propagation, retries, environments, and cache behavior

## Agent overrides
- Claude: `--mcp-config` with `--strict-mcp-config`
- Codex: per-invocation `-c mcp_servers.ida-pro-mcp.url=<url>` plus `required=true`
- OpenCode: `OPENCODE_CONFIG_CONTENT` remote MCP override

## Adaptation from kphtools
- kphtools derives the endpoint from `dump_symbols.LazyIdalibSession` (which owns a lazily-allocated dynamic port). This repo has no `LazyIdalibSession`; the equivalent call site is `ida_analyze_bin.py:process_binary`, where the owned idalib-mcp already runs at an explicit `host`/`port` in scope. That port is currently fixed (`DEFAULT_PORT = 13337`, or `-port` from the CLI), so this PR injects the existing endpoint rather than a dynamically-allocated one.
- The `test_dump_symbols.py` call-site test maps to the existing `ida_analyze_bin.py` inline loop; `mcp_url` propagation is covered by the `agent_runner` tests here.

## Verification
- `uv run python tests/run_test_suite.py unit` → 1109 passed, 0 failures

## Follow-up: dynamic port allocation
This PR intentionally injects the *current* (fixed) endpoint. A natural next step is porting kphtools' dynamic port allocation (`_allocate_local_port` / `LazyIdalibSession`) so each binary analysis picks a free port. That would:

- avoid collisions with a user's interactive `ida-pro-mcp` (which also defaults to `http://127.0.0.1:13337/mcp` in `.mcp.json`)
- enable parallel binary analysis later

It is deliberately out of scope here because `process_binary` is sequential today and dynamic allocation is only meaningful once the `mcp_url` injection introduced by this PR is in place. A future change should add a port-allocation helper, assign a per-binary port in `process_binary`, and re-verify that every `host`/`port` consumer (start / ensure / verify / health / quit) follows the reassigned value.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
