### PR TITLE
chore(trust): refresh cutover tree digest

### DIFF
--- a/source_artifact_cutover.json
+++ b/source_artifact_cutover.json
@@ -1,1 +1,1 @@
-{"excluded_paths":["source_artifact_cutover.json","source_artifact_policy.yaml"],"prospective_tree_sha256":"sha256:c2705a7cad9e93af4a3c2b5cfddcea9a1adaef5020fe106487320e9f5b8c931c","schema_version":1}
+{"excluded_paths":["source_artifact_cutover.json","source_artifact_policy.yaml"],"prospective_tree_sha256":"sha256:4e0729d7b09cd3ee43134edfb240c8ad890e6726f198aa727daa5067de8704f5","schema_version":1}


### PR DESCRIPTION
## Summary
- approve the exact prospective repository-tree digest for PR #902 after the `CBaseEntity_ScriptSetGravityScale` correction
- keep the trust bridge limited to `source_artifact_cutover.json`

## Bound identity
- PR #902 merge tree: `21bce23401a74a9d6e2f48def2fdefaabb585494`
- approved digest: `sha256:4e0729d7b09cd3ee43134edfb240c8ad890e6726f198aa727daa5067de8704f5`

## Validation
- `uv run python -m unittest tests.test_trusted_artifact_pr`: 15 passed
- `uv run python format_repo_files.py --check`: passed
- `git diff --check`: passed