### PR TITLE
fix(ci): bridge accepted-bin trusted entrypoint

### DIFF
--- a/accepted_bin.py
+++ b/accepted_bin.py
@@ -1,0 +1,83 @@
+#!/usr/bin/env python3
+"""Synchronize a verified binary-only workspace into the disposable accepted-bin cache."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from pathlib import Path
+
+from release_workflow_lib.binary_cache import verify_source_binary_root
+from release_workflow_lib.errors import ReleaseWorkflowError
+from release_workflow_lib.legacy_yaml_cleanup import cleanup_legacy_accepted_yaml
+from release_workflow_lib.restore_accepted_bin import restore_accepted_bin
+from release_workflow_lib.sync_accepted_bin import sync_accepted_bin
+
+
+def parse_args(argv=None) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    commands = parser.add_subparsers(dest="command", required=True)
+    sync = commands.add_parser("sync")
+    sync.add_argument("--repo-root", default=".")
+    sync.add_argument("--persisted-root", required=True)
+    sync.add_argument("--gamever", required=True)
+    restore = commands.add_parser("restore")
+    restore.add_argument("--repo-root", default=".")
+    restore.add_argument("--persisted-root", required=True)
+    restore.add_argument("--gamever", required=True)
+    restore.add_argument("--required", action="store_true")
+    verify = commands.add_parser("verify")
+    verify.add_argument("--repo-root", default=".")
+    verify.add_argument("--gamever", required=True)
+    cleanup = commands.add_parser("cleanup-legacy-yaml")
+    cleanup.add_argument("--repo-root", default=".")
+    cleanup.add_argument("--persisted-root", required=True)
+    cleanup.add_argument("--gamever", required=True)
+    return parser.parse_args(argv)
+
+
+def main(argv=None) -> int:
+    args = parse_args(argv)
+    try:
+        if args.command == "sync":
+            result = sync_accepted_bin(
+                repo_root=Path(args.repo_root),
+                persisted_root=Path(args.persisted_root),
+                gamever=args.gamever,
+            )
+        elif args.command == "restore":
+            result = restore_accepted_bin(
+                repo_root=Path(args.repo_root),
+                persisted_root=Path(args.persisted_root),
+                gamever=args.gamever,
+                required=args.required,
+            )
+        elif args.command == "verify":
+            repo_root = Path(args.repo_root).resolve()
+            lock = verify_source_binary_root(
+                repo_root=repo_root,
+                gamever=args.gamever,
+                binary_root=repo_root / "bin" / args.gamever,
+                label="workspace binary tree",
+            )
+            result = {
+                "verified": True,
+                "gamever": args.gamever,
+                "binary_lock_sha256": lock.sha256,
+            }
+        else:
+            result = cleanup_legacy_accepted_yaml(
+                repo_root=Path(args.repo_root),
+                persisted_root=Path(args.persisted_root),
+                gamever=args.gamever,
+            )
+    except (OSError, ReleaseWorkflowError) as exc:
+        print(f"Error: {exc}", file=sys.stderr)
+        return 1
+    print(json.dumps(result, ensure_ascii=False, sort_keys=True))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/release_workflow_lib/binary_cache.py
+++ b/release_workflow_lib/binary_cache.py
@@ -1,0 +1,168 @@
+"""Shared validation, exclusion, and locking rules for disposable binary caches."""
+
+from __future__ import annotations
+
+import os
+import re
+from contextlib import contextmanager
+from pathlib import Path, PurePosixPath
+
+from binary_lock import BinaryLockError, load_binary_lock, verify_binary_root
+from gamesymbol_snapshot_lib.config import load_contract
+from gamesymbol_snapshot_lib.errors import SnapshotConfigError
+from release_workflow_lib.errors import ReleaseWorkflowError
+from release_workflow_lib.hashing import normalized_relative_path, reject_reparse_points
+
+
+GAMEVER_RE = re.compile(r"^[0-9]{4,10}[a-z]?$")
+IDA_DATABASE_SUFFIXES = (".i64", ".idb", ".id0", ".id1", ".id2", ".nam", ".til")
+BINSYNC_REPO_SUFFIX = ".bsproj"
+BINSYNC_SIDECAR_SUFFIX = ".binsync.json"
+DISPOSABLE_ANALYSIS_SUFFIXES = (*IDA_DATABASE_SUFFIXES, BINSYNC_REPO_SUFFIX, BINSYNC_SIDECAR_SUFFIX)
+BINARY_CACHE_LOCK_ROOT = ("binary-cache", "locks")
+
+
+def require_gamever(value: str) -> str:
+    value = str(value)
+    if not GAMEVER_RE.fullmatch(value):
+        raise ReleaseWorkflowError(f"invalid GAMEVER: {value!r}")
+    return value
+
+
+def is_binary_cache_excluded_path(path: Path) -> bool:
+    """Return whether a path is analysis state or forbidden YAML truth."""
+    path = Path(path)
+    return path.suffix.lower() in {".yaml", ".yml"} or any(
+        part.lower().endswith(DISPOSABLE_ANALYSIS_SUFFIXES) for part in path.parts
+    )
+
+
+def ignore_binary_cache_state(_directory: str, names: list[str]) -> set[str]:
+    return {name for name in names if is_binary_cache_excluded_path(Path(name))}
+
+
+def configured_binary_paths(repo_root: str | Path, gamever: str) -> frozenset[str]:
+    """Return the exact accepted-cache paths declared by one analysis config."""
+    repo_root = Path(repo_root).resolve()
+    gamever = require_gamever(gamever)
+    try:
+        contract = load_contract(
+            repo_root / "configs" / f"{gamever}.yaml",
+            gamever,
+            repo_root / "bin",
+            artifactdir=repo_root / "bin_artifacts",
+        )
+    except SnapshotConfigError as exc:
+        raise ReleaseWorkflowError(f"unable to load configured binary allowlist for {gamever}: {exc}") from exc
+    paths = {
+        normalized_relative_path(f"{target.module_name}/{PurePosixPath(target.source_path).name}")
+        for target in contract.binary_targets.values()
+    }
+    if not paths:
+        raise ReleaseWorkflowError(f"configured binary allowlist is empty for {gamever}")
+    return frozenset(paths)
+
+
+def load_source_binary_lock(repo_root: str | Path, gamever: str):
+    """Load the canonical lock bound to this checkout's config and download selection."""
+    repo_root = Path(repo_root).resolve()
+    gamever = require_gamever(gamever)
+    try:
+        contract = load_contract(
+            repo_root / "configs" / f"{gamever}.yaml",
+            gamever,
+            repo_root / "bin",
+            artifactdir=repo_root / "bin_artifacts",
+        )
+        return load_binary_lock(
+            repo_root / "binary_locks" / f"{gamever}.json",
+            game_version=gamever,
+            download_payload=(repo_root / "download.yaml").read_bytes(),
+            binary_targets=contract.binary_targets,
+        )
+    except (BinaryLockError, OSError, SnapshotConfigError) as exc:
+        raise ReleaseWorkflowError(f"unable to load source binary lock for {gamever}: {exc}") from exc
+
+
+def verify_source_binary_root(*, repo_root: str | Path, gamever: str, binary_root: str | Path, label: str):
+    """Require one local binary tree to match the checkout-owned lock exactly."""
+    lock = load_source_binary_lock(repo_root, gamever)
+    try:
+        verify_binary_root(lock.document, Path(binary_root))
+    except BinaryLockError as exc:
+        raise ReleaseWorkflowError(f"{label} does not match source binary lock for {gamever}: {exc}") from exc
+    return lock
+
+
+def validate_binary_cache_tree(root: str | Path, allowed_paths: frozenset[str], *, allow_excluded: bool) -> None:
+    """Require an exact configured binary file set and optionally tolerated cache state."""
+    root = Path(root)
+    reject_reparse_points(root)
+    durable = set()
+    excluded = []
+    allowed_directories = {
+        parent.as_posix()
+        for path in allowed_paths
+        for parent in PurePosixPath(path).parents
+        if parent != PurePosixPath(".")
+    }
+    unexpected_directories = []
+    for path in root.rglob("*"):
+        relative = path.relative_to(root)
+        if is_binary_cache_excluded_path(relative):
+            excluded.append(relative.as_posix())
+        elif path.is_file():
+            durable.add(normalized_relative_path(relative.as_posix()))
+        elif path.is_dir() and normalized_relative_path(relative.as_posix()) not in allowed_directories:
+            unexpected_directories.append(relative.as_posix())
+    if excluded and not allow_excluded:
+        raise ReleaseWorkflowError("excluded analysis state remains in accepted bin: " + ", ".join(sorted(excluded)))
+    if unexpected_directories:
+        raise ReleaseWorkflowError(
+            "binary cache contains unexpected directories: " + ", ".join(sorted(unexpected_directories))
+        )
+    if durable != set(allowed_paths):
+        missing = sorted(set(allowed_paths) - durable)
+        unexpected = sorted(durable - set(allowed_paths))
+        raise ReleaseWorkflowError(f"binary cache allowlist mismatch: missing={missing!r}; unexpected={unexpected!r}")
+
+
+@contextmanager
+def version_lock(lock_path: Path):
+    """Acquire one non-blocking cross-platform lock for a GAMEVER cache writer."""
+    lock_path.parent.mkdir(parents=True, exist_ok=True)
+    handle = lock_path.open("a+b")
+    try:
+        handle.seek(0, os.SEEK_END)
+        if handle.tell() == 0:
+            handle.write(b"0")
+            handle.flush()
+        try:
+            if os.name == "nt":
+                import msvcrt
+
+                handle.seek(0)
+                msvcrt.locking(handle.fileno(), msvcrt.LK_NBLCK, 1)
+            else:
+                import fcntl
+
+                fcntl.flock(handle.fileno(), fcntl.LOCK_EX | fcntl.LOCK_NB)
+        except OSError as exc:
+            raise ReleaseWorkflowError(f"unable to acquire per-version binary cache lock: {lock_path}") from exc
+        try:
+            yield
+        finally:
+            try:
+                if os.name == "nt":
+                    import msvcrt
+
+                    handle.seek(0)
+                    msvcrt.locking(handle.fileno(), msvcrt.LK_UNLCK, 1)
+                else:
+                    import fcntl
+
+                    fcntl.flock(handle.fileno(), fcntl.LOCK_UN)
+            except OSError:
+                pass
+    finally:
+        handle.close()

