### PR TITLE
test(cpp-tests): add IEngineServiceMgr vtable validation

### DIFF
--- a/configs/14178.yaml
+++ b/configs/14178.yaml
@@ -13806,3 +13806,28 @@ cpp_tests:
       - fdump-vtable-layouts
     # No reference_modules yet: ICommandLine has no binary reference YAMLs
     # (tier0/vstdlib is not an analyzed module). Compile-only validation.
+  - name: IEngineServiceMgr_MSVC
+    symbol: IEngineServiceMgr
+    alias_symbols:
+      - CEngineServiceMgr
+    cpp: cpp_tests/iengineservicemgr.cpp
+    headers:
+      - hl2sdk_cs2/public/engine/IEngineService.h  # Used by the fix-cppheaders SKILL
+    target: x86_64-pc-windows-msvc
+    include_directories:
+      - hl2sdk_cs2/game/shared
+      - hl2sdk_cs2/public
+      - hl2sdk_cs2/public/tier0
+      - hl2sdk_cs2/public/tier1
+      - hl2sdk_cs2/public/mathlib
+    defines:
+      - COMPILER_MSVC=1
+      - COMPILER_MSVC64=1
+      - _MSVC_STL_USE_ABORT_AS_DOOM_FUNCTION
+    additional_compiler_options:
+      - fms-extensions
+      - fms-compatibility
+      - Xclang
+      - fdump-vtable-layouts
+    reference_modules:
+      - engine  # bin/{gamever}/engine/CEngineServiceMgr_*.{platform}.yaml

--- a/cpp_tests/iengineservicemgr.cpp
+++ b/cpp_tests/iengineservicemgr.cpp
@@ -1,0 +1,21 @@
+#include <tier0/platform.h>
+#undef RESTRICT
+#define RESTRICT
+
+#include <tier1/convar.h>
+#include <KeyValues.h>
+
+// RenderDeviceInfo_t is defined via eiface.h (heavy protobuf chain); forward-declare
+// the opaque type since IEngineServiceMgr only references it by reference.
+struct RenderDeviceInfo_t;
+
+#include <engine/IEngineService.h>
+
+IEngineServiceMgr * engineservicemgr();
+
+int main() {
+
+    engineservicemgr()->PrintStatus();
+
+    return 0;
+}


### PR DESCRIPTION
## Summary
- Adds `cpp_tests/iengineservicemgr.cpp` to validate the `IEngineServiceMgr` vtable layout from `hl2sdk_cs2` against the binary reference YAMLs (`CEngineServiceMgr`).
- Adds a `cpp_tests:` entry (`IEngineServiceMgr_MSVC`) in `configs/14178.yaml` with alias `CEngineServiceMgr` and reference module `engine`.
- Adds `IEngineServiceMgr::unk302` to `hl2sdk_cs2/public/engine/IEngineService.h` so the reconstructed interface header produces a vtable matching the binary (61 vfuncs vs 60 previously).
- `hl2sdk_cs2` submodule pointer bumped to `56f8a156` (`fix(engine): add IEngineServiceMgr::unk302 vtable slot to match binary`).

## Validation
- Manual clang compile (`x86_64-pc-windows-msvc`) succeeds; vtable layout comparison against `bin/14178/engine/CEngineServiceMgr_*` reports **0 differences** (parsed=61, declared=61 via alias `CEngineServiceMgr`).
- Note: a full `run_cpp_tests.py` run is currently blocked by a **pre-existing** snapshot `config-digest` mismatch (HEAD config digest `41771c0f` vs published `d25ac5c6`). This is unrelated to this change and affects `configs/14178.yaml` `modules` (not `cpp_tests`).