### PR TITLE
chore(trust): approve latest-gamever validation tree

### DIFF
--- a/source_artifact_cutover.json
+++ b/source_artifact_cutover.json
@@ -1,1 +1,1 @@
-{"excluded_paths":["source_artifact_cutover.json","source_artifact_policy.yaml"],"prospective_tree_sha256":"sha256:cf5a275792a17bc598bacc3134dff95c3a1806125df2224df2d3b2c05b8ea50c","schema_version":1}
+{"excluded_paths":["source_artifact_cutover.json","source_artifact_policy.yaml"],"prospective_tree_sha256":"sha256:c16527bad82a275c00352a004d185ceedcb2a2ecfb0096a730b0ffe0c854aa1c","schema_version":1}


### PR DESCRIPTION
Approve the exact source-owned prospective tree after scoping trusted producer validation to the current latest GAMEVER. This bridge updates only the cutover inventory digest; no source artifacts are changed.