### PR TITLE
chore(trust): refresh cutover tree digest

### DIFF
--- a/source_artifact_cutover.json
+++ b/source_artifact_cutover.json
@@ -1,1 +1,1 @@
-{"excluded_paths":["source_artifact_cutover.json","source_artifact_policy.yaml"],"prospective_tree_sha256":"sha256:4e0729d7b09cd3ee43134edfb240c8ad890e6726f198aa727daa5067de8704f5","schema_version":1}
+{"excluded_paths":["source_artifact_cutover.json","source_artifact_policy.yaml"],"prospective_tree_sha256":"sha256:c5f53949d1f6327f765e9c2c5fa7f9c14a21e647a6effd33d663cc0c18a2570a","schema_version":1}


### PR DESCRIPTION
## Summary

- approve the exact prospective repository-tree digest for PR #902 after correcting CNetworkMessages_GetNetworkSerializationContextData vfunc metadata
- keep the trust bridge limited to source_artifact_cutover.json

## Bound identity

- PR #902 merge commit: 3befe185d0b772311b738fab868c933480f13648
- PR #902 merge tree: c727adbcdb70936d2c2d2791fa311f37342856c8
- approved digest: sha256:c5f53949d1f6327f765e9c2c5fa7f9c14a21e647a6effd33d663cc0c18a2570a

## Validation

- uv run python -m unittest tests.test_trusted_artifact_pr: 15 passed
- uv run python format_repo_files.py --check: passed
- git diff --check: passed