### PR TITLE
CSchemaClassBinding_DestructInPlace

### DIFF
--- a/configs/14176.yaml
+++ b/configs/14176.yaml
@@ -6096,6 +6096,9 @@ modules:
     path_windows: game/csgo/bin/win64/server.dll
     path_linux: game/csgo/bin/linuxsteamrt64/libserver.so
     skills:
+      - name: find-CSchemaClassBinding_DestructInPlace
+        expected_output:
+          - CSchemaClassBinding_DestructInPlace.{platform}.yaml
       - name: find-CSource2Server_vtable
         expected_output:
           - CSource2Server_vtable.{platform}.yaml
@@ -9232,6 +9235,10 @@ modules:
         expected_input:
           - CEntitySystem_FindComponentTypeByName.{platform}.yaml
     symbols:
+      - name: CSchemaClassBinding_DestructInPlace
+        category: func
+        alias:
+          - CSchemaClassBinding::DestructInPlace
       - name: CSource2Server_vtable
         category: vtable
       - name: CSource2Server_GetAllServerClasses

--- a/ida_preprocessor_scripts/find-CSchemaClassBinding_DestructInPlace.py
+++ b/ida_preprocessor_scripts/find-CSchemaClassBinding_DestructInPlace.py
@@ -1,0 +1,64 @@
+#!/usr/bin/env python3
+"""Preprocess script for find-CSchemaClassBinding_DestructInPlace skill."""
+
+from ida_analyze_util import preprocess_common_skill
+
+TARGET_FUNCTION_NAMES = [
+    "CSchemaClassBinding_DestructInPlace",
+]
+
+FUNC_XREFS = [
+    {
+        "func_name": "CSchemaClassBinding_DestructInPlace",
+        "xref_strings": [
+            "Class does not allow destruction from its schema binding",
+            "Cannot destruct abstract class",
+        ],
+        "xref_gvs": [],
+        "xref_signatures": [],
+        "xref_funcs": [],
+        "exclude_funcs": [],
+        "exclude_strings": [],
+        "exclude_gvs": [],
+        "exclude_signatures": [],
+    },
+]
+
+GENERATE_YAML_DESIRED_FIELDS = [
+    (
+        "CSchemaClassBinding_DestructInPlace",
+        [
+            "func_name",
+            "func_va",
+            "func_rva",
+            "func_size",
+            "func_sig",
+        ],
+    ),
+]
+
+
+async def preprocess_skill(
+    session,
+    skill_name,
+    expected_outputs,
+    old_yaml_map,
+    new_binary_dir,
+    platform,
+    image_base,
+    debug=False,
+):
+    """Find the schema-binding destructor by its diagnostic strings."""
+    _ = skill_name
+    return await preprocess_common_skill(
+        session=session,
+        expected_outputs=expected_outputs,
+        old_yaml_map=old_yaml_map,
+        new_binary_dir=new_binary_dir,
+        platform=platform,
+        image_base=image_base,
+        func_names=TARGET_FUNCTION_NAMES,
+        func_xrefs=FUNC_XREFS,
+        generate_yaml_desired_fields=GENERATE_YAML_DESIRED_FIELDS,
+        debug=debug,
+    )


### PR DESCRIPTION
## Summary
- Add the server CSchemaClassBinding::DestructInPlace regular-function finder.
- Locate it from both schema-binding destruction diagnostics and emit func_sig metadata.

## Validation
- implementation-specific tests: uv run ruff format/check; uv run ida_analyze_bin.py -debug (Failed: 0); gamedata config validation passed.
- candidate preparation and C++ validation: delegated to pr-self-runner.yml CI; snapshot/gamedata publication is release-pipeline only

Closes #208