### PR TITLE
chore(trust): approve artifact output bridge tree

### DIFF
--- a/source_artifact_cutover.json
+++ b/source_artifact_cutover.json
@@ -1,1 +1,1 @@
-{"excluded_paths":["source_artifact_cutover.json","source_artifact_policy.yaml"],"prospective_tree_sha256":"sha256:42e86219e9bd6f095919a3184df2afb5055bda1be8a4f5a38fcdb1290cdd22c1","schema_version":1}
+{"excluded_paths":["source_artifact_cutover.json","source_artifact_policy.yaml"],"prospective_tree_sha256":"sha256:07cb95c1b69476033a5f1579b729c75d36bbb05795e45bf873a1d76528d330f3","schema_version":1}


### PR DESCRIPTION
Approve the exact source-owned cutover tree after routing Agent YAML output through CS2VIBE_ARTIFACT_DIR.