### PR TITLE
CEngineServer_SetClientListening

### DIFF
--- a/configs/14176.yaml
+++ b/configs/14176.yaml
@@ -6665,6 +6665,20 @@ modules:
           - UTIL_PlayerSlotToPlayerController.{platform}.yaml
           - CBasePlayerController_GetPawn.{platform}.yaml
           - g_pEntitySystem.{platform}.yaml
+      - name: find-CUserMessageVoiceMask_t_vtable
+        expected_output:
+          - CUserMessageVoiceMask_t_vtable.{platform}.yaml
+      - name: find-CVoiceGameMgr_UpdateMasks
+        expected_output:
+          - CVoiceGameMgr_UpdateMasks.{platform}.yaml
+        expected_input:
+          - CUserMessageVoiceMask_t_vtable.{platform}.yaml
+      - name: find-CVoiceGameMgr_UpdateMasks-decompiles
+        expected_output:
+          - CEngineServer_SetClientListening.{platform}.yaml
+          - CEngineServer_SetClientProximity.{platform}.yaml
+        expected_input:
+          - CVoiceGameMgr_UpdateMasks.{platform}.yaml
       - name: find-CSource2GameClients_ClientDisconnect
         expected_output:
           - CSource2GameClients_ClientDisconnect.{platform}.yaml
@@ -11619,6 +11633,20 @@ modules:
         category: vfunc
         alias:
           - CEngineServer::UnloadSpawnGroup
+      - name: CUserMessageVoiceMask_t_vtable
+        category: vtable
+      - name: CVoiceGameMgr_UpdateMasks
+        category: func
+        alias:
+          - CVoiceGameMgr::UpdateMasks
+      - name: CEngineServer_SetClientListening
+        category: vfunc
+        alias:
+          - CEngineServer::SetClientListening
+      - name: CEngineServer_SetClientProximity
+        category: vfunc
+        alias:
+          - CEngineServer::SetClientProximity
       - name: INetworkServerService_SetGameSpawnGroupMgr
         category: vfunc
         alias:

--- a/ida_preprocessor_scripts/find-CUserMessageVoiceMask_t_vtable.py
+++ b/ida_preprocessor_scripts/find-CUserMessageVoiceMask_t_vtable.py
@@ -1,0 +1,44 @@
+#!/usr/bin/env python3
+"""Preprocess script for find-CUserMessageVoiceMask_t_vtable skill."""
+
+from ida_analyze_util import preprocess_common_skill
+
+TARGET_CLASS_NAMES = ["CUserMessageVoiceMask_t"]
+
+GENERATE_YAML_DESIRED_FIELDS = [
+    (
+        "CUserMessageVoiceMask_t",
+        [
+            "vtable_class",
+            "vtable_symbol",
+            "vtable_va",
+            "vtable_rva",
+            "vtable_size",
+            "vtable_numvfunc",
+            "vtable_entries",
+        ],
+    ),
+]
+
+
+async def preprocess_skill(
+    session,
+    skill_name,
+    expected_outputs,
+    old_yaml_map,
+    new_binary_dir,
+    platform,
+    image_base,
+    debug=False,
+):
+    """Generate the voice-mask message vtable YAML by symbol lookup."""
+    _ = skill_name, old_yaml_map
+    return await preprocess_common_skill(
+        session=session,
+        expected_outputs=expected_outputs,
+        vtable_class_names=TARGET_CLASS_NAMES,
+        platform=platform,
+        image_base=image_base,
+        generate_yaml_desired_fields=GENERATE_YAML_DESIRED_FIELDS,
+        debug=debug,
+    )

--- a/ida_preprocessor_scripts/find-CVoiceGameMgr_UpdateMasks-decompiles.py
+++ b/ida_preprocessor_scripts/find-CVoiceGameMgr_UpdateMasks-decompiles.py
@@ -1,0 +1,91 @@
+#!/usr/bin/env python3
+"""Preprocess script for find-CVoiceGameMgr_UpdateMasks-decompiles skill."""
+
+from ida_analyze_util import preprocess_common_skill
+
+TARGET_FUNCTION_NAMES = [
+    "CEngineServer_SetClientListening",
+    "CEngineServer_SetClientProximity",
+]
+
+LLM_DECOMPILE = [
+    {
+        "symbol_name": "CEngineServer_SetClientListening",
+        "prompt_path": "prompt/call_llm_decompile.md",
+        "reference_yaml_paths": [
+            "references/server/CVoiceGameMgr_UpdateMasks.{platform}.yaml",
+        ],
+        "expected_result_sections": ["found_vcall", "found_funcptr"],
+        "dependency_policy": {
+            "CVoiceGameMgr_UpdateMasks.{platform}.yaml": "required",
+        },
+    },
+    {
+        "symbol_name": "CEngineServer_SetClientProximity",
+        "prompt_path": "prompt/call_llm_decompile.md",
+        "reference_yaml_paths": [
+            "references/server/CVoiceGameMgr_UpdateMasks.{platform}.yaml",
+        ],
+        "expected_result_sections": ["found_vcall", "found_funcptr"],
+        "dependency_policy": {
+            "CVoiceGameMgr_UpdateMasks.{platform}.yaml": "required",
+        },
+    },
+]
+
+FUNC_VTABLE_RELATIONS = [
+    ("CEngineServer_SetClientListening", "CEngineServer"),
+    ("CEngineServer_SetClientProximity", "CEngineServer"),
+]
+
+GENERATE_YAML_DESIRED_FIELDS = [
+    (
+        "CEngineServer_SetClientListening",
+        [
+            "func_name",
+            "vfunc_sig",
+            "vfunc_offset",
+            "vfunc_index",
+            "vtable_name",
+        ],
+    ),
+    (
+        "CEngineServer_SetClientProximity",
+        [
+            "func_name",
+            "vfunc_sig",
+            "vfunc_offset",
+            "vfunc_index",
+            "vtable_name",
+        ],
+    ),
+]
+
+
+async def preprocess_skill(
+    session,
+    skill_name,
+    expected_outputs,
+    old_yaml_map,
+    new_binary_dir,
+    platform,
+    image_base,
+    llm_config=None,
+    debug=False,
+):
+    """Find both engine voice vfuncs from UpdateMasks's decompile."""
+    _ = skill_name
+    return await preprocess_common_skill(
+        session=session,
+        expected_outputs=expected_outputs,
+        old_yaml_map=old_yaml_map,
+        new_binary_dir=new_binary_dir,
+        platform=platform,
+        image_base=image_base,
+        func_names=TARGET_FUNCTION_NAMES,
+        func_vtable_relations=FUNC_VTABLE_RELATIONS,
+        llm_decompile_specs=LLM_DECOMPILE,
+        llm_config=llm_config,
+        generate_yaml_desired_fields=GENERATE_YAML_DESIRED_FIELDS,
+        debug=debug,
+    )

