### PR TITLE
chore(trust): refresh cutover tree digest

### DIFF
--- a/source_artifact_cutover.json
+++ b/source_artifact_cutover.json
@@ -1,1 +1,1 @@
-{"excluded_paths":["source_artifact_cutover.json","source_artifact_policy.yaml"],"prospective_tree_sha256":"sha256:0b49cb53e61c3dd02ba3a4fd8fc28344fc3e2d0c89963e86c364268f2f1e78e0","schema_version":1}
+{"excluded_paths":["source_artifact_cutover.json","source_artifact_policy.yaml"],"prospective_tree_sha256":"sha256:ea41ad7efae4ffb7a6e11dc2dba6d96ba95d05ad593f0905229ee43db92b199e","schema_version":1}


### PR DESCRIPTION
Approves the exact prospective tree for PR #902 after the trusted-root and LLM runner-stall fixes. Validation: canonical digest recomputation and tests.test_trusted_pr_context (5/5).