### PR TITLE
chore(trust): approve GetUserIDString fallback tree

### DIFF
--- a/source_artifact_cutover.json
+++ b/source_artifact_cutover.json
@@ -1,1 +1,1 @@
-{"excluded_paths":["source_artifact_cutover.json","source_artifact_policy.yaml"],"prospective_tree_sha256":"sha256:3231e0fdb5db61d7274d53a5ae2ac55e984b25a29f05397b974651a0e25215b6","schema_version":1}
+{"excluded_paths":["source_artifact_cutover.json","source_artifact_policy.yaml"],"prospective_tree_sha256":"sha256:cf5a275792a17bc598bacc3134dff95c3a1806125df2224df2d3b2c05b8ea50c","schema_version":1}


### PR DESCRIPTION
Refreshes the source-owned cutover tree digest for the newly added GetUserIDString fallback skill. Required before PR #902 can bind its trusted planner.