### PR TITLE
chore(trust): refresh cutover tree digest

### DIFF
--- a/source_artifact_cutover.json
+++ b/source_artifact_cutover.json
@@ -1,1 +1,1 @@
-{"excluded_paths":["source_artifact_cutover.json","source_artifact_policy.yaml"],"prospective_tree_sha256":"sha256:faaf7c76cc5639c4a5ec2280d554eced2691ad9cec6c9917915e4283968924ce","schema_version":1}
+{"excluded_paths":["source_artifact_cutover.json","source_artifact_policy.yaml"],"prospective_tree_sha256":"sha256:0bb54dc42a66dbd217dae4f1a0023107e0d38f485d38c904be8440c07691633e","schema_version":1}


### PR DESCRIPTION
Approves the exact prospective repository tree for PR #902 after preserving the CBaseEntity_SetGravityScale cross-boundary signature contract.\n\nComputed with the trusted main-branch inventory algorithm from merge commit 757952cf571b7fef3b3d270584d5827cc3d3f0f3.\n\n- approved digest: sha256:0bb54dc42a66dbd217dae4f1a0023107e0d38f485d38c904be8440c07691633e\n- targeted trust tests: 6 passed\n\nThis PR changes only source_artifact_cutover.json.