### PR TITLE
fix(cache): harden atomic JSON replacement on Windows

### DIFF
--- a/idb_cache.py
+++ b/idb_cache.py
@@ -153,8 +153,15 @@ def _ready_payload(*, gamever: str, generation: str, cache_key: str, manifest_sh
 
 def _write_ready(persisted_root: Path, gamever: str, payload: dict) -> None:
     cache_root = _cache_root(persisted_root, gamever)
-    reject_reparse_components(Path(persisted_root), cache_root)
-    write_canonical_json(cache_root / "READY.json", payload)
+    ready_path = cache_root / "READY.json"
+    reject_reparse_components(Path(persisted_root), ready_path)
+    expected = canonical_json_bytes(payload)
+    try:
+        if ready_path.read_bytes() == expected:
+            return
+    except OSError:
+        pass
+    write_canonical_json(ready_path, payload)
 
 
 def _load_generation(

--- a/release_workflow_lib/hashing.py
+++ b/release_workflow_lib/hashing.py
@@ -1,8 +1,11 @@
 import hashlib
 import json
 import os
+import random
 import stat
 import subprocess
+import time
+import uuid
 from pathlib import Path, PurePosixPath
 
 from release_workflow_lib.errors import ReleaseWorkflowError
@@ -10,6 +13,11 @@ from release_workflow_lib.errors import ReleaseWorkflowError
 HEX_SHA256_LENGTH = 64
 READ_CHUNK_SIZE = 1024 * 1024
 REGULAR_GIT_MODES = {"100644", "100755"}
+WINDOWS_ERROR_ACCESS_DENIED = 5
+WINDOWS_ERROR_SHARING_VIOLATION = 32
+WINDOWS_REPLACE_RETRY_ERRORS = {WINDOWS_ERROR_ACCESS_DENIED, WINDOWS_ERROR_SHARING_VIOLATION}
+WINDOWS_REPLACE_RETRY_DELAYS = (0.05, 0.1, 0.2, 0.4, 0.8, 1.6)
+WINDOWS_REPLACE_RETRY_JITTER_RATIO = 0.25
 
 
 def canonical_json_bytes(value: object) -> bytes:
@@ -28,12 +36,53 @@ def sha256_file(path: Path) -> str:
     return digest.hexdigest()
 
 
+def _path_matches_payload(path: Path, payload: bytes) -> bool:
+    try:
+        return path.read_bytes() == payload
+    except OSError:
+        return False
+
+
+def _replace_with_windows_retry(source: Path, target: Path, payload: bytes) -> None:
+    attempts = 0
+    while True:
+        attempts += 1
+        try:
+            os.replace(source, target)
+            return
+        except OSError as exc:
+            if _path_matches_payload(target, payload):
+                return
+            winerror = getattr(exc, "winerror", None)
+            retry_index = attempts - 1
+            if winerror not in WINDOWS_REPLACE_RETRY_ERRORS:
+                raise
+            if retry_index >= len(WINDOWS_REPLACE_RETRY_DELAYS):
+                raise OSError(
+                    f"atomic replace failed after {attempts} attempts with WinError {winerror}: "
+                    f"{source} -> {target}: {exc}"
+                ) from exc
+            delay = WINDOWS_REPLACE_RETRY_DELAYS[retry_index]
+            jitter = random.uniform(0.0, delay * WINDOWS_REPLACE_RETRY_JITTER_RATIO)
+            time.sleep(delay + jitter)
+
+
 def write_canonical_json(path: Path, value: object) -> None:
     path = Path(path)
     path.parent.mkdir(parents=True, exist_ok=True)
-    temporary = path.with_name(f".{path.name}.{os.getpid()}.tmp")
-    temporary.write_bytes(canonical_json_bytes(value))
-    os.replace(temporary, path)
+    payload = canonical_json_bytes(value)
+    temporary = path.with_name(f".{path.name}.{uuid.uuid4().hex}.tmp")
+    try:
+        temporary.write_bytes(payload)
+        _replace_with_windows_retry(temporary, path, payload)
+    except BaseException:
+        try:
+            temporary.unlink(missing_ok=True)
+        except OSError:
+            pass
+        raise
+    else:
+        temporary.unlink(missing_ok=True)
 
 
 def load_json_object(path: Path) -> dict:

--- a/tests/run_test_suite.py
+++ b/tests/run_test_suite.py
@@ -58,6 +58,7 @@ UNIT_MODULES = frozenset(
     {
         "test_agent_runner",
         "test_analysis_config",
+        "test_atomic_json_write",
         "test_binary_hashing",
         "test_bump_download",
         "test_copy_depot_bin",

--- a/tests/test_atomic_json_write.py
+++ b/tests/test_atomic_json_write.py
@@ -1,0 +1,132 @@
+import tempfile
+import unittest
+from concurrent.futures import ThreadPoolExecutor
+from pathlib import Path
+from unittest.mock import patch
+
+from release_workflow_lib import hashing
+
+
+def _windows_error(winerror: int) -> OSError:
+    error = OSError(f"simulated WinError {winerror}")
+    error.winerror = winerror
+    return error
+
+
+class TestAtomicJsonWrite(unittest.TestCase):
+    def test_retries_transient_windows_replace_errors(self) -> None:
+        with tempfile.TemporaryDirectory() as temp_dir:
+            target = Path(temp_dir) / "READY.json"
+            with (
+                patch.object(
+                    hashing.os,
+                    "replace",
+                    side_effect=[_windows_error(5), _windows_error(32), None],
+                ) as replace,
+                patch.object(hashing.random, "uniform", return_value=0.0),
+                patch.object(hashing.time, "sleep") as sleep,
+            ):
+                hashing.write_canonical_json(target, {"state": "ready"})
+
+            self.assertEqual(3, replace.call_count)
+            self.assertEqual([unittest.mock.call(0.05), unittest.mock.call(0.1)], sleep.call_args_list)
+            temporary_paths = {call.args[0] for call in replace.call_args_list}
+            self.assertEqual(1, len(temporary_paths))
+            self.assertRegex(next(iter(temporary_paths)).name, r"^\.READY\.json\.[0-9a-f]{32}\.tmp$")
+            self.assertEqual([], list(Path(temp_dir).glob(".READY.json.*.tmp")))
+
+    def test_accepts_matching_target_written_by_another_writer(self) -> None:
+        with tempfile.TemporaryDirectory() as temp_dir:
+            target = Path(temp_dir) / "READY.json"
+            payload = hashing.canonical_json_bytes({"state": "ready"})
+
+            def concurrent_replace(_source: Path, destination: Path) -> None:
+                destination.write_bytes(payload)
+                raise _windows_error(5)
+
+            with (
+                patch.object(hashing.os, "replace", side_effect=concurrent_replace) as replace,
+                patch.object(hashing.time, "sleep") as sleep,
+            ):
+                hashing.write_canonical_json(target, {"state": "ready"})
+
+            replace.assert_called_once()
+            sleep.assert_not_called()
+            self.assertEqual(payload, target.read_bytes())
+            self.assertEqual([], list(Path(temp_dir).glob(".READY.json.*.tmp")))
+
+    def test_reports_retry_exhaustion_and_removes_temporary_file(self) -> None:
+        with tempfile.TemporaryDirectory() as temp_dir:
+            target = Path(temp_dir) / "READY.json"
+            with (
+                patch.object(hashing.os, "replace", side_effect=_windows_error(5)) as replace,
+                patch.object(hashing.random, "uniform", return_value=0.0),
+                patch.object(hashing.time, "sleep") as sleep,
+                self.assertRaisesRegex(OSError, r"after 7 attempts with WinError 5"),
+            ):
+                hashing.write_canonical_json(target, {"state": "ready"})
+
+            self.assertEqual(7, replace.call_count)
+            self.assertEqual(6, sleep.call_count)
+            self.assertEqual([], list(Path(temp_dir).glob(".READY.json.*.tmp")))
+
+    def test_does_not_retry_non_windows_replace_error(self) -> None:
+        with tempfile.TemporaryDirectory() as temp_dir:
+            target = Path(temp_dir) / "READY.json"
+            failure = OSError("permanent failure")
+            with (
+                patch.object(hashing.os, "replace", side_effect=failure) as replace,
+                patch.object(hashing.time, "sleep") as sleep,
+                self.assertRaisesRegex(OSError, "permanent failure"),
+            ):
+                hashing.write_canonical_json(target, {"state": "ready"})
+
+            replace.assert_called_once()
+            sleep.assert_not_called()
+            self.assertEqual([], list(Path(temp_dir).glob(".READY.json.*.tmp")))
+
+    def test_cleanup_failure_does_not_mask_replace_failure(self) -> None:
+        with tempfile.TemporaryDirectory() as temp_dir:
+            target = Path(temp_dir) / "READY.json"
+            replacement_failure = OSError("replacement failed")
+            with (
+                patch.object(hashing.os, "replace", side_effect=replacement_failure),
+                patch.object(Path, "unlink", side_effect=OSError("cleanup failed")),
+                self.assertRaises(OSError) as raised,
+            ):
+                hashing.write_canonical_json(target, {"state": "ready"})
+
+            self.assertIs(replacement_failure, raised.exception)
+
+    def test_uses_distinct_temporary_paths_for_sequential_writes(self) -> None:
+        with tempfile.TemporaryDirectory() as temp_dir:
+            target = Path(temp_dir) / "READY.json"
+            sources = []
+
+            def capture_replace(source: Path, _destination: Path) -> None:
+                sources.append(source)
+
+            with patch.object(hashing.os, "replace", side_effect=capture_replace):
+                hashing.write_canonical_json(target, {"sequence": 1})
+                hashing.write_canonical_json(target, {"sequence": 2})
+
+            self.assertEqual(2, len(sources))
+            self.assertNotEqual(sources[0], sources[1])
+
+    def test_concurrent_writers_leave_one_complete_payload(self) -> None:
+        with tempfile.TemporaryDirectory() as temp_dir:
+            target = Path(temp_dir) / "READY.json"
+            payloads = [{"sequence": sequence, "value": "x" * 1024} for sequence in range(16)]
+
+            def write(payload: dict) -> None:
+                hashing.write_canonical_json(target, payload)
+
+            with ThreadPoolExecutor(max_workers=8) as executor:
+                list(executor.map(write, payloads))
+
+            self.assertIn(hashing.load_json_object(target), payloads)
+            self.assertEqual([], list(Path(temp_dir).glob(".READY.json.*.tmp")))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_idb_cache.py
+++ b/tests/test_idb_cache.py
@@ -33,6 +33,34 @@ class TestIdbCache(unittest.TestCase):
             iter_configured_binaries=self._configured_binaries,
         )
 
+    def test_write_ready_skips_unchanged_pointer(self) -> None:
+        with tempfile.TemporaryDirectory() as temp_dir:
+            persisted_root = Path(temp_dir)
+            gamever = "14180"
+            payload = {"schema_version": 1, "gamever": gamever, "generation": "generation"}
+            ready_path = persisted_root / "idb-cache" / gamever / "READY.json"
+            ready_path.parent.mkdir(parents=True)
+            ready_path.write_bytes(idb_cache.canonical_json_bytes(payload))
+
+            with patch.object(idb_cache, "write_canonical_json") as write:
+                idb_cache._write_ready(persisted_root, gamever, payload)
+
+            write.assert_not_called()
+
+    def test_write_ready_replaces_changed_pointer(self) -> None:
+        with tempfile.TemporaryDirectory() as temp_dir:
+            persisted_root = Path(temp_dir)
+            gamever = "14180"
+            payload = {"schema_version": 1, "gamever": gamever, "generation": "new-generation"}
+            ready_path = persisted_root / "idb-cache" / gamever / "READY.json"
+            ready_path.parent.mkdir(parents=True)
+            ready_path.write_bytes(idb_cache.canonical_json_bytes({"generation": "old-generation"}))
+
+            with patch.object(idb_cache, "write_canonical_json") as write:
+                idb_cache._write_ready(persisted_root, gamever, payload)
+
+            write.assert_called_once_with(ready_path, payload)
+
     def test_publish_probe_and_restore_verified_generation(self) -> None:
         with tempfile.TemporaryDirectory() as temp_dir:
             root = Path(temp_dir)


### PR DESCRIPTION
## Summary
- skip redundant READY.json replacement when the canonical pointer content is unchanged
- retry transient Windows access and sharing failures with bounded jittered backoff while preserving atomic replacement
- use UUID temporary paths, clean failed writes, and accept an identical pointer completed by a concurrent writer
- add focused retry, cleanup, concurrency, and IDB cache pointer tests

## Validation
- uv run python -m unittest tests.test_atomic_json_write tests.test_idb_cache: 19 passed
- uv run python tests/run_test_suite.py unit -b --durations 30: 1136 passed
- uv run python tests/run_test_suite.py all -b --durations 30: assignment audit discovered 1300 tests; 1278 passed, 3 environment-related class skips, 0 failures, 0 errors
- uv run python -m unittest discover -s tests -b: 1278 passed, 3 environment-related class skips
- uv run python format_repo_files.py --check: passed
- uv run ruff check release_workflow_lib/hashing.py idb_cache.py tests/test_atomic_json_write.py tests/test_idb_cache.py tests/run_test_suite.py: passed