### PR TITLE
chore(trust): approve synchronized PR B tree

### DIFF
--- a/source_artifact_cutover.json
+++ b/source_artifact_cutover.json
@@ -1,1 +1,1 @@
-{"excluded_paths":["source_artifact_cutover.json","source_artifact_policy.yaml"],"prospective_tree_sha256":"sha256:eab3b58d08783685dccb2b59e0897a6a413f3156822d28600000c3382bc0df92","schema_version":1}
+{"excluded_paths":["source_artifact_cutover.json","source_artifact_policy.yaml"],"prospective_tree_sha256":"sha256:4e98fbf045f4a9d7bcedc1f3bd75850a20a9a1d2611d5f0db11b9458713e227b","schema_version":1}


### PR DESCRIPTION
Update the base-approved source-owned cutover digest for PR #902 after syncing the merged queue-gate bridge. The digest excludes the approval manifest and policy as before; this is an independent trust approval only.