### PR TITLE
chore(trust): refresh cutover tree digest

### DIFF
--- a/source_artifact_cutover.json
+++ b/source_artifact_cutover.json
@@ -1,1 +1,1 @@
-{"excluded_paths":["source_artifact_cutover.json","source_artifact_policy.yaml"],"prospective_tree_sha256":"sha256:ea41ad7efae4ffb7a6e11dc2dba6d96ba95d05ad593f0905229ee43db92b199e","schema_version":1}
+{"excluded_paths":["source_artifact_cutover.json","source_artifact_policy.yaml"],"prospective_tree_sha256":"sha256:c2705a7cad9e93af4a3c2b5cfddcea9a1adaef5020fe106487320e9f5b8c931c","schema_version":1}


### PR DESCRIPTION
## Summary
- approve the exact prospective source-owned tree for the latest 14178b validation fixes
- keep the cutover manifest and policy excluded from the approved tree digest

## Validation
- `uv run python format_repo_files.py --check`
- `uv run python -m unittest tests.test_trusted_artifact_pr tests.test_trusted_pr_context` (20 passed)
- `git diff --check`
- repository PR validation remains delegated to trusted CI