### PR TITLE
chore(trust): refresh source cutover digest

### DIFF
--- a/source_artifact_cutover.json
+++ b/source_artifact_cutover.json
@@ -1,1 +1,1 @@
-{"excluded_paths":["source_artifact_cutover.json","source_artifact_policy.yaml"],"prospective_tree_sha256":"sha256:07cb95c1b69476033a5f1579b729c75d36bbb05795e45bf873a1d76528d330f3","schema_version":1}
+{"excluded_paths":["source_artifact_cutover.json","source_artifact_policy.yaml"],"prospective_tree_sha256":"sha256:7c3788986be73ad019cb818f28d70dcd0c7960ce6ac680a7ac41e5ba5f18825b","schema_version":1}


### PR DESCRIPTION
Refresh the base-approved source-owned cutover tree digest to include the fallback skill committed on PR #902. This keeps the bridge transition fail-closed while allowing PR #902's exact prospective tree.