### PR TITLE
chore(trust): approve latest validation workflow tree

### DIFF
--- a/source_artifact_cutover.json
+++ b/source_artifact_cutover.json
@@ -1,1 +1,1 @@
-{"excluded_paths":["source_artifact_cutover.json","source_artifact_policy.yaml"],"prospective_tree_sha256":"sha256:c16527bad82a275c00352a004d185ceedcb2a2ecfb0096a730b0ffe0c854aa1c","schema_version":1}
+{"excluded_paths":["source_artifact_cutover.json","source_artifact_policy.yaml"],"prospective_tree_sha256":"sha256:da98d7bdfb6a644adff1138a992e4c2d526350df7e98ddb866c0029e5392c67f","schema_version":1}


### PR DESCRIPTION
Refresh the source-owned cutover inventory digest after the latest-gamever validation workflow bridge merged.