### PR TITLE
fix(validation): execute authorized nodes despite skip markers

### DIFF
--- a/.github/workflows/phase-d-validation.yml
+++ b/.github/workflows/phase-d-validation.yml
@@ -12,7 +12,13 @@ on:
         description: Exact reviewed PR head SHA; execution fails if the PR moved
         required: true
         type: string
+      resume_failed_shared_runtime:
+        description: Reuse run 34031704261 evidence and retry its one unattempted node
+        required: true
+        default: false
+        type: boolean
 permissions:
+  actions: read
   contents: read
   pull-requests: read
 concurrency:
@@ -89,6 +95,7 @@ jobs:
       CS2VIBE_LLM_FAKE_AS: ${{ secrets.CS2VIBE_LLM_FAKE_AS }}
       CS2VIBE_LLM_MODEL: ${{ secrets.CS2VIBE_LLM_MODEL }}
       CS2VIBE_STRING_MIN_LENGTH: '4'
+      PHASE_D_RESUME: ${{ inputs.resume_failed_shared_runtime }}
     steps:
       - uses: actions/checkout@v5
         with:
@@ -102,6 +109,19 @@ jobs:
           path: .phase-d-tools
           persist-credentials: false
       - uses: astral-sh/setup-uv@v9.0.0
+      - name: Require a fresh archived-evidence location
+        if: inputs.resume_failed_shared_runtime
+        shell: pwsh
+        run: |
+          if (Test-Path -LiteralPath "$env:RUNNER_TEMP\phase-d-34031704261-1") { throw 'Archived evidence location already exists.' }
+      - name: Download immutable evidence from the failed migration run
+        if: inputs.resume_failed_shared_runtime
+        uses: actions/download-artifact@v5
+        with:
+          github-token: ${{ github.token }}
+          run-id: 34031704261
+          name: phase-d-34031704261-1
+          path: ${{ runner.temp }}/phase-d-34031704261-1
       - name: Prepare the trusted environment and exact binaries
         shell: pwsh
         run: |
@@ -118,6 +138,7 @@ jobs:
           uv run --project .phase-d-tools python init_gamebin.py prepare 14178b --binsync skip
           if ($LASTEXITCODE -ne 0) { throw 'Binary initialization failed.' }
       - name: Compare selected samples and fresh-full from one immutable warm generation
+        if: ${{ !inputs.resume_failed_shared_runtime }}
         shell: pwsh
         run: |
           $pythonExe = (Get-Command python -ErrorAction Stop).Source
