### PR TITLE
fix(mcp): keep worker alive during async LLM waits

### DIFF
--- a/ida_analyze_util.py
+++ b/ida_analyze_util.py
@@ -28,6 +28,7 @@ except Exception:
     normalize_optional_temperature = None
 
 import ida_llm_decompile as _ida_llm_decompile
+from ida_mcp_keepalive import keepalive_worker_during
 from ida_llm_decompile import (
     _build_llm_decompile_request_cache_key,
     _debug_print_json,  # noqa: F401
@@ -8450,32 +8451,33 @@ async def preprocess_common_skill(
                 llm_symbol_name_list,
                 llm_decompile_specs_map,
             )
-            return await call_llm_decompile(
-                model=llm_request["model"],
-                symbol_name_list=llm_symbol_name_list,
-                expected_result_sections=expected_result_sections,
-                instruction_validations=instruction_validations,
-                disasm_code=primary_target_detail.get("disasm_code", ""),
-                target_disasm_codes=[target_detail.get("disasm_code", "") for target_detail in llm_target_details],
-                procedure=primary_target_detail.get("procedure", ""),
-                disasm_for_reference=llm_request["disasm_for_reference"],
-                procedure_for_reference=llm_request["procedure_for_reference"],
-                reference_blocks=reference_blocks,
-                target_blocks=target_blocks,
-                prompt_template=llm_request["prompt_template"],
-                platform=platform,
-                new_binary_dir=new_binary_dir,
-                temperature=llm_request.get("temperature"),
-                effort=llm_request.get("effort"),
-                api_key=llm_request.get("api_key"),
-                base_url=llm_request.get("base_url"),
-                fake_as=llm_request.get("fake_as"),
-                max_retries=llm_request.get("max_retries"),
-                retry_initial_delay=llm_request.get("retry_initial_delay"),
-                retry_backoff_factor=llm_request.get("retry_backoff_factor"),
-                retry_max_delay=llm_request.get("retry_max_delay"),
-                debug=debug,
-            )
+            async with keepalive_worker_during(session, debug=debug, activity="llm_decompile"):
+                return await call_llm_decompile(
+                    model=llm_request["model"],
+                    symbol_name_list=llm_symbol_name_list,
+                    expected_result_sections=expected_result_sections,
+                    instruction_validations=instruction_validations,
+                    disasm_code=primary_target_detail.get("disasm_code", ""),
+                    target_disasm_codes=[target_detail.get("disasm_code", "") for target_detail in llm_target_details],
+                    procedure=primary_target_detail.get("procedure", ""),
+                    disasm_for_reference=llm_request["disasm_for_reference"],
+                    procedure_for_reference=llm_request["procedure_for_reference"],
+                    reference_blocks=reference_blocks,
+                    target_blocks=target_blocks,
+                    prompt_template=llm_request["prompt_template"],
+                    platform=platform,
+                    new_binary_dir=new_binary_dir,
+                    temperature=llm_request.get("temperature"),
+                    effort=llm_request.get("effort"),
+                    api_key=llm_request.get("api_key"),
+                    base_url=llm_request.get("base_url"),
+                    fake_as=llm_request.get("fake_as"),
+                    max_retries=llm_request.get("max_retries"),
+                    retry_initial_delay=llm_request.get("retry_initial_delay"),
+                    retry_backoff_factor=llm_request.get("retry_backoff_factor"),
+                    retry_max_delay=llm_request.get("retry_max_delay"),
+                    debug=debug,
+                )
         except Exception:
             return _empty_llm_decompile_result()
 

--- a/ida_llm_decompile.py
+++ b/ida_llm_decompile.py
@@ -4,6 +4,7 @@
 from __future__ import annotations
 
 import asyncio
+import inspect
 import json
 import os
 import re
@@ -1259,7 +1260,10 @@ async def _call_llm_transport_attempt(
 ):
     max_attempts, retry_delay, retry_backoff_factor, retry_max_delay = retry_settings
     try:
-        return True, transport(**attempt_kwargs), retry_delay
+        content = transport(**attempt_kwargs)
+        if inspect.isawaitable(content):
+            content = await content
+        return True, content, retry_delay
     except Exception as exc:
         retry_delay = await _handle_llm_transport_error(
             exc,

--- a/ida_llm_utils.py
+++ b/ida_llm_utils.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import asyncio
 import json
 import uuid
 from collections.abc import Mapping, Sequence
@@ -10,7 +11,7 @@ from typing import Any
 from urllib.parse import urlparse
 
 import httpx
-from openai import OpenAI
+from openai import AsyncOpenAI
 
 CODEX_CLI_USER_AGENT = "codex-tui/0.144.1 (Windows 10.0.26200; x86_64) WindowsTerminal (codex-tui; 0.144.1)"
 CODEX_CLI_ORIGINATOR = "codex-tui"
@@ -65,7 +66,7 @@ def create_openai_client(api_key, base_url=None, *, api_key_required_message):
     if base_url is not None:
         client_kwargs["base_url"] = require_nonempty_text(base_url, "base_url")
 
-    return OpenAI(**client_kwargs)
+    return AsyncOpenAI(**client_kwargs)
 
 
 def extract_first_message_text(response) -> str:
@@ -254,7 +255,45 @@ def _fill_codex_template(node, *, model, user_prompt, cache_key) -> Any:
     return node
 
 
-def _call_llm_text_via_codex_http(
+async def _read_codex_sse_response(response: httpx.Response) -> str:
+    content_type = response.headers.get("content-type", "")
+    if "text/event-stream" not in content_type.lower():
+        raise RuntimeError(f"codex transport expected text/event-stream, got {content_type!r}")
+
+    text_parts: list[str] = []
+    saw_output_text_delta = False
+    failure_event_types = {"error", "response.error", "response.failed", "response.incomplete"}
+    async for line in response.aiter_lines():
+        if line is None:
+            continue
+        stripped_line = line.strip()
+        if not stripped_line.startswith("data:"):
+            continue
+        payload_text = stripped_line[5:].strip()
+        if not payload_text:
+            continue
+        if payload_text == "[DONE]":
+            break
+        payload = json.loads(payload_text)
+        event_type = payload.get("type") if isinstance(payload, Mapping) else None
+        if event_type in failure_event_types:
+            message = _extract_error_message_from_payload(payload)
+            raise RuntimeError(f"codex transport received {event_type}: {message}")
+        if event_type == "response.completed" and saw_output_text_delta:
+            continue
+        extracted_text = _extract_text_from_response_payload(payload)
+        if extracted_text:
+            if event_type == "response.output_text.delta":
+                saw_output_text_delta = True
+            text_parts.append(extracted_text)
+
+    final_text = "".join(text_parts).strip()
+    if not final_text:
+        raise RuntimeError("codex transport returned empty response text")
+    return final_text
+
+
+async def _call_llm_text_via_codex_http(
     *,
     model,
     messages,
@@ -325,50 +364,16 @@ def _call_llm_text_via_codex_http(
         "Host": host,
     }
     endpoint = normalized_base_url.rstrip("/") + "/responses"
-    text_parts: list[str] = []
-    saw_output_text_delta = False
-    failure_event_types = {"error", "response.error", "response.failed", "response.incomplete"}
-
-    with httpx.Client(
+    async with httpx.AsyncClient(
         timeout=httpx.Timeout(30.0, read=300.0),
         trust_env=False,
     ) as http_client:
-        with http_client.stream("POST", endpoint, headers=headers, json=body) as response:
+        async with http_client.stream("POST", endpoint, headers=headers, json=body) as response:
             response.raise_for_status()
-            content_type = response.headers.get("content-type", "")
-            if "text/event-stream" not in content_type.lower():
-                raise RuntimeError(f"codex transport expected text/event-stream, got {content_type!r}")
-            for line in response.iter_lines():
-                if line is None:
-                    continue
-                stripped_line = line.strip()
-                if not stripped_line.startswith("data:"):
-                    continue
-                payload_text = stripped_line[5:].strip()
-                if not payload_text:
-                    continue
-                if payload_text == "[DONE]":
-                    break
-                payload = json.loads(payload_text)
-                event_type = payload.get("type") if isinstance(payload, Mapping) else None
-                if event_type in failure_event_types:
-                    message = _extract_error_message_from_payload(payload)
-                    raise RuntimeError(f"codex transport received {event_type}: {message}")
-                if event_type == "response.completed" and saw_output_text_delta:
-                    continue
-                extracted_text = _extract_text_from_response_payload(payload)
-                if extracted_text:
-                    if event_type == "response.output_text.delta":
-                        saw_output_text_delta = True
-                    text_parts.append(extracted_text)
-
-    final_text = "".join(text_parts).strip()
-    if not final_text:
-        raise RuntimeError("codex transport returned empty response text")
-    return final_text
+            return await _read_codex_sse_response(response)
 
 
-def call_llm_text(
+async def call_llm_text(
     client=None,
     *,
     model,
@@ -383,7 +388,7 @@ def call_llm_text(
 ) -> str:
     normalized_effort = normalize_optional_effort(effort)
     if fake_as == "codex":
-        return _call_llm_text_via_codex_http(
+        return await _call_llm_text_via_codex_http(
             model=model,
             messages=messages,
             api_key=api_key,
@@ -393,12 +398,14 @@ def call_llm_text(
             prompt_cache_key=prompt_cache_key,
         )
 
+    owned_client = None
     if client is None:
-        client = create_openai_client(
+        owned_client = create_openai_client(
             api_key,
             base_url,
             api_key_required_message=("api_key is required for OpenAI-compatible LLM requests"),
         )
+        client = owned_client
 
     request_kwargs = {
         "model": require_nonempty_text(model, "model"),
@@ -408,5 +415,13 @@ def call_llm_text(
     normalized_temperature = normalize_optional_temperature(temperature)
     if normalized_temperature is not None:
         request_kwargs["temperature"] = normalized_temperature
-    response = client.chat.completions.create(**request_kwargs)
-    return extract_first_message_text(response)
+    try:
+        response = await client.chat.completions.create(**request_kwargs)
+        return extract_first_message_text(response)
+    finally:
+        if owned_client is not None:
+            await owned_client.close()
+
+
+def call_llm_text_sync(*args, **kwargs) -> str:
+    return asyncio.run(call_llm_text(*args, **kwargs))

--- a/ida_mcp_keepalive.py
+++ b/ida_mcp_keepalive.py
@@ -1,0 +1,46 @@
+from __future__ import annotations
+
+import asyncio
+from contextlib import asynccontextmanager, suppress
+from typing import Any
+
+WORKER_KEEPALIVE_INTERVAL_SECONDS = 240.0
+_WORKER_KEEPALIVE_TASK_NAME = "mcp-worker-keepalive"
+
+
+def _debug_log(debug: bool, message: str) -> None:
+    if debug:
+        print(f"[debug] {message}")
+
+
+async def _keepalive_worker(session: Any, *, debug: bool, activity: str) -> None:
+    while True:
+        await asyncio.sleep(WORKER_KEEPALIVE_INTERVAL_SECONDS)
+        try:
+            await session.call_tool(
+                name="py_eval",
+                arguments={"code": "1"},
+            )
+            _debug_log(debug, f"refreshed MCP worker TTL during {activity}")
+        except asyncio.CancelledError:
+            raise
+        except Exception as exc:
+            _debug_log(
+                debug,
+                f"MCP worker keepalive stopped during {activity}: {type(exc).__name__}: {exc}",
+            )
+            return
+
+
+@asynccontextmanager
+async def keepalive_worker_during(session: Any, *, debug: bool, activity: str):
+    task = asyncio.create_task(
+        _keepalive_worker(session, debug=debug, activity=activity),
+        name=_WORKER_KEEPALIVE_TASK_NAME,
+    )
+    try:
+        yield
+    finally:
+        task.cancel()
+        with suppress(asyncio.CancelledError):
+            await task

--- a/ida_vcall_finder.py
+++ b/ida_vcall_finder.py
@@ -12,7 +12,7 @@ from typing import Any
 import yaml
 from ida_analyze_util import build_remote_text_export_py_eval, parse_mcp_result
 from ida_llm_utils import (
-    call_llm_text,
+    call_llm_text_sync as call_llm_text,
     normalize_optional_temperature,
     require_nonempty_text,
 )

--- a/memory/llm_decompile.md
+++ b/memory/llm_decompile.md
@@ -28,6 +28,7 @@ permalink: cs2-vibesignatures/llm-decompile
 - `ida_analyze_util.py` - `parse_llm_decompile_response`
 - `ida_analyze_util.py` - `preprocess_common_skill`
 - `ida_llm_utils.py` - `call_llm_text`, `create_openai_client`, `normalize_optional_temperature`, `normalize_optional_effort`
+- `ida_mcp_keepalive.py` - `keepalive_worker_during`
 - `ida_preprocessor_scripts/prompt/call_llm_decompile.md` - shared prompt template consumed by `_prepare_llm_decompile_request`
 - `tests/test_ida_analyze_util.py` - `TestLlmDecompileSupport`
 
@@ -41,7 +42,9 @@ Target detail resolution is MCP-driven. `_load_llm_decompile_target_detail_via_m
 - Hex-Rays pseudocode when available
 - `func_name` and `func_va`
 
-`call_llm_decompile(...)` renders `reference_blocks` and `target_blocks`, injects them into `call_llm_decompile.md`, calls the shared `ida_llm_utils.call_llm_text(...)` transport, retries transient 429/5xx-style failures with exponential backoff, and parses the YAML response with `parse_llm_decompile_response(...)`.
+`call_llm_decompile(...)` renders `reference_blocks` and `target_blocks`, injects them into `call_llm_decompile.md`, awaits the shared `ida_llm_utils.call_llm_text(...)` transport, retries transient 429/5xx-style failures with exponential backoff, and parses the YAML response with `parse_llm_decompile_response(...)`. The OpenAI-compatible path uses `AsyncOpenAI`, while Codex-compatible SSE uses `httpx.AsyncClient`.
+
+The actual remote LLM await runs inside `ida_mcp_keepalive.keepalive_worker_during(...)`. It sends `py_eval("1")` through the already bound database session every 240 seconds so ida-pro-mcp forwards real JSON-RPC traffic to the IDALIB worker before its 600-second idle TTL expires. The task is cancelled and awaited after success or failure; heartbeat failures are debug-only and do not replace the foreground LLM result.
 
 The normalized result is consumed back inside `preprocess_common_skill(...)`:
 - `found_call` -> `_resolve_direct_call_target_via_mcp(...)` -> `_preprocess_direct_func_sig_via_mcp(...)`
@@ -67,6 +70,7 @@ flowchart TD
 
 ## Dependencies
 - `ida_llm_utils.py` for OpenAI-compatible client creation, transport, temperature normalization, and effort normalization.
+- `ida_mcp_keepalive.py` for bound-worker TTL refresh during remote LLM waits.
 - `ida_preprocessor_scripts/prompt/call_llm_decompile.md` for the user prompt template.
 - `ida_preprocessor_scripts/references/**/*.yaml` for reference disassembly/pseudocode payloads and target function names.
 - `configs/<GAMEVER>.yaml` for symbol aliases when current-version YAML cannot supply `func_va`.

--- a/tests/run_test_suite.py
+++ b/tests/run_test_suite.py
@@ -83,6 +83,7 @@ UNIT_MODULES = frozenset(
         "test_idb_cache",
         "test_ida_analyze_util",
         "test_ida_llm_utils",
+        "test_ida_mcp_keepalive",
         "test_ida_mcp_session",
         "test_ida_preprocessor_contracts_commands",
         "test_ida_preprocessor_contracts_gamesystems",

--- a/tests/test_ida_analyze_util.py
+++ b/tests/test_ida_analyze_util.py
@@ -1,4 +1,5 @@
 import ast
+from contextlib import asynccontextmanager
 import json
 import os
 import sys
@@ -9052,6 +9053,16 @@ found_struct_offset: []
     async def test_preprocess_common_skill_uses_llm_decompile_vcall_fallback_for_func_yaml(
         self,
     ) -> None:
+        keepalive_calls = []
+
+        @asynccontextmanager
+        async def record_keepalive(session, *, debug, activity):
+            keepalive_calls.append(("enter", session, debug, activity))
+            try:
+                yield
+            finally:
+                keepalive_calls.append(("exit", session, debug, activity))
+
         func_name = "CLoopModeGame_OnLoopActivate"
         output_path = f"/tmp/{func_name}.windows.yaml"
         target_detail_payload = {
@@ -9156,6 +9167,11 @@ found_struct_offset: []
                 ) as mock_call_llm_decompile,
                 patch.object(
                     ida_analyze_util,
+                    "keepalive_worker_during",
+                    record_keepalive,
+                ),
+                patch.object(
+                    ida_analyze_util,
                     "preprocess_vtable_via_mcp",
                     AsyncMock(
                         return_value={
@@ -9220,6 +9236,13 @@ found_struct_offset: []
 
         self.assertTrue(result)
         mock_call_llm_decompile.assert_awaited_once()
+        self.assertEqual(
+            [
+                ("enter", session, True, "llm_decompile"),
+                ("exit", session, True, "llm_decompile"),
+            ],
+            keepalive_calls,
+        )
         self.assertNotIn("client", mock_call_llm_decompile.call_args.kwargs)
         self.assertEqual(
             "gpt-4.1-mini",

--- a/tests/test_ida_llm_utils.py
+++ b/tests/test_ida_llm_utils.py
@@ -3,7 +3,7 @@ import threading
 import unittest
 from http.server import BaseHTTPRequestHandler, HTTPServer
 from types import SimpleNamespace
-from unittest.mock import MagicMock, patch
+from unittest.mock import AsyncMock, patch
 
 import ida_llm_utils
 
@@ -25,7 +25,7 @@ class TestCreateOpenAiClient(unittest.TestCase):
                 api_key_required_message="LLM API key required",
             )
 
-    @patch("ida_llm_utils.OpenAI")
+    @patch("ida_llm_utils.AsyncOpenAI")
     def test_create_openai_client_uses_trimmed_api_key_and_base_url(self, mock_openai) -> None:
         mock_client = object()
         mock_openai.return_value = mock_client
@@ -89,8 +89,8 @@ class TestExtractFirstMessageText(unittest.TestCase):
             ida_llm_utils.extract_first_message_text(response)
 
 
-class TestCallLlmText(unittest.TestCase):
-    def test_call_llm_text_invokes_chat_completions_and_returns_first_message_text(self) -> None:
+class TestCallLlmText(unittest.IsolatedAsyncioTestCase):
+    async def test_call_llm_text_invokes_chat_completions_and_returns_first_message_text(self) -> None:
         response = SimpleNamespace(
             choices=[
                 SimpleNamespace(
@@ -98,7 +98,7 @@ class TestCallLlmText(unittest.TestCase):
                 )
             ]
         )
-        create = MagicMock(return_value=response)
+        create = AsyncMock(return_value=response)
         client = SimpleNamespace(
             chat=SimpleNamespace(
                 completions=SimpleNamespace(create=create),
@@ -106,7 +106,7 @@ class TestCallLlmText(unittest.TestCase):
         )
         messages = [{"role": "user", "content": "hello"}]
 
-        text = ida_llm_utils.call_llm_text(
+        text = await ida_llm_utils.call_llm_text(
             client,
             model="  gpt-4o-mini  ",
             messages=messages,
@@ -114,14 +114,14 @@ class TestCallLlmText(unittest.TestCase):
         )
 
         self.assertEqual("found_vcall:\n  []", text)
-        create.assert_called_once_with(
+        create.assert_awaited_once_with(
             model="gpt-4o-mini",
             messages=messages,
             reasoning_effort="medium",
             temperature=0.25,
         )
 
-    def test_call_llm_text_omits_temperature_when_not_configured(self) -> None:
+    async def test_call_llm_text_omits_temperature_when_not_configured(self) -> None:
         response = SimpleNamespace(
             choices=[
                 SimpleNamespace(
@@ -129,7 +129,7 @@ class TestCallLlmText(unittest.TestCase):
                 )
             ]
         )
-        create = MagicMock(return_value=response)
+        create = AsyncMock(return_value=response)
         client = SimpleNamespace(
             chat=SimpleNamespace(
                 completions=SimpleNamespace(create=create),
@@ -137,22 +137,22 @@ class TestCallLlmText(unittest.TestCase):
         )
         messages = [{"role": "user", "content": "hello"}]
 
-        text = ida_llm_utils.call_llm_text(
+        text = await ida_llm_utils.call_llm_text(
             client,
             model="gpt-4o-mini",
             messages=messages,
         )
 
         self.assertEqual("found_vcall:\n  []", text)
-        create.assert_called_once_with(
+        create.assert_awaited_once_with(
             model="gpt-4o-mini",
             messages=messages,
             reasoning_effort="medium",
         )
 
-    def test_call_llm_text_forwards_reasoning_effort_to_sdk(self) -> None:
+    async def test_call_llm_text_forwards_reasoning_effort_to_sdk(self) -> None:
         response = SimpleNamespace(choices=[SimpleNamespace(message=SimpleNamespace(content="done"))])
-        create = MagicMock(return_value=response)
+        create = AsyncMock(return_value=response)
         client = SimpleNamespace(
             chat=SimpleNamespace(
                 completions=SimpleNamespace(create=create),
@@ -160,25 +160,25 @@ class TestCallLlmText(unittest.TestCase):
         )
         messages = [{"role": "user", "content": "hello"}]
 
-        text = ida_llm_utils.call_llm_text(
+        text = await ida_llm_utils.call_llm_text(
             client,
             model="gpt-5.4",
             messages=messages,
         )
 
         self.assertEqual("done", text)
-        create.assert_called_once_with(
+        create.assert_awaited_once_with(
             model="gpt-5.4",
             messages=messages,
             reasoning_effort="medium",
         )
 
-    def test_call_llm_text_strips_internal_message_ids_for_chat_completions(self) -> None:
+    async def test_call_llm_text_strips_internal_message_ids_for_chat_completions(self) -> None:
         response = SimpleNamespace(choices=[SimpleNamespace(message=SimpleNamespace(content="done"))])
-        create = MagicMock(return_value=response)
+        create = AsyncMock(return_value=response)
         client = SimpleNamespace(chat=SimpleNamespace(completions=SimpleNamespace(create=create)))
 
-        ida_llm_utils.call_llm_text(
+        await ida_llm_utils.call_llm_text(
             client,
             model="gpt-5.4",
             messages=[{"id": "msg_stable", "role": "user", "content": "hello"}],
@@ -190,21 +190,23 @@ class TestCallLlmText(unittest.TestCase):
         )
 
     @patch("ida_llm_utils.create_openai_client")
-    def test_call_llm_text_creates_request_client_when_missing(
+    async def test_call_llm_text_creates_request_client_when_missing(
         self,
         mock_create_openai_client,
     ) -> None:
         response = SimpleNamespace(choices=[SimpleNamespace(message=SimpleNamespace(content="done"))])
-        create = MagicMock(return_value=response)
+        create = AsyncMock(return_value=response)
+        close = AsyncMock()
         client = SimpleNamespace(
             chat=SimpleNamespace(
                 completions=SimpleNamespace(create=create),
             )
         )
+        client.close = close
         mock_create_openai_client.return_value = client
         messages = [{"role": "user", "content": "hello"}]
 
-        text = ida_llm_utils.call_llm_text(
+        text = await ida_llm_utils.call_llm_text(
             model="gpt-5.4",
             messages=messages,
             api_key="test-api-key",
@@ -217,11 +219,26 @@ class TestCallLlmText(unittest.TestCase):
             "https://example.invalid/v1",
             api_key_required_message=("api_key is required for OpenAI-compatible LLM requests"),
         )
-        create.assert_called_once_with(
+        create.assert_awaited_once_with(
             model="gpt-5.4",
             messages=messages,
             reasoning_effort="medium",
         )
+        close.assert_awaited_once_with()
+
+
+class TestCallLlmTextSync(unittest.TestCase):
+    @patch("ida_llm_utils.call_llm_text", new_callable=AsyncMock)
+    def test_call_llm_text_sync_runs_async_transport(self, mock_call_llm_text) -> None:
+        mock_call_llm_text.return_value = "done"
+
+        result = ida_llm_utils.call_llm_text_sync(
+            model="gpt-5.4",
+            messages=[{"role": "user", "content": "hello"}],
+        )
+
+        self.assertEqual("done", result)
+        mock_call_llm_text.assert_awaited_once()
 
 
 class _CodexHandler(BaseHTTPRequestHandler):
@@ -265,7 +282,7 @@ def _serve_http(server: HTTPServer) -> None:
     server.serve_forever(poll_interval=0.01)
 
 
-class TestCallLlmTextCodexHttp(unittest.TestCase):
+class TestCallLlmTextCodexHttp(unittest.IsolatedAsyncioTestCase):
     def setUp(self) -> None:
         _CodexHandler.content_type = "text/event-stream"
         _CodexHandler.sse_events = [
@@ -288,8 +305,8 @@ class TestCallLlmTextCodexHttp(unittest.TestCase):
         self._server.server_close()
         self._thread.join(timeout=1.0)
 
-    def test_call_llm_text_posts_responses_sse_with_codex_headers(self) -> None:
-        result = ida_llm_utils.call_llm_text(
+    async def test_call_llm_text_posts_responses_sse_with_codex_headers(self) -> None:
+        result = await ida_llm_utils.call_llm_text(
             None,
             model="gpt-5.4",
             messages=[
@@ -321,8 +338,8 @@ class TestCallLlmTextCodexHttp(unittest.TestCase):
             input_items[-1]["content"],
         )
 
-    def test_call_llm_text_codex_uses_top_level_text_attribute(self) -> None:
-        result = ida_llm_utils.call_llm_text(
+    async def test_call_llm_text_codex_uses_top_level_text_attribute(self) -> None:
+        result = await ida_llm_utils.call_llm_text(
             None,
             model="gpt-5.4",
             messages=[{"role": "user", "content": SimpleNamespace(text="  Hello  ")}],
@@ -339,7 +356,7 @@ class TestCallLlmTextCodexHttp(unittest.TestCase):
             user_input["content"],
         )
 
-    def test_call_llm_text_codex_preserves_message_ids_across_retries(self) -> None:
+    async def test_call_llm_text_codex_preserves_message_ids_across_retries(self) -> None:
         messages = [
             {"id": "msg_initial", "role": "user", "content": "Initial prompt"},
             {"id": "msg_bad_output", "role": "assistant", "content": "bad YAML"},
@@ -347,7 +364,7 @@ class TestCallLlmTextCodexHttp(unittest.TestCase):
         ]
 
         for _ in range(2):
-            ida_llm_utils.call_llm_text(
+            await ida_llm_utils.call_llm_text(
                 None,
                 model="gpt-5.4",
                 messages=messages,
@@ -369,11 +386,11 @@ class TestCallLlmTextCodexHttp(unittest.TestCase):
             [body["prompt_cache_key"] for body in _CodexHandler.json_bodies],
         )
 
-    def test_call_llm_text_rejects_non_sse_content_type(self) -> None:
+    async def test_call_llm_text_rejects_non_sse_content_type(self) -> None:
         _CodexHandler.content_type = "application/json"
 
         with self.assertRaisesRegex(RuntimeError, "expected text/event-stream"):
-            ida_llm_utils.call_llm_text(
+            await ida_llm_utils.call_llm_text(
                 None,
                 model="gpt-5.4",
                 messages=[{"role": "user", "content": "Who are you?"}],
@@ -382,7 +399,7 @@ class TestCallLlmTextCodexHttp(unittest.TestCase):
                 fake_as="codex",
             )
 
-    def test_call_llm_text_codex_avoids_completed_text_dup_after_deltas(self) -> None:
+    async def test_call_llm_text_codex_avoids_completed_text_dup_after_deltas(self) -> None:
         _CodexHandler.sse_events = [
             'data: {"type":"response.output_text.delta","delta":"answer"}\n\n',
             (
@@ -392,7 +409,7 @@ class TestCallLlmTextCodexHttp(unittest.TestCase):
             "data: [DONE]\n\n",
         ]
 
-        result = ida_llm_utils.call_llm_text(
+        result = await ida_llm_utils.call_llm_text(
             None,
             model="gpt-5.4",
             messages=[{"role": "user", "content": "Who are you?"}],
@@ -403,7 +420,7 @@ class TestCallLlmTextCodexHttp(unittest.TestCase):
 
         self.assertEqual("answer", result)
 
-    def test_call_llm_text_codex_raises_on_failed_event_after_delta(self) -> None:
+    async def test_call_llm_text_codex_raises_on_failed_event_after_delta(self) -> None:
         _CodexHandler.sse_events = [
             'data: {"type":"response.output_text.delta","delta":"partial"}\n\n',
             'data: {"type":"response.failed","reason":"model_error"}\n\n',
@@ -411,7 +428,7 @@ class TestCallLlmTextCodexHttp(unittest.TestCase):
         ]
 
         with self.assertRaisesRegex(RuntimeError, r"codex transport.*response\.failed"):
-            ida_llm_utils.call_llm_text(
+            await ida_llm_utils.call_llm_text(
                 None,
                 model="gpt-5.4",
                 messages=[{"role": "user", "content": "Who are you?"}],
@@ -420,7 +437,7 @@ class TestCallLlmTextCodexHttp(unittest.TestCase):
                 fake_as="codex",
             )
 
-    def test_call_llm_text_codex_uses_completed_as_fallback_without_deltas(self) -> None:
+    async def test_call_llm_text_codex_uses_completed_as_fallback_without_deltas(self) -> None:
         _CodexHandler.sse_events = [
             (
                 'data: {"type":"response.completed","response":{"output":[{"content":'
@@ -429,7 +446,7 @@ class TestCallLlmTextCodexHttp(unittest.TestCase):
             "data: [DONE]\n\n",
         ]
 
-        result = ida_llm_utils.call_llm_text(
+        result = await ida_llm_utils.call_llm_text(
             None,
             model="gpt-5.4",
             messages=[{"role": "user", "content": "Who are you?"}],

--- a/tests/test_ida_mcp_keepalive.py
+++ b/tests/test_ida_mcp_keepalive.py
@@ -1,0 +1,59 @@
+import asyncio
+import unittest
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, patch
+
+import ida_mcp_keepalive
+
+
+class TestKeepaliveWorkerDuring(unittest.IsolatedAsyncioTestCase):
+    async def test_forwards_py_eval_and_stops_after_context(self) -> None:
+        keepalive_called = asyncio.Event()
+
+        async def record_keepalive(*_args, **_kwargs) -> None:
+            keepalive_called.set()
+
+        session = SimpleNamespace(call_tool=AsyncMock(side_effect=record_keepalive))
+
+        with patch.object(ida_mcp_keepalive, "WORKER_KEEPALIVE_INTERVAL_SECONDS", 0.001):
+            async with ida_mcp_keepalive.keepalive_worker_during(
+                session,
+                debug=False,
+                activity="llm_decompile",
+            ):
+                await asyncio.wait_for(keepalive_called.wait(), timeout=1)
+            keepalive_count = session.call_tool.await_count
+            await asyncio.sleep(0.005)
+
+        self.assertGreaterEqual(keepalive_count, 1)
+        self.assertEqual(keepalive_count, session.call_tool.await_count)
+        self.assertTrue(
+            all(
+                call.kwargs == {"name": "py_eval", "arguments": {"code": "1"}}
+                for call in session.call_tool.await_args_list
+            )
+        )
+
+    async def test_keepalive_failure_does_not_replace_foreground_result(self) -> None:
+        keepalive_called = asyncio.Event()
+
+        async def fail_keepalive(*_args, **_kwargs) -> None:
+            keepalive_called.set()
+            raise RuntimeError("worker unavailable")
+
+        session = SimpleNamespace(call_tool=AsyncMock(side_effect=fail_keepalive))
+
+        with (
+            patch.object(ida_mcp_keepalive, "WORKER_KEEPALIVE_INTERVAL_SECONDS", 0.001),
+            patch("builtins.print") as mock_print,
+        ):
+            async with ida_mcp_keepalive.keepalive_worker_during(
+                session,
+                debug=True,
+                activity="llm_decompile",
+            ):
+                await asyncio.wait_for(keepalive_called.wait(), timeout=1)
+                result = "foreground result"
+
+        self.assertEqual("foreground result", result)
+        mock_print.assert_called()


### PR DESCRIPTION
## Summary
- make OpenAI-compatible and Codex SSE LLM transports fully asynchronous while retaining a narrow synchronous bridge for vcall aggregation
- refresh the bound IDALIB worker with `py_eval(1)` every 240 seconds only while awaiting remote LLM results, and always stop the heartbeat afterward
- add async transport, heartbeat lifecycle, and LLM integration coverage; Agent fallback remains unchanged

## Validation
- implementation-specific tests: 33 focused tests passed; 134 LLM/preprocessor tests passed; Ruff check/format and compileall passed
- repository suites: unit 1122/1122 passed; all and legacy discovery each ran 1267 tests with 3 skipped and no failures
- candidate preparation and C++ validation: delegated to `pr-self-runner.yml` CI; snapshot/gamedata publication is release-pipeline only