### PR TITLE
chore(trust): approve final portable test tree

### DIFF
--- a/source_artifact_cutover.json
+++ b/source_artifact_cutover.json
@@ -1,1 +1,1 @@
-{"excluded_paths":["source_artifact_cutover.json","source_artifact_policy.yaml"],"prospective_tree_sha256":"sha256:498d4e8cdd5cdacc338e66a6b65a7db1ec10178e96ae272b3bf85f8e05877705","schema_version":1}
+{"excluded_paths":["source_artifact_cutover.json","source_artifact_policy.yaml"],"prospective_tree_sha256":"sha256:42e86219e9bd6f095919a3184df2afb5055bda1be8a4f5a38fcdb1290cdd22c1","schema_version":1}


### PR DESCRIPTION
Update the base-approved source-owned cutover digest after the final portable Git fixture fix in PR #902. Uses the exact trusted planner tree inventory normalization.