### PR TITLE
CNetworkGameServerBase_GetGlobals

### DIFF
--- a/configs/14178b.yaml
+++ b/configs/14178b.yaml
@@ -1547,6 +1547,11 @@ modules:
         expected_input:
           - CNetworkGameServerBase_vtable.{platform}.yaml
           - INetworkGameServer_GetTimescale.{platform}.yaml
+      - name: find-CNetworkGameServerBase_GetGlobals
+        expected_output:
+          - CNetworkGameServerBase_GetGlobals.{platform}.yaml
+        expected_input:
+          - CNetworkGameServerBase_vtable.{platform}.yaml
       - name: find-INetworkGameServer_GetServerNetworkAddress
         expected_output:
           - INetworkGameServer_GetServerNetworkAddress.{platform}.yaml
@@ -3436,6 +3441,10 @@ modules:
         category: vfunc
         alias:
           - CNetworkGameServerBase::GetTimescale
+      - name: CNetworkGameServerBase_GetGlobals
+        category: vfunc
+        alias:
+          - CNetworkGameServerBase::GetGlobals
       - name: INetworkGameServer_GetServerNetworkAddress
         category: vfunc
         alias:

--- a/ida_preprocessor_scripts/find-CNetworkGameServerBase_GetGlobals.py
+++ b/ida_preprocessor_scripts/find-CNetworkGameServerBase_GetGlobals.py
@@ -1,0 +1,54 @@
+#!/usr/bin/env python3
+"""Resolve CNetworkGameServerBase::GetGlobals from its declared vtable slot."""
+
+from pathlib import Path
+
+from ida_analyze_util import _preprocess_direct_func_sig_via_mcp, write_func_yaml
+
+
+TARGET_FUNCTION_NAME = "CNetworkGameServerBase_GetGlobals"
+VTABLE_CLASS = "CNetworkGameServerBase"
+# INetworkGameServer declares GetGlobals after Init, SetGameSpawnGroupMgr,
+# SetGameSessionManifest, RegisterLoadingSpawnGroups, Shutdown, AddRef, and
+# Release. The inherited slot is therefore index 7 (0x38) on both platforms.
+VFUNC_OFFSET = "0x38"
+
+
+def _match_output(expected_outputs, platform):
+    expected_filename = f"{TARGET_FUNCTION_NAME}.{platform}.yaml"
+    matches = [output_path for output_path in expected_outputs if Path(output_path).name == expected_filename]
+    return matches[0] if len(matches) == 1 else None
+
+
+async def preprocess_skill(
+    session,
+    skill_name,
+    expected_outputs,
+    old_yaml_map,
+    new_binary_dir,
+    platform,
+    image_base,
+    debug=False,
+):
+    """Resolve the SDK-defined inherited slot without an unstable getter signature."""
+    _ = skill_name, old_yaml_map, new_binary_dir
+    output_path = _match_output(expected_outputs, platform)
+    if not output_path:
+        return False
+
+    result = await _preprocess_direct_func_sig_via_mcp(
+        session=session,
+        new_path=output_path,
+        image_base=image_base,
+        platform=platform,
+        func_name=TARGET_FUNCTION_NAME,
+        debug=debug,
+        direct_vtable_class=VTABLE_CLASS,
+        direct_vfunc_offset=VFUNC_OFFSET,
+        require_func_sig=False,
+    )
+    if not isinstance(result, dict):
+        return False
+
+    write_func_yaml(output_path, result)
+    return True


### PR DESCRIPTION
## Summary
- Add a preprocessor finder for CNetworkGameServerBase::GetGlobals using the SDK-defined inherited vtable slot (0x38).
- Register the finder and vfunc alias for game version 14178b.

## Validation
- Linux isolated finder passed: 1 successful, 0 failed.
- Python syntax and config parsing passed.
- Repository PR validation is delegated to pr-self-runner.yml CI.