### PR TITLE
chore(trust): approve planner-normalized cutover tree

### DIFF
--- a/source_artifact_cutover.json
+++ b/source_artifact_cutover.json
@@ -1,1 +1,1 @@
-{"excluded_paths":["source_artifact_cutover.json","source_artifact_policy.yaml"],"prospective_tree_sha256":"sha256:4e98fbf045f4a9d7bcedc1f3bd75850a20a9a1d2611d5f0db11b9458713e227b","schema_version":1}
+{"excluded_paths":["source_artifact_cutover.json","source_artifact_policy.yaml"],"prospective_tree_sha256":"sha256:498d4e8cdd5cdacc338e66a6b65a7db1ec10178e96ae272b3bf85f8e05877705","schema_version":1}


### PR DESCRIPTION
Update the base-approved cutover digest using the exact trusted planner tree inventory normalization. This is an independent manifest-only trust approval for PR #902.