@@ -129,6 +150,14 @@ jobs:
             --warm-generation "$env:WARM_GENERATION" --cache-key "$env:WARM_CACHE_KEY" --ida-version "$idaVersion" `
             --persisted-root "$env:PERSISTED_WORKSPACE" --output-root "$env:PHASE_D_ROOT"
           if ($LASTEXITCODE -ne 0) { throw 'Phase-D comparison failed; inspect the diagnostic artifact.' }
+      - name: Verify archived evidence and retry only the unattempted node
+        if: inputs.resume_failed_shared_runtime
+        shell: pwsh
+        run: |
+          uv run --project .phase-d-tools python .phase-d-tools/phase_d_resume.py `
+            --repo-root "${{ github.workspace }}" --evidence-root "$env:RUNNER_TEMP\phase-d-34031704261-1" `
+            --persisted-root "$env:PERSISTED_WORKSPACE" --output-root "$env:PHASE_D_ROOT"
+          if ($LASTEXITCODE -ne 0) { throw 'Phase-D continuation failed; inspect its diagnostics.' }
       - name: Upload experiment evidence including failures
         if: always()
         uses: actions/upload-artifact@v4

--- a/docs/plans/full-analysis-performance-handoff.md
+++ b/docs/plans/full-analysis-performance-handoff.md
@@ -311,3 +311,21 @@ PR 改为 trusted prepare → base 白名单物料化 → selected execute → �
 - 保存原计划、实验计划、preparation、warm restore、执行证据、完整验证、命令日志与各阶段耗时；失败也上传诊断，`comparison.json.valid` 仅在全部比较完成后为 true。此处尚不声明真实 runner 已验证。
 - 发布流程仍由 empty-root `-force_all -rename`、`release_artifact_rebuild.py verify` 与 hosted verification 保护；publish jobs 依赖这些成功结果。当前工作流无独立外部告警发送步骤，失败通过 Actions job/check 呈现；个人通知订阅未核验。
 - **清理门槛：PR #926 已合并。**届时删除临时 workflow、`phase_d_validation.py`、`tests/test_phase_d_validation.py`，移除 `tests/run_test_suite.py` 中对应归属；保留本交接文档、运行链接和汇总证据。不得在 #926 合并前清理入口。
+
+### 启用前运行记录
+
+- 临时维护入口通过 PR #928（`26ea0b2f`）合入；身份绑定修正通过 PR #929（`99bca9a3`）合入。
+- 首次 run `34031579577` 在身份预检失败，未执行分析；GitHub 仍报告 #926 原 base/merge，修正为维护工具与样本身份分别绑定。
+- 正式实验：[run 34031704261](https://github.com/HLND2T/CS2_VibeSignatures/actions/runs/34031704261)，绑定 #926 head `df457afa71313cd45d27ccaa9d1bd8f5187f0d61`、base `db8e615b01cd0e600b7288de96f4e6e359157774`、merge `b46ae7aae6e388ce3854ec02a82bbf4e57932e33`。已结束：前三个 selected 样本及 fresh-full 成功，共享运行时 selected 样本在最终证据检查失败。
+- 本地真实树规划预演通过：PR 样本 6 组 / 6 节点 / 3520 继承；artifact-only 3 / 3 / 3523；跨 stage 14 / 10 / 3512；共享运行时 3529 / 2235 / 0。跨 stage 源为 `find-CLoopModeFactory_CLoopModeGame_Shutdown-decompiles.py`。
+- 临时脚本固定执行五轮：三个小闭包 selected、一个 fresh-full、一个共享运行时全量 selected。**其中两轮为全量，按历史单轮约两小时估算，整个迁移实验为数小时规模。**每轮后的 downstream 检查也被重复执行；当前入口把全部轮次放在一个 Actions step，未结束时 REST 日志不可读，进度可见性有限。
+- 本地回归：unit 1192、repository-contract 83、release-integration 15 通过；unit 以进程内空值隔离本机字符串最小长度覆盖，真实分析保持用户要求的 4。actionlint、仓库格式检查及新增行为测试通过。
+
+### 单节点续验（2026-09-07）
+
+- 失败根因：`process_binary` 在 IDA 会话中的第二次 `skip_if_exists` 检查遗漏 `not force_all` 条件，导致 selected 模式已经授权的 `7:241:server:linux:find-CFlashbangProjectile_Spawn_NetworkStateChangedNotify` 未执行。报告为 2195 succeeded、40 skipped，其中仅该节点为 `skip_if_exists`；完整文件比较也仅缺少对应 Linux YAML。
+- 原 fresh-full 报告为 valid=true、2196 succeeded，且没有 `skip_if_exists` 节点。三个小闭包的 3526 个文件与 full 基线完全相同。PR 样本 producer 109.578 秒、总计 466.687 秒；full producer 7204.719 秒、总计 7604.359 秒（总计均包含 prepare/restore/verify/downstream，不包含前面的统一规划）。
+- 修复严格限于第二次 skip 检查补 `and not force_all`；普通增量跳过、已有输出的 alternatives winner 行为保持原语义。回归覆盖标记在会话前存在及会话中生成的两种情况。
+- 用户要求跳过已成功的 2195 条 skill；临时 `phase_d_resume.py` 仅用于该固定 run 和准确 source SHA。它重新核验已上传的四个成功报告、旧失败报告的摘要/绑定、保留节点的证据及除缺失文件之外的完整字节；只允许准确的一行 executor 修复。恢复同一 warm generation，从准确 source Git blobs 继承其它输出，仅运行没有 prerequisite、额外输出或下游的这一个节点。
+- 续验使用 records-only 验证入口核对跨 run 的组/节点覆盖，原失败报告和原 comparison.json 均不修改，也不生成冒充原单次 run 的成功报告。新报告标为 `phase-d-cross-run-continuation-not-pr-attestation`，记录原报告、补跑报告、executor 修复摘要与完整 inventory 比较；它是一次性迁移续验证据，不引入生产 PR/release 的通用 resume 契约。
+- 全量下游证据仅在源码/config 和补齐后的完整 inventory 与已验证 full 基线完全一致后复用。#926 合并后的临时入口清理范围同时包含 `phase_d_resume.py`；永久保留执行器修复及其回归测试。

--- a/ida_analyze_bin.py
+++ b/ida_analyze_bin.py
@@ -3746,7 +3746,7 @@ def process_binary(
                     error=str(e),
                 )
                 continue
-            if skip_for_existing_artifacts:
+            if skip_for_existing_artifacts and not force_all:
                 print(f"  Skipping skill: {skill_name} (all skip_if_exists artifacts exist)")
                 skip_count += 1
                 _report_skill_status(

--- a/phase_d_resume.py
+++ b/phase_d_resume.py
@@ -1,0 +1,271 @@
+#!/usr/bin/env python3
+"""One-off Phase-D continuation of run 34031704261; never emits a production attestation."""
+
+from __future__ import annotations
+
+import argparse
+import copy
+import hashlib
+import json
+import os
+import shutil
+from pathlib import Path
+
+from gamesymbol_snapshot_lib.config import load_contract
+from phase_d_validation import GAMEVER, compare_inventories, inventory, run_logged, version, write_json
+from idb_cache import restore_cache
+from release_workflow_lib.binary_cache import verify_source_binary_root
+from trusted_artifact_pr import (
+    GitTreeRepository,
+    _canonical_json_bytes,
+    _digest,
+    _selected_execution_digest,
+    _load_selected_execution_manifest,
+    load_trusted_artifact_plan,
+    prepare_isolated_rebuild,
+    validate_isolated_rebuild,
+    validate_selected_execution_records,
+)
+
+
+TARGET = "server/CFlashbangProjectile_Spawn_NetworkStateChangedNotify.linux.yaml"
+NODE = "7:241:server:linux:find-CFlashbangProjectile_Spawn_NetworkStateChangedNotify"
+SOURCE = "b46ae7aae6e388ce3854ec02a82bbf4e57932e33"
+
+
+def check_failed_records(report: dict, planned: dict) -> None:
+    """Reject every failure shape except the one unattempted skip found in the archived run."""
+    if report.get("valid") is not False or len(report.get("issues", [])) != 1:
+        raise ValueError("unexpected original failure shape")
+    missing = [node for node in report["nodes"] if node["node_id"] == NODE]
+    if len(missing) != 1 or missing[0].get("reason") != "skip_if_exists" or missing[0].get("attempted") is not False:
+        raise ValueError("expected the single skipped, unattempted node")
+    if missing[0]["attempted_paths"] or missing[0]["produced_paths"]:
+        raise ValueError("skipped node recorded writes")
+    missing_groups = [group for group in report["producer_groups"] if group["artifact_path"] == TARGET]
+    if (
+        len(missing_groups) != 1
+        or missing_groups[0].get("attempted_node_ids") != []
+        or missing_groups[0].get("winner_node_id") is not None
+        or missing_groups[0].get("output_sha256") is not None
+    ):
+        raise ValueError("missing group already claims execution or production")
+    subset = copy.deepcopy(planned)
+    subset["execute_nodes"] = [node for node in planned["execute_nodes"] if node["node_id"] != NODE]
+    subset["execute_groups"] = [group for group in planned["execute_groups"] if group["artifact_path"] != TARGET]
+    retained = {
+        "nodes": [node for node in report["nodes"] if node["node_id"] != NODE],
+        "producer_groups": [group for group in report["producer_groups"] if group["artifact_path"] != TARGET],
+    }
+    validate_selected_execution_records(retained, subset)
+
+
+def retry_plan(original: dict) -> dict:
+    """Explicit maintenance plan: one node executes, all other bytes come from exact source Git blobs."""
+    result = copy.deepcopy(original)
+    result.update(base_sha=SOURCE, head_sha=SOURCE, merge_sha=SOURCE)
+    selected = version(result)
+    selected["base_artifacts"] = selected["merge_artifacts"]
+    selected["base_config_sha256"] = selected["merge_config_sha256"]
+    selected["base_binary_lock_sha256"] = selected["merge_binary_lock_sha256"]
+    groups = selected["execute_groups"]
+    selected["execute_groups"] = [group for group in groups if group["artifact_path"] == TARGET]
+    selected["execute_nodes"] = [node for node in selected["execute_nodes"] if node["node_id"] == NODE]
+    if len(selected["execute_groups"]) != 1 or len(selected["execute_nodes"]) != 1:
+        raise ValueError("retry closure is not exactly the reviewed node")
+    prefix = f"bin_artifacts/{GAMEVER}/"
+    selected["inherit_paths"] = [
+        dict(item, path=item["path"].removeprefix(prefix))
+        for item in selected["merge_artifacts"]["files"]
+        if item["path"] != prefix + TARGET
+    ]
+    present = {item["path"].removeprefix(prefix) for item in selected["merge_artifacts"]["files"]}
+    selected["inherited_absent_groups"] = [group for group in groups if group["artifact_path"] not in present]
+    selected["removed_paths"] = []
+    selected["invalidated_paths"] = [TARGET]
+    selected["reasons"] = ["Explicit one-off Phase-D repair of an unattempted node"]
+    result.pop("plan_sha256")
+    result["plan_sha256"] = _digest("trusted-pr-plan", result)
+    return result
+
+
+def resume(args) -> dict:
+    repo = GitTreeRepository(args.repo_root)
+    if repo.resolve_commit("HEAD") != SOURCE:
+        raise ValueError("continuation requires the original reviewed source checkout")
+    if os.environ.get("CS2VIBE_STRING_MIN_LENGTH") != "4":
+        raise ValueError("continuation must preserve string minimum 4")
+    root = args.evidence_root.resolve()
+    output = args.output_root.resolve()
+    if output.is_relative_to(args.repo_root.resolve()) or output.is_relative_to(root):
+        raise ValueError("continuation output must be fresh and outside source/old evidence")
+    output.mkdir(parents=True, exist_ok=False)
+    previous = json.loads((root / "comparison.json").read_text())
+    if previous["source_sha"] != SOURCE or previous["string_min_length"] != "4":
+        raise ValueError("previous experiment identity drifted")
+    expected_names = {"pr-926", "artifact-only", "cross-stage", "fresh-full"}
+    if {item["name"] for item in previous["results"]} != expected_names or len(previous["results"]) != 4:
+        raise ValueError("previous successful experiment set drifted")
+    baseline_root = root / "fresh-full/rebuild/actual-bin-artifacts"
+    for item in previous["results"]:
+        name = item["name"]
+        validation = validate_isolated_rebuild(
+            repo_root=repo.root,
+            plan=root / name / "experimental-plan.json",
+            preparation=root / name / "rebuild/preparation.json",
+        )
+        if validation != item["validation"]:
+            raise ValueError(f"archived validation drifted: {name}")
+        compare_inventories(baseline_root, root / name / "rebuild/actual-bin-artifacts")
+    original = load_trusted_artifact_plan(root / "shared-runtime/experimental-plan.json")
+    if original["merge_tree_sha"] != repo.tree_sha(SOURCE):
+        raise ValueError("archived source tree differs from the reviewed experiment")
+    planned = version(original)
+    preparation = json.loads((root / "shared-runtime/rebuild/preparation.json").read_text())
+    unsigned_preparation = {key: value for key, value in preparation.items() if key != "preparation_sha256"}
+    if preparation["preparation_sha256"] != _digest("isolated-preparation", unsigned_preparation):
+        raise ValueError("archived preparation digest drifted")
+    if preparation["plan_sha256"] != original["plan_sha256"] or Path(preparation["staging_root"]).parents[1] != root:
+        raise ValueError("archived evidence must be restored to its exact bound runner path")
+    manifest = _load_selected_execution_manifest(Path(preparation["selected_execution_manifests"][GAMEVER]))
+    failed_path = root / "shared-runtime/rebuild/execution-reports/14178b.selected.json"
+    raw = failed_path.read_bytes()
+    failed = json.loads(raw)
+    unsigned = {key: value for key, value in failed.items() if key != "execution_sha256"}
+    if raw != _canonical_json_bytes(failed) or failed["execution_sha256"] != _selected_execution_digest(unsigned):
+        raise ValueError("archived failed execution digest drifted")
+    if failed["plan_sha256"] != original["plan_sha256"] or failed["manifest_sha256"] != manifest["manifest_sha256"]:
+        raise ValueError("archived selected provenance drifted")
+    if (
+        failed["artifact_root"] != preparation["actual_artifact_root"]
+        or failed["binary_root"] != preparation["binary_root"]
+        or failed["config_path"] != str(Path(preparation["config_root"]) / f"{GAMEVER}.yaml")
+        or failed.get("required_warm_idb") is not True
+    ):
+        raise ValueError("archived execution root bindings drifted")
+    if failed["inherited_initial_inventory_sha256"] != preparation["initial_actual_inventory_sha256"][GAMEVER]:
+        raise ValueError("archived initial inventory binding drifted")
+    if manifest["execute_nodes"] != planned["execute_nodes"] or manifest["execute_groups"] != planned["execute_groups"]:
+        raise ValueError("archived manifest closure drifted")
+    check_failed_records(failed, planned)
+    baseline = inventory(baseline_root)
+    retained = inventory(root / "shared-runtime/rebuild/actual-bin-artifacts")
+    if retained != {path: value for path, value in baseline.items() if path != f"{GAMEVER}/{TARGET}"}:
+        raise ValueError("previous artifacts differ beyond the single missing output")
+
+    # The executor delta is deliberately restricted: all retained nodes avoided this branch.
+    tool_root = Path(__file__).resolve().parent
+    original_executor = repo.read(SOURCE, "ida_analyze_bin.py")
+    old = b"            if skip_for_existing_artifacts:\n"
+    new = b"            if skip_for_existing_artifacts and not force_all:\n"
+    executor = GitTreeRepository(tool_root).read("HEAD", "ida_analyze_bin.py")
+    if original_executor.count(old) != 1 or executor != original_executor.replace(old, new):
+        raise ValueError("executor differs beyond the reviewed one-line skip fix")
+    contract = load_contract(repo.root / "configs/14178b.yaml", GAMEVER, repo.root / "bin")
+    if planned["inherit_paths"] or {group["group_id"] for group in planned["execute_groups"]} != set(
+        contract.producer_groups
+    ):
+        raise ValueError("archived shared-runtime plan is not a full execution closure")
+    node = contract.nodes[NODE]
+    group = contract.producer_group_for_path(TARGET)
+    if (
+        node.prerequisites
+        or node.outputs != {TARGET}
+        or contract.downstream_group_ids({group.group_id}) != {group.group_id}
+    ):
+        raise ValueError("the retry node now has prerequisites, extra outputs or downstream dependencies")
+    maintenance_plan = retry_plan(original)
+    write_json(output / "maintenance-plan.json", maintenance_plan)
+    prepared = prepare_isolated_rebuild(
+        repo_root=repo.root, plan=maintenance_plan, staging_root=output / "retry", game_version=GAMEVER
+    )
+    warm = previous["results"][0]["warm_restore"]
+    if any(item["warm_restore"] != warm for item in previous["results"]):
+        raise ValueError("previous warm identities differ")
+    if json.loads((root / "shared-runtime/warm-restore.json").read_text()) != warm:
+        raise ValueError("failed sample warm identity differs")
+    restored = restore_cache(
+        repo_root=repo.root,
+        persisted_root=args.persisted_root,
+        gamever=GAMEVER,
+        generation=warm["generation"],
+        expected_cache_key=warm["cache_key"],
+        ida_version=warm["ida_version"],
+    )
+    write_json(output / "warm-restore.json", restored)
+    lock = verify_source_binary_root(
+        repo_root=repo.root,
+        gamever=GAMEVER,
+        binary_root=repo.root / "bin" / GAMEVER,
+        label="Phase-D continuation binaries",
+    )
+    if lock.sha256 != planned["merge_binary_lock_sha256"]:
+        raise ValueError("continuation binary identity drifted")
+    import sys
+
+    command = [
+        sys.executable,
+        str(tool_root / "ida_analyze_bin.py"),
+        "-gamever",
+        GAMEVER,
+        "-configyaml",
+        str(Path(prepared["config_root"]) / f"{GAMEVER}.yaml"),
+        "-bindir",
+        "bin",
+        "-artifactdir",
+        prepared["actual_artifact_root"],
+        "-oldartifactdir",
+        "bin_artifacts",
+        "-execution_report",
+        prepared["execution_reports"][GAMEVER],
+        "-require_warm_idb",
+        "-selected_execution",
+        prepared["selected_execution_manifests"][GAMEVER],
+    ]
+    elapsed = run_logged(repo.root, command, output / "retry.log")
+    validation = validate_isolated_rebuild(repo_root=repo.root, plan=maintenance_plan, preparation=prepared)
+    write_json(output / "retry-validation.json", validation)
+    supplemental = json.loads(Path(prepared["execution_reports"][GAMEVER]).read_text())
+    # Validate a records-only coverage view. Never fabricate a successful original report.
+    records = {
+        "nodes": [record for record in failed["nodes"] if record["node_id"] != NODE] + supplemental["nodes"],
+        "producer_groups": [record for record in failed["producer_groups"] if record["artifact_path"] != TARGET]
+        + supplemental["producer_groups"],
+    }
+    validate_selected_execution_records(records, planned)
+    combined = output / "combined-artifacts"
+    shutil.copytree(root / "shared-runtime/rebuild/actual-bin-artifacts", combined)
+    target = combined / GAMEVER / TARGET
+    shutil.copyfile(Path(prepared["actual_artifact_root"]) / GAMEVER / TARGET, target)
+    comparison = compare_inventories(baseline_root, combined)
+    compare_inventories(baseline_root, Path(prepared["actual_artifact_root"]))
+    result = {
+        "schema_version": 1,
+        "purpose": "phase-d-cross-run-continuation-not-pr-attestation",
+        "valid": True,
+        "original_run": 34031704261,
+        "source_sha": SOURCE,
+        "source_tree_sha": original["merge_tree_sha"],
+        "original_failed_report_sha256": failed["execution_sha256"],
+        "supplemental_report_sha256": supplemental["execution_sha256"],
+        "executor_sha256": hashlib.sha256(executor).hexdigest(),
+        "executor_delta": "one-line forced skip guard",
+        "retained_successful_nodes": sum(record["status"] == "succeeded" for record in failed["nodes"]),
+        "retried_nodes": [NODE],
+        "covered_groups": len(records["producer_groups"]),
+        "comparison": comparison,
+        "warm_restore": restored,
+        "binary_lock_sha256": lock.sha256,
+        "producer_seconds": elapsed,
+        "downstream_evidence": "reused verified fresh-full result after exact source/config/inventory equality",
+        "prior_results": previous["results"],
+    }
+    write_json(output / "continuation.json", result)
+    return result
+
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser(description=__doc__)
+    for name in ("repo-root", "evidence-root", "output-root", "persisted-root"):
+        parser.add_argument(f"--{name}", type=Path, required=True)
+    resume(parser.parse_args())

--- a/tests/test_ida_analyze_bin.py
+++ b/tests/test_ida_analyze_bin.py
@@ -2553,6 +2553,58 @@ class TestProcessBinary(unittest.TestCase):
                 self.assertEqual((1, 0, 0), result)
                 self.assertEqual(producer == "agent", finalize_outputs.call_args.kwargs["regenerate_func_signatures"])
 
+    def test_forced_execution_ignores_skip_if_exists_before_and_during_session(self) -> None:
+        for initially_present in (False, True):
+            with self.subTest(initially_present=initially_present), TemporaryDirectory() as temp_dir:
+                artifact_dir = Path(temp_dir) / "artifacts"
+                artifact_dir.mkdir()
+                marker = artifact_dir / "Marker.linux.yaml"
+                target = artifact_dir / "Target.linux.yaml"
+                if initially_present:
+                    marker.write_text("marker\n", encoding="utf-8")
+                skills = (
+                    []
+                    if initially_present
+                    else [{"name": "produce-marker", "expected_output": ["Marker.{platform}.yaml"]}]
+                )
+                skills.append(
+                    {
+                        "name": "produce-target",
+                        "optional_output": ["Target.{platform}.yaml"],
+                        "skip_if_exists": ["Marker.{platform}.yaml"],
+                    }
+                )
+                calls = []
+
+                def preprocess(*, skill_name, **_kwargs):
+                    calls.append(skill_name)
+                    (marker if skill_name == "produce-marker" else target).write_text("output\n", encoding="utf-8")
+                    return "success"
+
+                process = object()
+                with (
+                    patch.object(ida_analyze_bin, "start_idalib_mcp", return_value=process),
+                    patch.object(ida_analyze_bin, "ensure_mcp_available", return_value=(process, True)),
+                    patch.object(ida_analyze_bin, "_run_validate_expected_input_artifacts_via_mcp", return_value=[]),
+                    patch.object(ida_analyze_bin, "_run_preprocess_single_skill_via_mcp", side_effect=preprocess),
+                    patch.object(ida_analyze_bin, "_finalize_produced_symbol_outputs", return_value=[]),
+                    patch.object(ida_analyze_bin, "quit_ida_gracefully", return_value=None),
+                ):
+                    counts = ida_analyze_bin.process_binary(
+                        binary_path=str(Path(temp_dir) / "libserver.so"),
+                        skills=skills,
+                        agent="codex",
+                        host="127.0.0.1",
+                        port=13337,
+                        ida_args="",
+                        platform="linux",
+                        artifact_dir=artifact_dir,
+                        force_all=True,
+                    )
+                self.assertEqual((len(skills), 0, 0), counts)
+                self.assertEqual([skill["name"] for skill in skills], calls)
+                self.assertTrue(target.is_file())
+
     def test_force_all_multi_output_fallback_only_produces_missing_outputs(self) -> None:
         with TemporaryDirectory() as temp_dir:
             binary_dir = Path(temp_dir) / "server"

--- a/tests/test_phase_d_validation.py
+++ b/tests/test_phase_d_validation.py
@@ -4,10 +4,68 @@ import unittest
 from pathlib import Path
 
 from phase_d_validation import compare_inventories, experimental_plan, synthetic_base
+from phase_d_resume import NODE, TARGET, check_failed_records
 from trusted_artifact_pr import GitTreeRepository, _digest
 
 
 class PhaseDValidationTests(unittest.TestCase):
+    def test_partial_continuation_validates_retained_evidence_without_marking_original_valid(self):
+        groups = [
+            {
+                "group_id": name,
+                "artifact_path": path,
+                "required": True,
+                "fingerprint": name,
+                "alternative_node_ids": [name],
+            }
+            for name, path in (("kept", "kept.yaml"), (NODE, TARGET))
+        ]
+        planned = {
+            "game_version": "14178b",
+            "execute_groups": groups,
+            "execute_nodes": [
+                {"node_id": name, "outputs": [path]} for name, path in (("kept", "kept.yaml"), (NODE, TARGET))
+            ],
+            "merge_artifacts": {"files": [{"path": "bin_artifacts/14178b/kept.yaml", "sha256": "kept-hash"}]},
+        }
+        report = {
+            "valid": False,
+            "issues": ["missing attempt"],
+            "nodes": [
+                {
+                    "node_id": "kept",
+                    "status": "succeeded",
+                    "attempted": True,
+                    "attempted_paths": ["kept.yaml"],
+                    "produced_paths": ["kept.yaml"],
+                },
+                {
+                    "node_id": NODE,
+                    "status": "skipped",
+                    "reason": "skip_if_exists",
+                    "attempted": False,
+                    "attempted_paths": [],
+                    "produced_paths": [],
+                },
+            ],
+            "producer_groups": [
+                dict(groups[0], attempted_node_ids=["kept"], winner_node_id="kept", output_sha256="kept-hash"),
+                dict(groups[1], attempted_node_ids=[], winner_node_id=None, output_sha256=None),
+            ],
+        }
+        before = copy.deepcopy(report)
+        check_failed_records(report, planned)
+        self.assertEqual(before, report)
+        for path in ("foreign.yaml", TARGET):
+            tampered = copy.deepcopy(report)
+            tampered["nodes"][0]["produced_paths"].append(path)
+            with self.assertRaises(RuntimeError):
+                check_failed_records(tampered, planned)
+        tampered = copy.deepcopy(report)
+        tampered["nodes"][1]["produced_paths"] = [TARGET]
+        with self.assertRaises(ValueError):
+            check_failed_records(tampered, planned)
+
     def test_strategy_trial_preserves_the_original_plan_and_closure(self):
         original = {"execution_strategy": "fresh-full-v1", "execute_nodes": ["a"]}
         original["plan_sha256"] = _digest("trusted-pr-plan", original)

--- a/trusted_artifact_pr.py
+++ b/trusted_artifact_pr.py
@@ -1388,6 +1388,15 @@ def _load_selected_execution_report(path: Path, *, preparation: dict, version: d
     ):
         raise TrustedArtifactPrError(f"selected execution report does not prove the required PR run for {gamever}")
 
+    validate_selected_execution_records(report, version)
+    if report.get("inherited_initial_inventory_sha256") != preparation["initial_actual_inventory_sha256"].get(gamever):
+        raise TrustedArtifactPrError(f"selected execution report lost the seeded-root binding for {gamever}")
+    return report
+
+
+def validate_selected_execution_records(report: dict, version: dict) -> None:
+    """Validate group/node coverage and writes; callers must separately bind provenance and roots."""
+    gamever = version["game_version"]
     expected_files = {
         item["path"].removeprefix(f"bin_artifacts/{gamever}/"): item for item in version["merge_artifacts"]["files"]
     }
@@ -1530,9 +1539,6 @@ def _load_selected_execution_report(path: Path, *, preparation: dict, version: d
             continue
         if record.get("attempted") is not True or record.get("status") != "succeeded":
             raise TrustedArtifactPrError(f"planned prerequisite node lacks successful execution evidence: {node_id}")
-    if report.get("inherited_initial_inventory_sha256") != preparation["initial_actual_inventory_sha256"].get(gamever):
-        raise TrustedArtifactPrError(f"selected execution report lost the seeded-root binding for {gamever}")
-    return report
 
 
 def _load_selected_execution_manifest(path: Path) -> dict:


### PR DESCRIPTION
## Problem and fix

Phase-D's shared-runtime selected run completed 2195 skills but skipped the Linux `CFlashbangProjectile_Spawn_NetworkStateChangedNotify` producer when another skill created its `skip_if_exists` marker during the IDA session. The final evidence check correctly rejected the missing attempt/output. The second skip-marker check now honors forced execution, matching the pre-start check; ordinary incremental skipping and alternative-winner behavior stay intact.

## One-off migration continuation

Add a temporary continuation switch to the existing main-only Phase-D workflow. It consumes immutable artifact evidence from run 34031704261, re-verifies the four successful runs and the retained shared-runtime node records, and permits only the reviewed one-line executor change. It restores the exact original warm generation, inherits 3525 files from exact source Git blobs, and executes the single missing node (no prerequisite, extra output, or downstream dependency).

The new result is explicitly cross-run migration evidence, not a PR/release attestation. It preserves the original failed report, checks combined coverage through the same extracted records validator, and compares the repaired complete inventory with the validated full baseline. Downstream evidence is reused only after exact source/config/inventory agreement. No general resume mode or weakened production report acceptance is introduced. Remove this temporary helper with the Phase-D workflow after #926 merges; retain the executor fix and regression test.

## Validation

- Regression first reproduced both pre-existing and in-session marker skips; fixed result passes
- Analyzer/release regression: 207 passed
- Trusted planner/context regression: 43 passed
- Phase-D helper tests: 5 passed, including rejected unauthorized retained writes and preservation of the original failed report
- Real archived evidence audit and retry preparation: retained records verified; 1 retry node and 3525 inherited files
- All three successful selected inventories match the full baseline; failed shared-runtime inventory differs only by the one missing YAML
- actionlint and formatting checks passed
- Live single-node continuation is pending this independently merged trusted maintenance update
