### PR TITLE
chore(trust): approve GetFreeClient fallback tree

### DIFF
--- a/source_artifact_cutover.json
+++ b/source_artifact_cutover.json
@@ -1,1 +1,1 @@
-{"excluded_paths":["source_artifact_cutover.json","source_artifact_policy.yaml"],"prospective_tree_sha256":"sha256:7c3788986be73ad019cb818f28d70dcd0c7960ce6ac680a7ac41e5ba5f18825b","schema_version":1}
+{"excluded_paths":["source_artifact_cutover.json","source_artifact_policy.yaml"],"prospective_tree_sha256":"sha256:3231e0fdb5db61d7274d53a5ae2ac55e984b25a29f05397b974651a0e25215b6","schema_version":1}


### PR DESCRIPTION
Refreshes the source-owned cutover tree digest for the newly added GetFreeClient fallback skill. This is required before PR #902 can bind its trusted planner.