### PR TITLE
chore(trust): refresh cutover tree digest

### DIFF
--- a/source_artifact_cutover.json
+++ b/source_artifact_cutover.json
@@ -1,1 +1,1 @@
-{"excluded_paths":["source_artifact_cutover.json","source_artifact_policy.yaml"],"prospective_tree_sha256":"sha256:630d0ebba8f83813cd28f10a587ca0dacb147608666bfdc3083d737fadee5548","schema_version":1}
+{"excluded_paths":["source_artifact_cutover.json","source_artifact_policy.yaml"],"prospective_tree_sha256":"sha256:0b49cb53e61c3dd02ba3a4fd8fc28344fc3e2d0c89963e86c364268f2f1e78e0","schema_version":1}


### PR DESCRIPTION
Refresh the base-approved source-owned cutover tree digest for PR #902 after registering the new llm decompile test module. The digest excludes source_artifact_cutover.json and source_artifact_policy.yaml and covers the exact prospective tree.