--- a/ida_preprocessor_scripts/find-CVoiceGameMgr_UpdateMasks.py
+++ b/ida_preprocessor_scripts/find-CVoiceGameMgr_UpdateMasks.py
@@ -1,0 +1,86 @@
+#!/usr/bin/env python3
+"""Preprocess script for find-CVoiceGameMgr_UpdateMasks skill."""
+
+import os
+
+try:
+    import yaml
+except ImportError:
+    yaml = None
+
+from ida_analyze_util import preprocess_common_skill
+
+TARGET_FUNCTION_NAMES = ["CVoiceGameMgr_UpdateMasks"]
+
+GENERATE_YAML_DESIRED_FIELDS = [
+    (
+        "CVoiceGameMgr_UpdateMasks",
+        [
+            "func_name",
+            "func_sig",
+            "func_va",
+            "func_rva",
+            "func_size",
+        ],
+    ),
+]
+
+
+def _read_vtable_va(yaml_path):
+    try:
+        with open(yaml_path, "r", encoding="utf-8") as handle:
+            data = yaml.safe_load(handle)
+        if isinstance(data, dict):
+            value = data.get("vtable_va")
+            if value:
+                return str(value)
+    except Exception:
+        pass
+    return None
+
+
+async def preprocess_skill(
+    session,
+    skill_name,
+    expected_outputs,
+    old_yaml_map,
+    new_binary_dir,
+    platform,
+    image_base,
+    debug=False,
+):
+    """Find the voice-mask updater by references to its message vtable."""
+    _ = skill_name
+    vtable_path = os.path.join(new_binary_dir, f"CUserMessageVoiceMask_t_vtable.{platform}.yaml")
+    vtable_va = _read_vtable_va(vtable_path)
+    if not vtable_va:
+        if debug:
+            print("    Preprocess: CUserMessageVoiceMask_t vtable_va not found")
+        return False
+
+    xref_va = vtable_va if platform == "windows" else hex(int(vtable_va, 16) - 0x10)
+    func_xrefs = [
+        {
+            "func_name": "CVoiceGameMgr_UpdateMasks",
+            "xref_strings": [],
+            "xref_gvs": [xref_va],
+            "xref_signatures": [],
+            "xref_funcs": [],
+            "exclude_funcs": [],
+            "exclude_strings": [],
+            "exclude_gvs": [],
+            "exclude_signatures": [],
+        },
+    ]
+    return await preprocess_common_skill(
+        session=session,
+        expected_outputs=expected_outputs,
+        old_yaml_map=old_yaml_map,
+        new_binary_dir=new_binary_dir,
+        platform=platform,
+        image_base=image_base,
+        func_names=TARGET_FUNCTION_NAMES,
+        func_xrefs=func_xrefs,
+        generate_yaml_desired_fields=GENERATE_YAML_DESIRED_FIELDS,
+        debug=debug,
+    )

--- a/ida_preprocessor_scripts/references/server/CVoiceGameMgr_UpdateMasks.linux.yaml
+++ b/ida_preprocessor_scripts/references/server/CVoiceGameMgr_UpdateMasks.linux.yaml
@@ -1,0 +1,1 @@
+func_name: CVoiceGameMgr_UpdateMasks

--- a/ida_preprocessor_scripts/references/server/CVoiceGameMgr_UpdateMasks.windows.yaml
+++ b/ida_preprocessor_scripts/references/server/CVoiceGameMgr_UpdateMasks.windows.yaml
@@ -1,0 +1,1 @@
+func_name: CVoiceGameMgr_UpdateMasks


### PR DESCRIPTION
## Summary
- Add CUserMessageVoiceMask_t vtable and CVoiceGameMgr_UpdateMasks xref discovery.
- Add LLM discovery for CEngineServer_SetClientListening and SetClientProximity from UpdateMasks.

## Validation
- Ruff, Python syntax, config validation, and focused scheduling/LLM dependency tests passed locally.
- candidate preparation and C++ validation: delegated to pr-self-runner.yml CI; snapshot/gamedata publication is release-pipeline only