### PR TITLE
chore(trust): refresh cutover tree digest

### DIFF
--- a/source_artifact_cutover.json
+++ b/source_artifact_cutover.json
@@ -1,1 +1,1 @@
-{"excluded_paths":["source_artifact_cutover.json","source_artifact_policy.yaml"],"prospective_tree_sha256":"sha256:da98d7bdfb6a644adff1138a992e4c2d526350df7e98ddb866c0029e5392c67f","schema_version":1}
+{"excluded_paths":["source_artifact_cutover.json","source_artifact_policy.yaml"],"prospective_tree_sha256":"sha256:8d2974a07be8d27dae1a81d735f7553ca8d105e46ef5303b544d602024f366af","schema_version":1}


### PR DESCRIPTION
Refresh the base-approved source-owned cutover tree digest after the latest dev commit. This keeps the cutover bridge bound to the exact prospective tree; no artifact content or validation scope changes.