### PR TITLE
ci(validation): add temporary Phase-D comparison workflow

### DIFF
--- a/.github/workflows/phase-d-validation.yml
+++ b/.github/workflows/phase-d-validation.yml
@@ -1,0 +1,133 @@
+name: Phase D Selected Full Comparison
+run-name: Phase D PR ${{ inputs.pull_request }} at ${{ inputs.expected_head }}
+on:
+  workflow_dispatch:
+    inputs:
+      pull_request:
+        description: Same-repository PR containing new symbols and a finder change
+        required: true
+        default: '926'
+        type: string
+      expected_head:
+        description: Exact reviewed PR head SHA; execution fails if the PR moved
+        required: true
+        type: string
+permissions:
+  contents: read
+  pull-requests: read
+concurrency:
+  group: phase-d-validation
+  cancel-in-progress: false
+jobs:
+  bind:
+    if: github.repository == 'HLND2T/CS2_VibeSignatures' && github.ref == 'refs/heads/main'
+    runs-on: ubuntu-latest
+    outputs:
+      base: ${{ steps.bind.outputs.base }}
+      head: ${{ steps.bind.outputs.head }}
+      source: ${{ steps.bind.outputs.source }}
+    steps:
+      - uses: actions/github-script@v8
+        id: bind
+        env:
+          PR_NUMBER: ${{ inputs.pull_request }}
+          EXPECTED_HEAD: ${{ inputs.expected_head }}
+        with:
+          script: |
+            if (!/^[1-9][0-9]*$/.test(process.env.PR_NUMBER) || !/^[0-9a-f]{40}$/.test(process.env.EXPECTED_HEAD)) {
+              throw new Error('Expected a PR number and a full lowercase head SHA');
+            }
+            const pull_number = Number(process.env.PR_NUMBER);
+            const { data: pr } = await github.rest.pulls.get({ ...context.repo, pull_number });
+            if (pr.state !== 'open' || pr.head.repo.full_name !== process.env.GITHUB_REPOSITORY ||
+                pr.base.ref !== 'main' || pr.base.sha !== context.sha || pr.head.sha !== process.env.EXPECTED_HEAD) {
+              throw new Error('PR identity or trusted main SHA drifted');
+            }
+            const { data: ref } = await github.rest.git.getRef({ ...context.repo, ref: `pull/${pull_number}/merge` });
+            const { data: commit } = await github.rest.git.getCommit({ ...context.repo, commit_sha: ref.object.sha });
+            if (commit.parents.length !== 2 || commit.parents[0].sha !== pr.base.sha || commit.parents[1].sha !== pr.head.sha) {
+              throw new Error('Prospective merge parents do not match the reviewed PR');
+            }
+            core.setOutput('base', pr.base.sha);
+            core.setOutput('head', pr.head.sha);
+            core.setOutput('source', ref.object.sha);
+            await core.summary.addRaw(`Phase-D experiment only; base ${pr.base.sha}, head ${pr.head.sha}, source ${ref.object.sha}`).write();
+  warmup:
+    needs: bind
+    uses: ./.github/workflows/warmup-idb.yml
+    with:
+      gamever: 14178b
+      source_sha: ${{ needs.bind.outputs.source }}
+    secrets: inherit
+  compare:
+    needs: [bind, warmup]
+    runs-on: [self-hosted, windows, x64]
+    environment: win64
+    timeout-minutes: 720
+    env:
+      GIT_CONFIG_COUNT: '1'
+      GIT_CONFIG_KEY_0: core.longpaths
+      GIT_CONFIG_VALUE_0: 'true'
+      BASE_SHA: ${{ needs.bind.outputs.base }}
+      HEAD_SHA: ${{ needs.bind.outputs.head }}
+      SOURCE_SHA: ${{ needs.bind.outputs.source }}
+      WARM_GENERATION: ${{ needs.warmup.outputs.generation }}
+      WARM_CACHE_KEY: ${{ needs.warmup.outputs.cache_key }}
+      BINARY_LOCK_SHA256: ${{ needs.warmup.outputs.binary_lock_sha256 }}
+      PERSISTED_WORKSPACE: ${{ secrets.PERSISTED_WORKSPACE }}
+      CS2VIBE_AGENT: ${{ secrets.CS2VIBE_AGENT }}
+      CS2VIBE_AGENT_MODEL: ${{ secrets.CS2VIBE_AGENT_MODEL }}
+      CS2VIBE_LLM_APIKEY: ${{ secrets.CS2VIBE_LLM_APIKEY }}
+      CS2VIBE_LLM_BASEURL: ${{ secrets.CS2VIBE_LLM_BASEURL }}
+      CS2VIBE_LLM_EFFORT: ${{ secrets.CS2VIBE_LLM_EFFORT }}
+      CS2VIBE_LLM_FAKE_AS: ${{ secrets.CS2VIBE_LLM_FAKE_AS }}
+      CS2VIBE_LLM_MODEL: ${{ secrets.CS2VIBE_LLM_MODEL }}
+      CS2VIBE_STRING_MIN_LENGTH: '4'
+    steps:
+      - uses: actions/checkout@v5
+        with:
+          ref: ${{ needs.bind.outputs.source }}
+          fetch-depth: 0
+          submodules: recursive
+          persist-credentials: false
+      - uses: actions/checkout@v5
+        with:
+          ref: ${{ needs.bind.outputs.base }}
+          path: .phase-d-tools
+          persist-credentials: false
+      - uses: astral-sh/setup-uv@v9.0.0
+      - name: Prepare the trusted environment and exact binaries
+        shell: pwsh
+        run: |
+          "PHASE_D_ROOT=$env:RUNNER_TEMP\phase-d-${{ github.run_id }}-${{ github.run_attempt }}" | Out-File $env:GITHUB_ENV -Encoding utf8 -Append
+          if ([string]::IsNullOrWhiteSpace($env:PERSISTED_WORKSPACE)) { throw 'PERSISTED_WORKSPACE is missing.' }
+          uv sync --project .phase-d-tools --locked
+          if ($LASTEXITCODE -ne 0) { throw 'Trusted environment sync failed.' }
+          $restoreJson = uv run --project .phase-d-tools python .phase-d-tools/accepted_bin.py restore `
+            --repo-root "${{ github.workspace }}" --persisted-root "$env:PERSISTED_WORKSPACE" --gamever 14178b --required
+          if ($LASTEXITCODE -ne 0) { throw 'Accepted binary restore failed.' }
+          if (($restoreJson | ConvertFrom-Json).binary_lock_sha256 -ne $env:BINARY_LOCK_SHA256) {
+            throw 'Accepted binaries differ from warmup.'
+          }
+          uv run --project .phase-d-tools python init_gamebin.py prepare 14178b --binsync skip
+          if ($LASTEXITCODE -ne 0) { throw 'Binary initialization failed.' }
+      - name: Compare selected samples and fresh-full from one immutable warm generation
+        shell: pwsh
+        run: |
+          $pythonExe = (Get-Command python -ErrorAction Stop).Source
+          $idaVersion = (& $pythonExe warmup_idb_worker.py --print-ida-version).Trim()
+          if ($LASTEXITCODE -ne 0 -or [string]::IsNullOrWhiteSpace($idaVersion)) { throw 'IDA identity is unavailable.' }
+          uv run --project .phase-d-tools python .phase-d-tools/phase_d_validation.py `
+            --repo-root "${{ github.workspace }}" --base-sha "$env:BASE_SHA" --head-sha "$env:HEAD_SHA" `
+            --source-sha "$env:SOURCE_SHA" --binary-lock-sha256 "$env:BINARY_LOCK_SHA256" `
+            --warm-generation "$env:WARM_GENERATION" --cache-key "$env:WARM_CACHE_KEY" --ida-version "$idaVersion" `
+            --persisted-root "$env:PERSISTED_WORKSPACE" --output-root "$env:PHASE_D_ROOT"
+          if ($LASTEXITCODE -ne 0) { throw 'Phase-D comparison failed; inspect the diagnostic artifact.' }
+      - name: Upload experiment evidence including failures
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: phase-d-${{ github.run_id }}-${{ github.run_attempt }}
+          path: ${{ runner.temp }}/phase-d-${{ github.run_id }}-${{ github.run_attempt }}
+          if-no-files-found: warn
+          retention-days: 30

--- a/docs/plans/full-analysis-performance-handoff.md
+++ b/docs/plans/full-analysis-performance-handoff.md
@@ -297,3 +297,16 @@ PR 改为 trusted prepare → base 白名单物料化 → selected execute → �
 3. 纯删除计划可执行：空 `execute_nodes`（契约删除 + 其余继承）为合法 manifest；executor 允许空模块集合继续组合验证（不启动 IDA），verifier/prepare 原本已支持零执行组。`-modules` 与 `-selected_execution` 显式互斥。
 4. 无输出 session prerequisite 的独立执行证据:不属于任何 producer group 的计划节点(纯会话副作用前置)必须 `attempted=true` 且 **成功**(succeeded)——执行失败不能证明依赖者所需的会话副作用已建立,不沿用 alternatives 允许失败尝试的规则;组级校验不覆盖它们,缺失该检查时报告标 aborted/failed 仍可通过。
 5. 合法 optional 缺席的 skip 被接受:executor 对"计划内 optional 生产者实际运行但未产出"记录 `status=skipped` 且 reason 为 `optional_output_absent` / `preprocess_absent`(报告本身 valid=true)。verifier 仅在该 skip reason 合法、节点零产出、且其 attempted 的每条输出路径**要么确实缺席于 merge tree,要么是它位于组内 winner 之前的合法回退让渡**(后一个 alternative 成功产出同一路径)时接受;其它 skip reason(existing_outputs、skip_if_exists、platform_mismatch 等)、已物化输出上的 skipped、以及 winner 之后的缺席声明一律拒绝。
+
+## 18. Phase-D 临时维护入口（2026-09-06）
+
+用户已授权新增独立手动 workflow，完成 Phase-D 后独立启用 selected 策略、rebase PR #926；临时入口在 #926 合并后清理。
+
+- `.github/workflows/phase-d-validation.yml` 仅允许从 main 手动运行，绑定调用时的 main、准确 PR head 和双亲匹配的 prospective merge SHA；只接收同仓库的开放 PR。
+- `phase_d_validation.py` 使用生产 planner/prepare/executor/verifier，不改变生产策略解析或 required-check 路由。实验计划仅切换 strategy 并重新计算 digest，原计划与实验计划分别留档，报告明确标为迁移实验而非 PR attestation。
+- PR #926 覆盖新增符号与 finder 修改；artifact-only、跨 stage、共享运行时样本通过隔离 Git index 构造临时 base/merge commits，不改工作树或分支。所有样本的 merge tree 完全相同。
+- 每次分析前恢复同一个不可变 warm generation 并核验 source binary lock。三个小闭包 selected 样本、一次 fresh-full 基线及共享运行时全量 selected 样本分别执行生产完整字节 verifier、snapshot/gamedata 和 C++ gates。相同 tree/binary/generation 允许所有 selected 样本与同一次 fresh-full 基线作完整 inventory 比较。
+- 真实分析显式设置 `CS2VIBE_STRING_MIN_LENGTH=4`（用户期望，避免 minlen=5 丢失短字符串锚点），并写入实验报告；不修改本机 `.env`。现有 unit suite 中两项测试依赖该变量未启用，基线测试以进程内空值隔离该本机覆盖，不能把这解释为分析应使用 5。
+- 保存原计划、实验计划、preparation、warm restore、执行证据、完整验证、命令日志与各阶段耗时；失败也上传诊断，`comparison.json.valid` 仅在全部比较完成后为 true。此处尚不声明真实 runner 已验证。
+- 发布流程仍由 empty-root `-force_all -rename`、`release_artifact_rebuild.py verify` 与 hosted verification 保护；publish jobs 依赖这些成功结果。当前工作流无独立外部告警发送步骤，失败通过 Actions job/check 呈现；个人通知订阅未核验。
+- **清理门槛：PR #926 已合并。**届时删除临时 workflow、`phase_d_validation.py`、`tests/test_phase_d_validation.py`，移除 `tests/run_test_suite.py` 中对应归属；保留本交接文档、运行链接和汇总证据。不得在 #926 合并前清理入口。

--- a/phase_d_validation.py
+++ b/phase_d_validation.py
@@ -1,0 +1,433 @@
+#!/usr/bin/env python3
+"""Temporary, non-gating selected/full migration experiment; remove after PR 926 merges."""
+
+from __future__ import annotations
+
+import argparse
+import copy
+import hashlib
+import json
+import os
+import subprocess
+import sys
+import time
+from pathlib import Path
+
+import yaml
+
+from bin_artifact_contract import _category_for, _category_map
+from gamesymbol_snapshot_lib.config import load_contract
+from ida_analyze_util import canonical_symbol_yaml_bytes
+from idb_cache import restore_cache
+from release_workflow_lib.binary_cache import verify_source_binary_root
+from trusted_artifact_pr import (
+    GitTreeRepository,
+    _digest,
+    build_trusted_artifact_plan,
+    prepare_isolated_rebuild,
+    validate_isolated_rebuild,
+)
+from trusted_pr_context import EXECUTION_STRATEGIES, build_trusted_pr_context
+
+
+SELECTED = "base-inherited-selected-v1"
+FULL = "fresh-full-v1"
+GAMEVER = "14178b"
+ARTIFACT_SAMPLE = "engine/CNetworkClientSpawnGroupCreatePrerequisites_Init.windows.yaml"
+
+
+def write_json(path: Path, document: dict) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps(document, indent=2, ensure_ascii=False) + "\n", encoding="utf-8")
+
+
+def experimental_plan(original: dict, strategy: str) -> dict:
+    """Change only strategy/digest for this maintenance experiment, never the closure."""
+    if strategy not in EXECUTION_STRATEGIES:
+        raise ValueError(f"unknown experiment strategy: {strategy}")
+    result = copy.deepcopy(original)
+    result.pop("plan_sha256", None)
+    result["execution_strategy"] = strategy
+    result["plan_sha256"] = _digest("trusted-pr-plan", result)
+    return result
+
+
+def inventory(root: Path) -> dict:
+    return {
+        path.relative_to(root).as_posix(): {
+            "size": path.stat().st_size,
+            "sha256": hashlib.sha256(path.read_bytes()).hexdigest(),
+        }
+        for path in sorted(root.rglob("*"))
+        if path.is_file()
+    }
+
+
+def compare_inventories(full: Path, selected: Path) -> dict:
+    expected, actual = inventory(full), inventory(selected)
+    if expected != actual:
+        different = sorted(path for path in expected.keys() | actual.keys() if expected.get(path) != actual.get(path))
+        raise RuntimeError(f"selected/full inventory differs: {different[:20]}")
+    return {"file_count": len(actual), "sha256": _digest("phase-d-inventory", actual)}
+
+
+def git_object(repo: GitTreeRepository, arguments: list[str], *, payload: bytes = b"", env=None) -> str:
+    environment = dict(
+        os.environ,
+        GIT_AUTHOR_NAME="Codex",
+        GIT_AUTHOR_EMAIL="codex@openai.com",
+        GIT_COMMITTER_NAME="Codex",
+        GIT_COMMITTER_EMAIL="codex@openai.com",
+    )
+    environment.update(env or {})
+    result = subprocess.run(
+        ["git", "-C", str(repo.root), *arguments],
+        input=payload,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        env=environment,
+        check=True,
+    )
+    return result.stdout.decode().strip()
+
+
+def synthetic_base(repo: GitTreeRepository, source: str, path: str, raw: bytes, scratch: Path) -> str:
+    """Write fixture commits through Git plumbing with an isolated index, leaving HEAD untouched."""
+    scratch.mkdir(parents=True, exist_ok=False)
+    environment = {"GIT_INDEX_FILE": str((scratch / "index").resolve())}
+    git_object(repo, ["read-tree", source], env=environment)
+    blob = git_object(repo, ["hash-object", "-w", "--stdin"], payload=raw)
+    git_object(repo, ["update-index", "--add", "--cacheinfo", f"100644,{blob},{path}"], env=environment)
+    tree = git_object(repo, ["write-tree"], env=environment)
+    return git_object(repo, ["commit-tree", tree, "-p", source], payload=b"Phase-D synthetic base fixture\n")
+
+
+def fixture_plan(repo: GitTreeRepository, source: str, path: str, raw: bytes, scratch: Path) -> dict:
+    base = synthetic_base(repo, source, path, raw, scratch)
+    merge = git_object(
+        repo,
+        ["commit-tree", repo.tree_sha(source), "-p", base, "-p", source],
+        payload=b"Phase-D fixture merge with exact experiment source tree\n",
+    )
+    context = build_trusted_pr_context(repo_root=repo.root, base_ref=base, head_ref=source, merge_ref=merge)
+    write_json(scratch / "context.json", context)
+    return build_trusted_artifact_plan(repo_root=repo.root, trusted_context=context)
+
+
+def version(plan: dict) -> dict:
+    return next(item for item in plan["game_versions"] if item["game_version"] == GAMEVER)
+
+
+def cross_stage_source(contract, repo: GitTreeRepository, source: str) -> tuple[str, set[str]]:
+    """Choose a real, small upstream closure containing a later-stage artifact consumer."""
+    candidates = []
+    for group_id, group in contract.producer_groups.items():
+        downstream = contract.downstream_group_ids({group_id})
+        upstream_nodes = [contract.nodes[node_id] for node_id in group.alternative_node_ids]
+        downstream_nodes = [
+            contract.nodes[node_id]
+            for other in downstream - {group_id}
+            for node_id in contract.producer_groups[other].alternative_node_ids
+        ]
+        for node in upstream_nodes:
+            if any(other.stage_index > node.stage_index for other in downstream_nodes):
+                candidates.append((len(downstream), node.skill_name, downstream))
+    for _, skill, downstream in sorted(candidates, key=lambda item: (item[0], item[1])):
+        path = f"ida_preprocessor_scripts/{skill}.py"
+        if repo.entries(source, path):
+            return path, set(downstream)
+    raise RuntimeError("no real cross-stage source fixture found")
+
+
+def plan_samples(args, root: Path) -> list[tuple[str, dict]]:
+    repo = GitTreeRepository(args.repo_root)
+    if repo.resolve_commit("HEAD") != args.source_sha:
+        raise RuntimeError("experiment checkout differs from the bound source")
+    context = build_trusted_pr_context(
+        repo_root=repo.root, base_ref=args.base_sha, head_ref=args.head_sha, merge_ref=args.source_sha
+    )
+    write_json(root / "real-context.json", context)
+    print("Planning the bound PR sample...", flush=True)
+    real = build_trusted_artifact_plan(repo_root=repo.root, trusted_context=context)
+    if real["affected_game_versions"] != [GAMEVER] or real["mode"] != "full":
+        raise RuntimeError("expected the maintained 14178b full-route sample")
+    added = [change["new_path"] for change in real["changed_paths"] if change["status"] == "A"]
+    modified = [change["new_path"] for change in real["changed_paths"] if change["status"] == "M"]
+    if not any(path.startswith(f"bin_artifacts/{GAMEVER}/") for path in added):
+        raise RuntimeError("real PR no longer covers a new symbol")
+    if not any(path.startswith("ida_preprocessor_scripts/find-") for path in modified):
+        raise RuntimeError("real PR no longer covers a finder modification")
+    contract = load_contract(
+        repo.root / "configs" / f"{GAMEVER}.yaml", GAMEVER, repo.root / "bin", artifactdir=repo.root / "bin_artifacts"
+    )
+    artifact_path = f"bin_artifacts/{GAMEVER}/{ARTIFACT_SAMPLE}"
+    payload = yaml.safe_load(repo.read(args.source_sha, artifact_path))
+    payload["func_va"] = hex(int(str(payload["func_va"]), 0) + 1)
+    payload["func_rva"] = hex(int(str(payload["func_rva"]), 0) + 1)
+    categories = _category_map(repo.root / "configs" / f"{GAMEVER}.yaml")
+    raw = canonical_symbol_yaml_bytes(payload, category=_category_for(ARTIFACT_SAMPLE, payload, categories))
+    print("Planning the artifact-only fixture...", flush=True)
+    artifact = fixture_plan(repo, args.source_sha, artifact_path, raw, root / "artifact-only-fixture")
+    cross_path, expected_groups = cross_stage_source(contract, repo, args.source_sha)
+    print(f"Planning the cross-stage fixture: {cross_path}", flush=True)
+    cross = fixture_plan(
+        repo,
+        args.source_sha,
+        cross_path,
+        repo.read(args.source_sha, cross_path) + b"\n# Phase-D source invalidation fixture.\n",
+        root / "cross-stage-fixture",
+    )
+    if not expected_groups.issubset({group["group_id"] for group in version(cross)["execute_groups"]}):
+        raise RuntimeError("cross-stage fixture did not select the downstream closure")
+    if len({node["stage_index"] for node in version(cross)["execute_nodes"]}) < 2:
+        raise RuntimeError("cross-stage sample must execute at least two stages")
+    shared_path = "ida_analyze_util.py"
+    print("Planning the shared-runtime fixture...", flush=True)
+    shared = fixture_plan(
+        repo,
+        args.source_sha,
+        shared_path,
+        repo.read(args.source_sha, shared_path) + b"\n# Phase-D shared runtime fixture.\n",
+        root / "shared-runtime-fixture",
+    )
+    if version(shared)["inherit_paths"] or len(version(shared)["execute_groups"]) != len(contract.producer_groups):
+        raise RuntimeError("shared runtime fixture did not force the complete contract")
+    samples = [("pr-926", real), ("artifact-only", artifact), ("cross-stage", cross), ("shared-runtime", shared)]
+    for name, plan in samples:
+        if plan["merge_tree_sha"] != real["merge_tree_sha"]:
+            raise RuntimeError("sample source trees differ")
+        if version(plan)["merge_binary_lock_sha256"] != args.binary_lock_sha256:
+            raise RuntimeError("sample binary lock differs from warmup")
+        write_json(root / f"{name}.original-plan.json", plan)
+        print(
+            f"Planned {name}: {len(version(plan)['execute_groups'])} groups, "
+            f"{len(version(plan)['execute_nodes'])} nodes, {len(version(plan)['inherit_paths'])} inherited",
+            flush=True,
+        )
+    write_json(
+        root / "samples.json",
+        {
+            "cross_stage_source": cross_path,
+            "artifact_only_path": artifact_path,
+            "synthetic_base_samples": ["artifact-only", "cross-stage", "shared-runtime"],
+        },
+    )
+    return samples
+
+
+def run_logged(repo_root: Path, command: list[str], log: Path) -> float:
+    started = time.monotonic()
+    print(f"Running {' '.join(command)}", flush=True)
+    with log.open("w", encoding="utf-8") as stream:
+        process = subprocess.Popen(
+            command,
+            cwd=repo_root,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.STDOUT,
+            text=True,
+            encoding="utf-8",
+            errors="replace",
+            env=dict(os.environ, PYTHONUNBUFFERED="1"),
+        )
+        for line in process.stdout:
+            stream.write(line)
+            stream.flush()
+            print(line, end="", flush=True)
+        code = process.wait()
+    if code:
+        raise RuntimeError(f"command failed with exit {code}; see {log}")
+    return time.monotonic() - started
+
+
+def execute_sample(args, root: Path, name: str, original: dict, strategy: str) -> dict:
+    started = time.monotonic()
+    destination = root / name
+    destination.mkdir()
+    plan = experimental_plan(original, strategy)
+    write_json(destination / "experimental-plan.json", plan)
+    preparation = prepare_isolated_rebuild(
+        repo_root=args.repo_root, plan=plan, staging_root=destination / "rebuild", game_version=GAMEVER
+    )
+    prepare_seconds = time.monotonic() - started
+    restore_start = time.monotonic()
+    restored = restore_cache(
+        repo_root=args.repo_root,
+        persisted_root=args.persisted_root,
+        gamever=GAMEVER,
+        generation=args.warm_generation,
+        expected_cache_key=args.cache_key,
+        ida_version=args.ida_version,
+    )
+    write_json(destination / "warm-restore.json", restored)
+    lock = verify_source_binary_root(
+        repo_root=args.repo_root,
+        gamever=GAMEVER,
+        binary_root=args.repo_root / "bin" / GAMEVER,
+        label="Phase-D restored binaries",
+    )
+    if lock.sha256 != args.binary_lock_sha256:
+        raise RuntimeError("restored binary lock differs from the experiment")
+    restore_seconds = time.monotonic() - restore_start
+    config = str(Path(preparation["config_root"]) / f"{GAMEVER}.yaml")
+    actual = preparation["actual_artifact_root"]
+    command = [
+        sys.executable,
+        "ida_analyze_bin.py",
+        "-gamever",
+        GAMEVER,
+        "-configyaml",
+        config,
+        "-bindir",
+        "bin",
+        "-artifactdir",
+        actual,
+        "-oldartifactdir",
+        "bin_artifacts",
+        "-execution_report",
+        preparation["execution_reports"][GAMEVER],
+        "-require_warm_idb",
+    ]
+    command += (
+        ["-selected_execution", preparation["selected_execution_manifests"][GAMEVER]]
+        if strategy == SELECTED
+        else ["-force_all"]
+    )
+    producer_seconds = run_logged(args.repo_root, command, destination / "producer.log")
+    verify_source_binary_root(
+        repo_root=args.repo_root,
+        gamever=GAMEVER,
+        binary_root=args.repo_root / "bin" / GAMEVER,
+        label="Phase-D executed binaries",
+    )
+    verify_start = time.monotonic()
+    validation = validate_isolated_rebuild(repo_root=args.repo_root, plan=plan, preparation=preparation)
+    write_json(destination / "validation.json", validation)
+    verify_seconds = time.monotonic() - verify_start
+    downstream = destination / "downstream"
+    downstream.mkdir()
+    snapshot, session = str(downstream / "snapshot.yaml"), str(downstream / "snapshot.session.json")
+    gamedata_session = str(downstream / "gamedata.session.json")
+    commands = [
+        [
+            sys.executable,
+            "gamesymbol_candidate.py",
+            "build",
+            "-gamever",
+            GAMEVER,
+            "-bindir",
+            "bin",
+            "-artifactdir",
+            actual,
+            "-configyaml",
+            config,
+            "-output",
+            snapshot,
+            "-session",
+            session,
+        ],
+        [
+            sys.executable,
+            "gamedata_candidate.py",
+            "build",
+            "-gamever",
+            GAMEVER,
+            "-build-id",
+            f"phase-d-{name}",
+            "-snapshot",
+            snapshot,
+            "-configyaml",
+            config,
+            "-candidate-root",
+            str(downstream / "gamedata"),
+            "-session",
+            gamedata_session,
+        ],
+        [sys.executable, "gamedata_candidate.py", "guard", "-session", gamedata_session],
+        [sys.executable, "run_cpp_tests.py", "-gamever", GAMEVER, "-snapshot", snapshot, "-configyaml", config],
+    ]
+    downstream_seconds = sum(
+        run_logged(args.repo_root, command, destination / f"downstream-{index}.log")
+        for index, command in enumerate(commands)
+    )
+    execution = json.loads(Path(preparation["execution_reports"][GAMEVER]).read_text(encoding="utf-8"))
+    producer_log = (destination / "producer.log").read_text(encoding="utf-8")
+    return {
+        "name": name,
+        "strategy": strategy,
+        "original_plan_sha256": original["plan_sha256"],
+        "experimental_plan_sha256": plan["plan_sha256"],
+        "merge_tree_sha": plan["merge_tree_sha"],
+        "binary_lock_sha256": args.binary_lock_sha256,
+        "warm_restore": restored,
+        "actual_root": actual,
+        "validation": validation,
+        "executed_group_count": len(execution["producer_groups"]),
+        "ida_session_starts": producer_log.count("Starting idalib-mcp:"),
+        "timing_seconds": {
+            "prepare": prepare_seconds,
+            "restore": restore_seconds,
+            "producer": producer_seconds,
+            "verify": verify_seconds,
+            "downstream": downstream_seconds,
+            "total": time.monotonic() - started,
+        },
+    }
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--repo-root", type=Path, required=True)
+    for name in (
+        "base-sha",
+        "head-sha",
+        "source-sha",
+        "binary-lock-sha256",
+        "warm-generation",
+        "cache-key",
+        "ida-version",
+    ):
+        parser.add_argument(f"--{name}", required=True)
+    parser.add_argument("--persisted-root", type=Path)
+    parser.add_argument("--output-root", type=Path, required=True)
+    parser.add_argument("--plan-only", action="store_true")
+    args = parser.parse_args()
+    args.repo_root = args.repo_root.resolve()
+    root = args.output_root.resolve()
+    if root.is_relative_to(args.repo_root):
+        raise RuntimeError("experiment evidence must live outside the checkout")
+    root.mkdir(parents=True, exist_ok=False)
+    report = {
+        "schema_version": 1,
+        "purpose": "phase-d-migration-experiment-not-pr-attestation",
+        "valid": False,
+        "source_sha": args.source_sha,
+        "string_min_length": os.environ.get("CS2VIBE_STRING_MIN_LENGTH"),
+        "results": [],
+    }
+    try:
+        samples = plan_samples(args, root)
+        if args.plan_only:
+            return 0
+        if args.persisted_root is None:
+            raise RuntimeError("persisted root is required for real runner execution")
+        # Every sample has exactly the same executed source tree. One full baseline therefore
+        # provides the byte comparator for all selected trials; each restores the same generation.
+        trials = [(name, plan, SELECTED) for name, plan in samples[:-1]]
+        trials += [("fresh-full", samples[0][1], FULL), (samples[-1][0], samples[-1][1], SELECTED)]
+        for name, plan, strategy in trials:
+            report["results"].append(execute_sample(args, root, name, plan, strategy))
+            write_json(root / "comparison.json", report)
+        baseline = next(result for result in report["results"] if result["strategy"] == FULL)
+        for result in report["results"]:
+            result["comparison"] = compare_inventories(Path(baseline["actual_root"]), Path(result["actual_root"]))
+        report["valid"] = True
+        return 0
+    except Exception as exc:
+        report["error"] = str(exc)
+        raise
+    finally:
+        write_json(root / "comparison.json", report)
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/run_test_suite.py
+++ b/tests/run_test_suite.py
@@ -83,6 +83,7 @@ UNIT_MODULES = frozenset(
         "test_ida_analyze_bin",
         "test_ida_llm_decompile",
         "test_idb_cache",
+        "test_phase_d_validation",
         "test_ida_analyze_util",
         "test_ida_llm_utils",
         "test_ida_mcp_keepalive",

--- a/tests/test_phase_d_validation.py
+++ b/tests/test_phase_d_validation.py
@@ -1,0 +1,60 @@
+import copy
+import tempfile
+import unittest
+from pathlib import Path
+
+from phase_d_validation import compare_inventories, experimental_plan, synthetic_base
+from trusted_artifact_pr import GitTreeRepository, _digest
+
+
+class PhaseDValidationTests(unittest.TestCase):
+    def test_strategy_trial_preserves_the_original_plan_and_closure(self):
+        original = {"execution_strategy": "fresh-full-v1", "execute_nodes": ["a"]}
+        original["plan_sha256"] = _digest("trusted-pr-plan", original)
+        before = copy.deepcopy(original)
+        trial = experimental_plan(original, "base-inherited-selected-v1")
+        self.assertEqual(before, original)
+        self.assertEqual(["a"], trial["execute_nodes"])
+        self.assertNotEqual(original["plan_sha256"], trial["plan_sha256"])
+        unsigned = {key: value for key, value in trial.items() if key != "plan_sha256"}
+        self.assertEqual(_digest("trusted-pr-plan", unsigned), trial["plan_sha256"])
+        trial["execute_nodes"].append("b")
+        self.assertEqual(["a"], original["execute_nodes"])
+
+    def test_unknown_trial_strategy_is_rejected(self):
+        with self.assertRaises(ValueError):
+            experimental_plan({}, "unknown")
+
+    def test_inventory_comparison_rejects_missing_extra_and_different_bytes(self):
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            full, selected = root / "full", root / "selected"
+            full.mkdir()
+            selected.mkdir()
+            (full / "a.yaml").write_bytes(b"expected")
+            for filename, payload in (("b.yaml", b"expected"), ("a.yaml", b"drift")):
+                candidate = selected / filename
+                candidate.write_bytes(payload)
+                with self.assertRaisesRegex(RuntimeError, "inventory"):
+                    compare_inventories(full, selected)
+                candidate.unlink()
+            (selected / "a.yaml").write_bytes(b"expected")
+            self.assertEqual(1, compare_inventories(full, selected)["file_count"])
+
+    def test_synthetic_base_uses_git_objects_without_mutating_checkout_or_index(self):
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            repo = GitTreeRepository(root)
+            repo.run("init")
+            repo.run("config", "user.name", "Phase D Test")
+            repo.run("config", "user.email", "phase-d@example.invalid")
+            (root / "source.py").write_bytes(b"value = 1\n")
+            repo.run("add", "source.py")
+            repo.run("commit", "-m", "fixture")
+            source = repo.resolve_commit("HEAD")
+            index_tree = repo.run("write-tree")
+            base = synthetic_base(repo, source, "source.py", b"value = 0\n", root / "scratch")
+            self.assertEqual(b"value = 0\n", repo.read(base, "source.py"))
+            self.assertEqual(b"value = 1\n", (root / "source.py").read_bytes())
+            self.assertEqual(index_tree, repo.run("write-tree"))
+            self.assertEqual(source, repo.resolve_commit("HEAD"))


### PR DESCRIPTION
## Summary

Add a temporary, main-only manual workflow to complete the selected/full migration comparison before enabling `base-inherited-selected-v1`. It pins the reviewed PR head, main base and prospective merge parents, restores the same immutable warm IDB generation before each execution, and retains diagnostics even on failure.

The real PR covers new symbols and a finder change. Isolated Git fixtures cover artifact-only, cross-stage dependencies and shared-runtime full fallback; all execute the same merge tree and compare against one fresh-full baseline. Each run uses the production prepare/executor/verifier and downstream snapshot, gamedata and C++ gates. Experimental strategy overrides are separately recorded and cannot claim a PR attestation. Real analysis explicitly uses `CS2VIBE_STRING_MIN_LENGTH=4` as requested.

Production policy remains fresh-full. This is an independently merged trusted maintenance bridge; the trusted-root guard remains unchanged. Remove the temporary workflow, helper, helper tests and suite registration after PR #926 merges; retain the handoff and evidence.

## Validation

- `actionlint .github/workflows/phase-d-validation.yml`: passed
- `uv run python format_repo_files.py --check`: passed
- New helper and suite-registration tests: 6 passed
- unit: 1192 passed with the process-local string-minimum override disabled for existing tests that assume the unset default; the local `.env` remains unchanged
- repository-contract: 83 passed
- release-integration: 15 passed
- Real runner comparisons and performance results are pending execution through this new maintenance entry point
- Repository PR checks remain owned by trusted CI; this workflow does not replace them
