### PR TITLE
test(reference-yaml): enforce required properties in reference YAML

### DIFF
--- a/tests/run_test_suite.py
+++ b/tests/run_test_suite.py
@@ -24,6 +24,7 @@ REPOSITORY_CONTRACT_MODULES = frozenset(
         "test_config_scheduling_dependencies",
         "test_pack_snapshot_skill",
         "test_pr_self_runner_workflow",
+        "test_reference_yaml_contract",
         "test_restore_from_snapshot_skill",
         "test_smoke_ida_mcp_2",
         "test_symbol_store_architecture",

--- a/tests/test_reference_yaml_contract.py
+++ b/tests/test_reference_yaml_contract.py
@@ -1,0 +1,66 @@
+"""Repository-contract tests for reference YAML assets.
+
+Every ``ida_preprocessor_scripts/references/**/*.yaml`` file is an input to the
+IDA preprocess pipeline and must carry at least ``func_name``, a resolvable
+``func_va``, and a non-empty ``disasm_code``. These tests fail with the exact
+file path and the specific anomaly so a stray stub (e.g. a file containing only
+``func_name``) is caught at PR time instead of during analysis.
+"""
+
+import unittest
+from pathlib import Path
+
+import generate_reference_yaml
+from trusted_yaml import load_yaml_file
+
+
+def _normalize_address_text(value) -> str | None:
+    return generate_reference_yaml._normalize_address_text(value)
+
+
+def _normalize_non_empty_text(value) -> str | None:
+    return generate_reference_yaml._normalize_non_empty_text(value)
+
+
+def _payload_problems(path: Path) -> list[str]:
+    """Return a human-readable list of contract violations for one YAML file."""
+    try:
+        payload = load_yaml_file(path, cache=True, copy_result=False)
+    except Exception as exc:  # noqa: BLE001 - surface any parse failure as a contract violation
+        return [f"YAML load error: {exc!r}"]
+
+    if not isinstance(payload, dict):
+        return [f"top-level YAML is not a mapping: {type(payload).__name__}"]
+
+    problems: list[str] = []
+    func_name = _normalize_non_empty_text(payload.get("func_name"))
+    func_va = _normalize_address_text(payload.get("func_va"))
+    disasm_code = _normalize_non_empty_text(payload.get("disasm_code"))
+
+    if func_name is None:
+        problems.append("func_name is missing or empty")
+    if func_va is None:
+        problems.append(f"func_va is missing or invalid: {payload.get('func_va')!r}")
+    if disasm_code is None:
+        problems.append("disasm_code is missing or empty/whitespace")
+    return problems
+
+
+class TestRepositoryReferenceYamlContract(unittest.TestCase):
+    def test_reference_yamls_have_required_properties(self) -> None:
+        references_root = Path("ida_preprocessor_scripts/references")
+        files = sorted(references_root.glob("**/*.yaml"))
+        self.assertGreater(len(files), 0, f"no reference YAML files found under {references_root}")
+
+        for path in files:
+            with self.subTest(reference=path.as_posix()):
+                problems = _payload_problems(path)
+                self.assertEqual(
+                    [],
+                    problems,
+                    f"{path.as_posix()} reference YAML anomaly: " + "; ".join(problems),
+                )
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Why / Intent

The reference YAMLs under `ida_preprocessor_scripts/references/**` are **inputs** to the IDA preprocess pipeline. Each one must carry a resolvable `func_va` and a non-empty `disasm_code`, otherwise the corresponding `find-*.py` consumer cannot locate/decompile the function during analysis.

We found this contract is **not enforced by any PR check**. A stub reference YAML (one that contains only `func_name`, like PR #859's `CPVSManager_ResetPVS.*.yaml` / `CSource2GameClients_ClientSetupVisibility.*.yaml`) slips through both:

- `validate-generated-output-pr.yml` — doesn't trigger for dev branches (only `gamesymbols/build/`), and even then never inspects reference YAML content.
- `pr-self-runner.yml` — runs the unittest suites, but no test reads reference YAML content; the repo-contract test only verifies the file exists and its `func_name` matches the dependency policy, which a stub satisfies.

The **intent** of this PR is to close that gap by enforcing the same contract the generator already guarantees at write time (`generate_reference_yaml.py:_validate_reference_yaml_payload`), but at PR-merge time. A malformed/stub reference then fails CI with a message that names the exact file and the property that is broken, instead of surfacing later during real analysis or being merged silently.

## Summary

Add a repository-contract test (`test_reference_yaml_contract`) that iterates every `ida_preprocessor_scripts/references/**/*.yaml` and asserts:

- `func_name` is present and non-empty
- `func_va` exists and is a valid address
- `disasm_code` is non-empty (not blank/whitespace)

## Changes

- `tests/test_reference_yaml_contract.py` (new): the repository-contract test, with per-file `subTest` isolation and clear error text `"<file> reference YAML anomaly: func_va is missing or invalid: ...; disasm_code is missing or empty/whitespace"`.
- `tests/run_test_suite.py`: add `test_reference_yaml_contract` to `REPOSITORY_CONTRACT_MODULES` so it is assigned to the `repository-contract` suite (avoids the suite-audit `unassigned` failure).

## Verification

- `PYTHONPATH=. uv run python tests/test_reference_yaml_contract.py` → `Ran 1 test ... OK` (all 527 reference YAMLs on `main` are valid).
- Suite assignment audit: `audit issues: []`.
- Probed detection against a PR #859-style stub → `['func_va is missing or invalid: None', 'disasm_code is missing or empty/whitespace']`.
- `uv run python format_repo_files.py --check` → pass, no changes.

## Test plan

- [x] Test passes against the clean `main` baseline
- [x] Correctly rejects a stub reference YAML (only `func_name`)
- [x] CI `pr-validate-full` repository-contract suite assignment is valid