--- a/release_workflow_lib/legacy_yaml_cleanup.py
+++ b/release_workflow_lib/legacy_yaml_cleanup.py
@@ -1,0 +1,272 @@
+"""Recoverably remove legacy YAML truth from the persisted accepted-bin cache."""
+
+from __future__ import annotations
+
+import os
+import shutil
+from pathlib import Path
+
+from release_workflow_lib.binary_cache import (
+    BINARY_CACHE_LOCK_ROOT,
+    configured_binary_paths,
+    is_binary_cache_excluded_path,
+    require_gamever,
+    validate_binary_cache_tree,
+    version_lock,
+)
+from release_workflow_lib.errors import ReleaseWorkflowError
+from release_workflow_lib.filesystem import remove_tree
+from release_workflow_lib.hashing import (
+    contained_path,
+    inventory_sha256,
+    load_json_object,
+    normalized_relative_path,
+    reject_reparse_components,
+    reject_reparse_points,
+    sha256_file,
+    verify_inventory,
+    write_canonical_json,
+)
+
+
+SCHEMA_VERSION = 1
+
+
+def _yaml_inventory(root: Path) -> list[dict]:
+    reject_reparse_points(root)
+    inventory = []
+    if not root.exists():
+        return inventory
+    for path in sorted(item for item in root.rglob("*") if item.is_file()):
+        if path.suffix.lower() not in {".yaml", ".yml"}:
+            continue
+        relative = normalized_relative_path(path.relative_to(root).as_posix())
+        inventory.append({"path": relative, "size": path.stat().st_size, "sha256": sha256_file(path)})
+    return inventory
+
+
+def _backup_manifest(gamever: str, files: list[dict]) -> dict:
+    return {
+        "schema_version": SCHEMA_VERSION,
+        "gamever": gamever,
+        "file_count": len(files),
+        "inventory_sha256": inventory_sha256(files),
+        "files": files,
+    }
+
+
+def _validate_backup(*, persisted_root: Path, gamever: str, backup_root: Path, files: list[dict]) -> dict:
+    manifest = _backup_manifest(gamever, files)
+    expected_backup = contained_path(
+        persisted_root,
+        "accepted-bin-legacy-yaml",
+        gamever,
+        manifest["inventory_sha256"].removeprefix("sha256:"),
+    )
+    if backup_root.resolve() != expected_backup.resolve():
+        raise ReleaseWorkflowError("legacy YAML cleanup backup path is not canonical")
+    reject_reparse_components(persisted_root, backup_root)
+    if load_json_object(backup_root / "manifest.json") != manifest:
+        raise ReleaseWorkflowError("legacy YAML cleanup backup manifest is invalid")
+    try:
+        backup_digest = verify_inventory(backup_root / "payload", files)
+    except ReleaseWorkflowError as exc:
+        raise ReleaseWorkflowError("legacy YAML cleanup backup payload is damaged") from exc
+    if backup_digest != manifest["inventory_sha256"]:
+        raise ReleaseWorkflowError("legacy YAML cleanup backup payload is damaged")
+    return manifest
+
+
+def _prepare_backup(*, persisted_root: Path, accepted: Path, gamever: str, files: list[dict]) -> tuple[Path, dict]:
+    manifest = _backup_manifest(gamever, files)
+    digest = manifest["inventory_sha256"]
+    digest_component = digest.removeprefix("sha256:")
+    backup_root = contained_path(persisted_root, "accepted-bin-legacy-yaml", gamever, digest_component)
+    incoming = contained_path(persisted_root, "accepted-bin-legacy-yaml", gamever, f".{digest_component}.incoming")
+    if backup_root.exists():
+        return backup_root, _validate_backup(
+            persisted_root=persisted_root,
+            gamever=gamever,
+            backup_root=backup_root,
+            files=files,
+        )
+    if incoming.exists():
+        reject_reparse_points(incoming)
+        remove_tree(incoming)
+    payload = incoming / "payload"
+    try:
+        payload.mkdir(parents=True, exist_ok=True)
+        for item in files:
+            source = contained_path(accepted, *Path(item["path"]).parts)
+            reject_reparse_components(accepted, source)
+            if not source.is_file() or source.stat().st_size != item["size"] or sha256_file(source) != item["sha256"]:
+                raise ReleaseWorkflowError(f"legacy accepted-bin YAML changed before backup: {item['path']}")
+            target = contained_path(payload, *Path(item["path"]).parts)
+            target.parent.mkdir(parents=True, exist_ok=True)
+            shutil.copy2(source, target)
+        if verify_inventory(payload, files) != digest:
+            raise ReleaseWorkflowError("legacy YAML incoming backup failed exact verification")
+        write_canonical_json(incoming / "manifest.json", manifest)
+        backup_root.parent.mkdir(parents=True, exist_ok=True)
+        os.replace(incoming, backup_root)
+    except Exception:
+        if incoming.exists():
+            remove_tree(incoming)
+        raise
+    return backup_root, manifest
+
+
+def _delete_yaml_path(path: Path) -> None:
+    path.unlink()
+
+
+def _allowed_directories(paths: set[str]) -> set[str]:
+    return {parent.as_posix() for value in paths for parent in Path(value).parents if parent != Path(".")}
+
+
+def _validate_pre_cleanup_tree(*, accepted: Path, files: list[dict], allowed_paths: frozenset[str]) -> None:
+    reject_reparse_points(accepted)
+    yaml_paths = {item["path"] for item in files}
+    directories = _allowed_directories(set(allowed_paths) | yaml_paths)
+    durable = set()
+    for path in accepted.rglob("*"):
+        relative = normalized_relative_path(path.relative_to(accepted).as_posix())
+        if path.is_dir():
+            if relative not in directories:
+                raise ReleaseWorkflowError(f"binary cache contains unexpected directories: {relative}")
+            continue
+        if relative in yaml_paths:
+            continue
+        if is_binary_cache_excluded_path(Path(relative)):
+            raise ReleaseWorkflowError(f"excluded analysis state remains in accepted bin: {relative}")
+        durable.add(relative)
+    if durable != set(allowed_paths):
+        missing = sorted(set(allowed_paths) - durable)
+        unexpected = sorted(durable - set(allowed_paths))
+        raise ReleaseWorkflowError(f"binary cache allowlist mismatch: missing={missing!r}; unexpected={unexpected!r}")
+
+
+def _prune_empty_directories(root: Path) -> None:
+    for path in sorted(
+        (item for item in root.rglob("*") if item.is_dir()), key=lambda item: len(item.parts), reverse=True
+    ):
+        try:
+            path.rmdir()
+        except OSError:
+            pass
+
+
+def _resume_deletion(*, accepted: Path, files: list[dict], allowed_paths: frozenset[str]) -> None:
+    current_files = _yaml_inventory(accepted)
+    current_paths = {item["path"] for item in current_files}
+    expected_paths = {item["path"] for item in files}
+    if not current_paths.issubset(expected_paths):
+        raise ReleaseWorkflowError("unrecorded legacy YAML appeared before cleanup completed")
+    _validate_pre_cleanup_tree(accepted=accepted, files=files, allowed_paths=allowed_paths)
+    for item in files:
+        path = contained_path(accepted, *Path(item["path"]).parts)
+        reject_reparse_components(accepted, path)
+        if not path.exists():
+            continue
+        if not path.is_file() or path.stat().st_size != item["size"] or sha256_file(path) != item["sha256"]:
+            raise ReleaseWorkflowError(f"legacy accepted-bin YAML drifted during cleanup: {item['path']}")
+        _delete_yaml_path(path)
+    _prune_empty_directories(accepted)
+    validate_binary_cache_tree(accepted, allowed_paths, allow_excluded=False)
+
+
+def cleanup_legacy_accepted_yaml(*, repo_root: str | Path, persisted_root: str | Path, gamever: str) -> dict:
+    gamever = require_gamever(gamever)
+    repo_root = Path(repo_root).resolve()
+    persisted_root = Path(persisted_root).resolve()
+    allowed_paths = configured_binary_paths(repo_root, gamever)
+    reject_reparse_components(persisted_root, persisted_root)
+    accepted = contained_path(persisted_root, "bin", gamever)
+    reject_reparse_components(persisted_root, accepted)
+    if not accepted.is_dir():
+        raise ReleaseWorkflowError(f"accepted-bin GAMEVER does not exist: {accepted}")
+    state_path = contained_path(persisted_root, "binary-cache", "legacy-yaml-cleanup", f"{gamever}.json")
+    receipt_path = contained_path(persisted_root, "binary-cache", "legacy-yaml-receipts", f"{gamever}.json")
+    lock_path = contained_path(persisted_root, *BINARY_CACHE_LOCK_ROOT, f"{gamever}.lock")
+    with version_lock(lock_path):
+        if receipt_path.is_file():
+            receipt = load_json_object(receipt_path)
+            backup_value = receipt.get("backup_root")
+            if not isinstance(backup_value, str) or not backup_value:
+                raise ReleaseWorkflowError("legacy YAML cleanup receipt identity is invalid")
+            backup_root = Path(backup_value)
+            reject_reparse_components(persisted_root, backup_root)
+            manifest = load_json_object(backup_root / "manifest.json")
+            files = manifest.get("files")
+            if not isinstance(files, list):
+                raise ReleaseWorkflowError("legacy YAML cleanup backup inventory is invalid")
+            manifest = _validate_backup(
+                persisted_root=persisted_root,
+                gamever=gamever,
+                backup_root=backup_root,
+                files=files,
+            )
+            expected_receipt = {
+                "schema_version": SCHEMA_VERSION,
+                "gamever": gamever,
+                "file_count": len(files),
+                "inventory_sha256": manifest["inventory_sha256"],
+                "backup_root": str(backup_root),
+                "backup_manifest_sha256": sha256_file(backup_root / "manifest.json"),
+            }
+            if receipt != expected_receipt:
+                raise ReleaseWorkflowError("legacy YAML cleanup receipt identity is invalid")
+            if _yaml_inventory(accepted):
+                raise ReleaseWorkflowError("legacy YAML reappeared after completed cleanup")
+            _resume_deletion(accepted=accepted, files=[], allowed_paths=allowed_paths)
+            return {**receipt, "status": "already-clean"}
+
+        if state_path.is_file():
+            state = load_json_object(state_path)
+            if state.get("schema_version") != SCHEMA_VERSION or state.get("gamever") != gamever:
+                raise ReleaseWorkflowError("legacy YAML cleanup state identity is invalid")
+            files = state.get("files")
+            backup_value = state.get("backup_root")
+            if not isinstance(files, list) or not isinstance(backup_value, str) or not backup_value:
+                raise ReleaseWorkflowError("legacy YAML cleanup state does not match its backup")
+            backup_root = Path(backup_value)
+            manifest = _validate_backup(
+                persisted_root=persisted_root,
+                gamever=gamever,
+                backup_root=backup_root,
+                files=files,
+            )
+            expected_state = {
+                **manifest,
+                "backup_root": str(backup_root),
+                "backup_manifest_sha256": sha256_file(backup_root / "manifest.json"),
+            }
+            if state != expected_state:
+                raise ReleaseWorkflowError("legacy YAML cleanup state does not match its backup")
+        else:
+            files = _yaml_inventory(accepted)
+            backup_root, manifest = _prepare_backup(
+                persisted_root=persisted_root,
+                accepted=accepted,
+                gamever=gamever,
+                files=files,
+            )
+            state = {
+                **manifest,
+                "backup_root": str(backup_root),
+                "backup_manifest_sha256": sha256_file(backup_root / "manifest.json"),
+            }
+            write_canonical_json(state_path, state)
+
+        _resume_deletion(accepted=accepted, files=files, allowed_paths=allowed_paths)
+        receipt = {
+            "schema_version": SCHEMA_VERSION,
+            "gamever": gamever,
+            "file_count": len(files),
+            "inventory_sha256": state["inventory_sha256"],
+            "backup_root": state["backup_root"],
+            "backup_manifest_sha256": state["backup_manifest_sha256"],
+        }
+        write_canonical_json(receipt_path, receipt)
+        state_path.unlink()
+        return {**receipt, "status": "cleaned"}

