### PR TITLE
chore(trust): refresh cutover tree digest

### DIFF
--- a/source_artifact_cutover.json
+++ b/source_artifact_cutover.json
@@ -1,1 +1,1 @@
-{"excluded_paths":["source_artifact_cutover.json","source_artifact_policy.yaml"],"prospective_tree_sha256":"sha256:c5f53949d1f6327f765e9c2c5fa7f9c14a21e647a6effd33d663cc0c18a2570a","schema_version":1}
+{"excluded_paths":["source_artifact_cutover.json","source_artifact_policy.yaml"],"prospective_tree_sha256":"sha256:faaf7c76cc5639c4a5ec2280d554eced2691ad9cec6c9917915e4283968924ce","schema_version":1}


### PR DESCRIPTION
## Summary

- approve the exact prospective repository-tree digest for PR #902 after making function-signature finalization and CNetworkMessages_dtor generation deterministic
- keep the trust bridge limited to source_artifact_cutover.json

## Bound identity

- PR #902 head commit: f41913aee925286afd830b08991a74c9068aa8a5
- PR #902 merge commit: d79f8310af47ea47b7630a6dbb62abcdc1a6e0bf
- PR #902 merge tree: a6be98632c6d760eec91c4de435490360b5cdf90
- approved digest: sha256:faaf7c76cc5639c4a5ec2280d554eced2691ad9cec6c9917915e4283968924ce

## Validation

- uv run python -m unittest tests.test_trusted_artifact_pr: 15 passed
- uv run python format_repo_files.py --check: passed
- git diff --check: passed