### PR TITLE
CEngineServer_SetClientListening

### DIFF
--- a/configs/14177b.yaml
+++ b/configs/14177b.yaml
@@ -1588,6 +1588,11 @@ modules:
       - name: find-CEngineServer_vtable
         expected_output:
           - CEngineServer_vtable.{platform}.yaml
+      - name: find-CEngineServer_SetClientUpdateRate
+        expected_output:
+          - CEngineServer_SetClientUpdateRate.{platform}.yaml
+        expected_input:
+          - CEngineServer_vtable.{platform}.yaml
       - name: find-CMapListService_vtable
         expected_output:
           - CMapListService_vtable.{platform}.yaml
@@ -3265,6 +3270,10 @@ modules:
           - INetworkGameClient::SendStringCmd
       - name: CEngineServer_vtable
         category: vtable
+      - name: CEngineServer_SetClientUpdateRate
+        category: vfunc
+        alias:
+          - CEngineServer::SetClientUpdateRate
       - name: CMapListService_vtable
         category: vtable
       - name: CEngineServer_DumpNetStats
@@ -6326,6 +6335,11 @@ modules:
           - CGameSceneNode_vtable.{platform}.yaml
       - name: find-CBasePlayerController_vtable
         expected_output:
+          - CBasePlayerController_vtable.{platform}.yaml
+      - name: find-CBasePlayerController_ClientSettingsChanged
+        expected_output:
+          - CBasePlayerController_ClientSettingsChanged.{platform}.yaml
+        expected_input:
           - CBasePlayerController_vtable.{platform}.yaml
       - name: find-CCSPlayerController_vtable
         expected_output:
@@ -9655,6 +9669,10 @@ modules:
         category: vtable
       - name: CBasePlayerController_vtable
         category: vtable
+      - name: CBasePlayerController_ClientSettingsChanged
+        category: vfunc
+        alias:
+          - CBasePlayerController::ClientSettingsChanged
       - name: CCSPlayerController_vtable
         category: vtable
       - name: CBasePlayerPawn_vtable

--- a/ida_preprocessor_scripts/find-CBasePlayerController_ClientSettingsChanged.py
+++ b/ida_preprocessor_scripts/find-CBasePlayerController_ClientSettingsChanged.py
@@ -1,0 +1,44 @@
+#!/usr/bin/env python3
+"""Preprocess script for find-CBasePlayerController_ClientSettingsChanged."""
+
+from ida_analyze_util import preprocess_common_skill
+
+TARGET_FUNCTION_NAMES = ["CBasePlayerController_ClientSettingsChanged"]
+FUNC_XREFS = [
+    {
+        "func_name": "CBasePlayerController_ClientSettingsChanged",
+        "xref_strings": ["SV: %d(%s) changed min command queue size to %d\\n"],
+        "xref_gvs": [],
+        "xref_signatures": [],
+        "xref_funcs": [],
+        "exclude_funcs": [],
+        "exclude_strings": [],
+        "exclude_gvs": [],
+        "exclude_signatures": [],
+    }
+]
+FUNC_VTABLE_RELATIONS = [("CBasePlayerController_ClientSettingsChanged", "CBasePlayerController_vtable")]
+GENERATE_YAML_DESIRED_FIELDS = [
+    (
+        "CBasePlayerController_ClientSettingsChanged",
+        ["func_name", "func_va", "func_rva", "func_size", "func_sig", "vtable_name", "vfunc_offset", "vfunc_index"],
+    )
+]
+
+
+async def preprocess_skill(
+    session, skill_name, expected_outputs, old_yaml_map, new_binary_dir, platform, image_base, debug=False
+):
+    return await preprocess_common_skill(
+        session=session,
+        expected_outputs=expected_outputs,
+        old_yaml_map=old_yaml_map,
+        new_binary_dir=new_binary_dir,
+        platform=platform,
+        image_base=image_base,
+        func_names=TARGET_FUNCTION_NAMES,
+        func_xrefs=FUNC_XREFS,
+        func_vtable_relations=FUNC_VTABLE_RELATIONS,
+        generate_yaml_desired_fields=GENERATE_YAML_DESIRED_FIELDS,
+        debug=debug,
+    )

--- a/ida_preprocessor_scripts/find-CEngineServer_SetClientUpdateRate.py
+++ b/ida_preprocessor_scripts/find-CEngineServer_SetClientUpdateRate.py
@@ -1,0 +1,44 @@
+#!/usr/bin/env python3
+"""Preprocess script for find-CEngineServer_SetClientUpdateRate."""
+
+from ida_analyze_util import preprocess_common_skill
+
+TARGET_FUNCTION_NAMES = ["CEngineServer_SetClientUpdateRate"]
+LLM_DECOMPILE = [
+    (
+        "CEngineServer_SetClientUpdateRate",
+        "prompt/call_llm_decompile.md",
+        "references/server/CBasePlayerController_ClientSettingsChanged.{platform}.yaml",
+    )
+]
+FUNC_VTABLE_RELATIONS = [("CEngineServer_SetClientUpdateRate", "CEngineServer_vtable")]
+GENERATE_YAML_DESIRED_FIELDS = [
+    ("CEngineServer_SetClientUpdateRate", ["func_name", "vfunc_sig", "vfunc_offset", "vfunc_index", "vtable_name"])
+]
+
+
+async def preprocess_skill(
+    session,
+    skill_name,
+    expected_outputs,
+    old_yaml_map,
+    new_binary_dir,
+    platform,
+    image_base,
+    llm_config=None,
+    debug=False,
+):
+    return await preprocess_common_skill(
+        session=session,
+        expected_outputs=expected_outputs,
+        old_yaml_map=old_yaml_map,
+        new_binary_dir=new_binary_dir,
+        platform=platform,
+        image_base=image_base,
+        func_names=TARGET_FUNCTION_NAMES,
+        func_vtable_relations=FUNC_VTABLE_RELATIONS,
+        llm_decompile_specs=LLM_DECOMPILE,
+        llm_config=llm_config,
+        generate_yaml_desired_fields=GENERATE_YAML_DESIRED_FIELDS,
+        debug=debug,
+    )


### PR DESCRIPTION
/create-preprocessor-scripts create "find-CBasePlayerController_ClientSettingsChanged" by xref_strings "SV: %d(%s) changed min command queue size to %d\n".

CBasePlayerController_ClientSettingsChanged is vfunc of CBasePlayerController_vtable.

/create-preprocessor-scripts create "find-CEngineServer_SetClientUpdateRate" by LLM_DECOMPILE with CBasePlayerController_ClientSettingsChanged, which is in server module.

CEngineServer_SetClientUpdateRate is vfunc of CEngineServer_vtable in engine module. (Both inlined and de-inlined chain should be supported.)