--- a/release_workflow_lib/restore_accepted_bin.py
+++ b/release_workflow_lib/restore_accepted_bin.py
@@ -1,0 +1,124 @@
+"""Restore only configured binaries from the disposable accepted-bin cache."""
+
+from __future__ import annotations
+
+import shutil
+from pathlib import Path, PurePosixPath
+
+from binary_lock import BinaryLockError, verify_binary_root
+from release_workflow_lib.binary_cache import (
+    BINARY_CACHE_LOCK_ROOT,
+    configured_binary_paths,
+    load_source_binary_lock,
+    require_gamever,
+    validate_binary_cache_tree,
+    version_lock,
+)
+from release_workflow_lib.errors import ReleaseWorkflowError
+from release_workflow_lib.hashing import (
+    contained_path,
+    inventory_sha256,
+    normalized_relative_path,
+    reject_reparse_components,
+    reject_reparse_points,
+    sha256_file,
+)
+
+
+def _allowed_directories(allowed_paths: frozenset[str]) -> frozenset[str]:
+    return frozenset(
+        parent.as_posix()
+        for path in allowed_paths
+        for parent in PurePosixPath(path).parents
+        if parent != PurePosixPath(".")
+    )
+
+
+def _validate_target_subset(root: Path, allowed_paths: frozenset[str]) -> None:
+    reject_reparse_points(root)
+    directories = _allowed_directories(allowed_paths)
+    for path in root.rglob("*"):
+        relative = normalized_relative_path(path.relative_to(root).as_posix())
+        if path.is_file() and relative not in allowed_paths:
+            raise ReleaseWorkflowError(f"workspace binary restore target contains an unexpected file: {relative}")
+        if path.is_dir() and relative not in directories:
+            raise ReleaseWorkflowError(f"workspace binary restore target contains an unexpected directory: {relative}")
+
+
+def _inventory(root: Path, allowed_paths: frozenset[str]) -> tuple[list[dict], str]:
+    files = []
+    for relative in sorted(allowed_paths):
+        path = root / PurePosixPath(relative)
+        files.append({"path": relative, "size": path.stat().st_size, "sha256": sha256_file(path)})
+    return files, inventory_sha256(files)
+
+
+def restore_accepted_bin(
+    *,
+    repo_root: Path,
+    persisted_root: Path,
+    gamever: str,
+    required: bool = False,
+) -> dict:
+    """Copy the exact configured binary set into ``repo_root/bin/<GAMEVER>``."""
+    gamever = require_gamever(gamever)
+    repo_root = Path(repo_root).resolve()
+    persisted_root = Path(persisted_root).resolve()
+    reject_reparse_components(persisted_root, persisted_root)
+    allowed_paths = configured_binary_paths(repo_root, gamever)
+    source_root = contained_path(persisted_root, "bin", gamever)
+    lock_path = contained_path(persisted_root, *BINARY_CACHE_LOCK_ROOT, f"{gamever}.lock")
+    target_root = contained_path(repo_root / "bin", gamever)
+    reject_reparse_components(repo_root, target_root)
+    binary_lock = load_source_binary_lock(repo_root, gamever)
+
+    with version_lock(lock_path):
+        if not source_root.is_dir():
+            if required:
+                raise ReleaseWorkflowError(f"accepted binary cache is missing: {source_root}")
+            return {
+                "restored": False,
+                "reason": "cache-missing",
+                "gamever": gamever,
+                "hash": None,
+                "file_count": 0,
+                "binary_lock_sha256": binary_lock.sha256,
+            }
+        validate_binary_cache_tree(source_root, allowed_paths, allow_excluded=False)
+        try:
+            verify_binary_root(binary_lock.document, source_root)
+        except BinaryLockError as exc:
+            if required:
+                raise ReleaseWorkflowError(
+                    f"accepted binary cache does not match source lock for {gamever}: {exc}"
+                ) from exc
+            return {
+                "restored": False,
+                "reason": "binary-lock-mismatch",
+                "gamever": gamever,
+                "hash": None,
+                "file_count": 0,
+                "binary_lock_sha256": binary_lock.sha256,
+            }
+        target_root.mkdir(parents=True, exist_ok=True)
+        _validate_target_subset(target_root, allowed_paths)
+        for relative in sorted(allowed_paths):
+            source = source_root / PurePosixPath(relative)
+            target = target_root / PurePosixPath(relative)
+            target.parent.mkdir(parents=True, exist_ok=True)
+            reject_reparse_components(target_root, target.parent)
+            shutil.copy2(source, target)
+        validate_binary_cache_tree(target_root, allowed_paths, allow_excluded=False)
+        try:
+            verify_binary_root(binary_lock.document, target_root)
+        except BinaryLockError as exc:
+            raise ReleaseWorkflowError(f"restored workspace does not match source lock for {gamever}: {exc}") from exc
+        files, digest = _inventory(target_root, allowed_paths)
+        return {
+            "restored": True,
+            "reason": None,
+            "gamever": gamever,
+            "hash": digest,
+            "file_count": len(files),
+            "binary_lock_sha256": binary_lock.sha256,
+        }


### PR DESCRIPTION
Adds the trusted accepted-bin entrypoint and its minimal import closure to main so merge-group validation can execute `.trusted-tools/accepted_bin.py`.

All four files are byte-identical to the corresponding files already present in PR #902:

- `accepted_bin.py`
- `release_workflow_lib/binary_cache.py`
- `release_workflow_lib/legacy_yaml_cleanup.py`
- `release_workflow_lib/restore_accepted_bin.py`

This avoids an add/add conflict and preserves the exact #902 prospective tree. A local `git merge-tree --write-tree` simulation produced the same tree SHA (`20f63375984a9451a71df82010d7aedaeec3e772`) as the current #902 branch tree.

Validation:

- `uv run python accepted_bin.py --help`
- `uv run python -m unittest tests.test_sync_accepted_bin` (7 passed)
- `uv run python format_repo_files.py --check`
- `uv run python tests/run_test_suite.py all -b --durations 30` (1310 passed, 3 skipped, 0 failures/errors)

Fixes the merge-group failure in run 33961457586 where the trusted main checkout did not contain `.trusted-tools/accepted_bin.py`.