### PR TITLE
fix(validation): bind Phase-D tools independently of PR base

### DIFF
--- a/.github/workflows/phase-d-validation.yml
+++ b/.github/workflows/phase-d-validation.yml
@@ -40,8 +40,14 @@ jobs:
             const pull_number = Number(process.env.PR_NUMBER);
             const { data: pr } = await github.rest.pulls.get({ ...context.repo, pull_number });
             if (pr.state !== 'open' || pr.head.repo.full_name !== process.env.GITHUB_REPOSITORY ||
-                pr.base.ref !== 'main' || pr.base.sha !== context.sha || pr.head.sha !== process.env.EXPECTED_HEAD) {
-              throw new Error('PR identity or trusted main SHA drifted');
+                pr.base.ref !== 'main' || pr.head.sha !== process.env.EXPECTED_HEAD) {
+              throw new Error('Reviewed PR identity drifted');
+            }
+            const { data: ancestry } = await github.rest.repos.compareCommitsWithBasehead({
+              ...context.repo, basehead: `${pr.base.sha}...${context.sha}`
+            });
+            if (!['ahead', 'identical'].includes(ancestry.status)) {
+              throw new Error('Reviewed PR base is not an ancestor of the trusted maintenance revision');
             }
             const { data: ref } = await github.rest.git.getRef({ ...context.repo, ref: `pull/${pull_number}/merge` });
             const { data: commit } = await github.rest.git.getCommit({ ...context.repo, commit_sha: ref.object.sha });
@@ -51,7 +57,7 @@ jobs:
             core.setOutput('base', pr.base.sha);
             core.setOutput('head', pr.head.sha);
             core.setOutput('source', ref.object.sha);
-            await core.summary.addRaw(`Phase-D experiment only; base ${pr.base.sha}, head ${pr.head.sha}, source ${ref.object.sha}`).write();
+            await core.summary.addRaw(`Phase-D experiment only; tools ${context.sha}, base ${pr.base.sha}, head ${pr.head.sha}, source ${ref.object.sha}`).write();
   warmup:
     needs: bind
     uses: ./.github/workflows/warmup-idb.yml
@@ -92,7 +98,7 @@ jobs:
           persist-credentials: false
       - uses: actions/checkout@v5
         with:
-          ref: ${{ needs.bind.outputs.base }}
+          ref: ${{ github.sha }}
           path: .phase-d-tools
           persist-credentials: false
       - uses: astral-sh/setup-uv@v9.0.0

--- a/docs/plans/full-analysis-performance-handoff.md
+++ b/docs/plans/full-analysis-performance-handoff.md
@@ -303,6 +303,7 @@ PR 改为 trusted prepare → base 白名单物料化 → selected execute → �
 用户已授权新增独立手动 workflow，完成 Phase-D 后独立启用 selected 策略、rebase PR #926；临时入口在 #926 合并后清理。
 
 - `.github/workflows/phase-d-validation.yml` 仅允许从 main 手动运行，绑定调用时的 main、准确 PR head 和双亲匹配的 prospective merge SHA；只接收同仓库的开放 PR。
+- GitHub 可保留 PR 原来的 base/merge 快照，即使 main 已前进。维护工具固定为 dispatch 的 main SHA，样本固定为 PR 报告的 base/head/merge；另核验样本 base 是维护 main 的祖先，不要求两者相等，也不提前改写业务分支。
 - `phase_d_validation.py` 使用生产 planner/prepare/executor/verifier，不改变生产策略解析或 required-check 路由。实验计划仅切换 strategy 并重新计算 digest，原计划与实验计划分别留档，报告明确标为迁移实验而非 PR attestation。
 - PR #926 覆盖新增符号与 finder 修改；artifact-only、跨 stage、共享运行时样本通过隔离 Git index 构造临时 base/merge commits，不改工作树或分支。所有样本的 merge tree 完全相同。
 - 每次分析前恢复同一个不可变 warm generation 并核验 source binary lock。三个小闭包 selected 样本、一次 fresh-full 基线及共享运行时全量 selected 样本分别执行生产完整字节 verifier、snapshot/gamedata 和 C++ gates。相同 tree/binary/generation 允许所有 selected 样本与同一次 fresh-full 基线作完整 inventory 比较。


### PR DESCRIPTION
GitHub retains PR #926's original base and prospective merge snapshot after the Phase-D maintenance bridge advances main. The initial manual run therefore stopped at the main-equals-PR-base check.

Bind maintenance tools to the dispatch main SHA and the sample to its reviewed base/head/merge identities independently. Require the sample base to be an ancestor of maintenance main and keep the exact reviewed head, same-repository and merge-parent checks. This changes only the temporary experiment entry point; production policy and gates remain unchanged.

Validation: actionlint passed; the live compare API reports the reviewed base is behind maintenance main (status ahead, behind_by=0). The first run stopped before binary execution. This is an independent trusted maintenance update.
