### PR TITLE
fix(ci): Preserve bump producer attempt and wait for PR head convergence

### DIFF
--- a/.github/workflows/bump-download.yml
+++ b/.github/workflows/bump-download.yml
@@ -25,6 +25,7 @@ jobs:
       source_gamever: ${{ steps.bump.outputs.analysis_config_source_gamever }}
       config_path: ${{ steps.bump.outputs.analysis_config_path }}
       candidate_artifact_name: ${{ steps.package.outputs.artifact_name }}
+      candidate_run_attempt: ${{ steps.package.outputs.run_attempt }}
       candidate_artifact_digest: ${{ steps.upload.outputs.artifact-digest }}
     env:
       DEPOTDOWNLOADER_STEAM_USERNAME: ${{ secrets.DEPOTDOWNLOADER_STEAM_USERNAME }}
@@ -180,6 +181,7 @@ jobs:
           if ($LASTEXITCODE -ne 0) { throw "Download bump candidate validation failed." }
           $artifactName = "bump-download-candidate-$tag-$env:GITHUB_RUN_ID-$env:GITHUB_RUN_ATTEMPT"
           "artifact_name=$artifactName" | Out-File $env:GITHUB_OUTPUT -Encoding utf8 -Append
+          "run_attempt=$env:GITHUB_RUN_ATTEMPT" | Out-File $env:GITHUB_OUTPUT -Encoding utf8 -Append
           "CANDIDATE_ROOT=$candidate" | Out-File $env:GITHUB_ENV -Encoding utf8 -Append
       - name: Upload exact download bump candidate
         id: upload
@@ -209,6 +211,7 @@ jobs:
           UNTRUSTED_CONFIG_PATH: ${{ needs.bump.outputs.config_path }}
           UNTRUSTED_ARTIFACT_NAME: ${{ needs.bump.outputs.candidate_artifact_name }}
           UNTRUSTED_ARTIFACT_DIGEST: ${{ needs.bump.outputs.candidate_artifact_digest }}
+          UNTRUSTED_RUN_ATTEMPT: ${{ needs.bump.outputs.candidate_run_attempt }}
         run: |
           $gameverPattern = '\A(?:[0-9]{4,10}[a-z]?|[1-9][0-9]*)\z'
           $gamever = $env:UNTRUSTED_GAMEVER
@@ -222,7 +225,15 @@ jobs:
           if ($env:UNTRUSTED_CONFIG_PATH -cne $expectedConfigPath) {
             throw "Self-hosted bump job returned an invalid config path."
           }
-          $expectedArtifactName = "bump-download-candidate-$gamever-$env:GITHUB_RUN_ID-$env:GITHUB_RUN_ATTEMPT"
+          # A failed-job rerun reuses outputs from the successful producer attempt.
+          $producerAttempt = $env:UNTRUSTED_RUN_ATTEMPT
+          $attemptNumber = 0L
+          if (-not [regex]::IsMatch($producerAttempt, '\A[1-9][0-9]*\z') -or
+              -not [long]::TryParse($producerAttempt, [ref]$attemptNumber) -or
+              $attemptNumber -gt [long]$env:GITHUB_RUN_ATTEMPT) {
+            throw "Self-hosted bump job returned an invalid producer run attempt."
+          }
+          $expectedArtifactName = "bump-download-candidate-$gamever-$env:GITHUB_RUN_ID-$producerAttempt"
           if ($env:UNTRUSTED_ARTIFACT_NAME -cne $expectedArtifactName) {
             throw "Self-hosted bump job returned an invalid artifact name."
           }
@@ -238,6 +249,7 @@ jobs:
           "config_path=$expectedConfigPath" | Out-File $env:GITHUB_OUTPUT -Encoding utf8 -Append
           "artifact_name=$expectedArtifactName" | Out-File $env:GITHUB_OUTPUT -Encoding utf8 -Append
           "artifact_digest=$artifactDigest" | Out-File $env:GITHUB_OUTPUT -Encoding utf8 -Append
+          "run_attempt=$producerAttempt" | Out-File $env:GITHUB_OUTPUT -Encoding utf8 -Append
       - name: Checkout exact bound default-branch base without credentials
         uses: actions/checkout@v5
         with:
@@ -262,6 +274,7 @@ jobs:
           CANDIDATE_SOURCE_GAMEVER: ${{ steps.validate-inputs.outputs.source_gamever }}
           CANDIDATE_ARTIFACT_NAME: ${{ steps.validate-inputs.outputs.artifact_name }}
           CANDIDATE_ARTIFACT_DIGEST: ${{ steps.validate-inputs.outputs.artifact_digest }}
+          CANDIDATE_RUN_ATTEMPT: ${{ steps.validate-inputs.outputs.run_attempt }}
         run: |
           git -C publication config user.name "source-artifact-automation"
           git -C publication config user.email "source-artifact-automation@users.noreply.github.com"
@@ -278,7 +291,7 @@ jobs:
             --actions-artifact-name "$env:CANDIDATE_ARTIFACT_NAME" `
             --actions-artifact-digest "$env:CANDIDATE_ARTIFACT_DIGEST" `
             --workflow-run-id "$env:GITHUB_RUN_ID" `
-            --workflow-run-attempt "$env:GITHUB_RUN_ATTEMPT" `
+            --workflow-run-attempt "$env:CANDIDATE_RUN_ATTEMPT" `
             --workflow-run-url "$env:GITHUB_SERVER_URL/$env:GITHUB_REPOSITORY/actions/runs/$env:GITHUB_RUN_ID" `
             --output "$receipt"
           if ($LASTEXITCODE -ne 0) { throw "Hosted download bump candidate verification failed." }
@@ -332,6 +345,7 @@ jobs:
             Remove-Item Env:GIT_PASSWORD -ErrorAction SilentlyContinue
           }
       - name: Create bump pull request with read/write PR token
+        id: create-pr
         uses: actions/github-script@v7
         env:
           BUMP_TAG: ${{ steps.validate-inputs.outputs.gamever }}
@@ -400,6 +414,7 @@ jobs:
               ].join('\n'),
             });
 
+            core.setOutput('pr_number', pull.number);
             core.notice(`Created bump pull request: ${pull.html_url}`);
       - name: Synchronize the new PR head with a protected PAT validation trigger
         id: synchronize
@@ -444,17 +459,35 @@ jobs:
         env:
           BUMP_BRANCH: bump-download/${{ steps.validate-inputs.outputs.gamever }}
           TRIGGER_SHA: ${{ steps.synchronize.outputs.trigger_sha }}
+          PR_NUMBER: ${{ steps.create-pr.outputs.pr_number }}
         with:
           github-token: ${{ github.token }}
           script: |
-            const pulls = await github.paginate(github.rest.pulls.list, {
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              state: 'open',
-              head: `${context.repo.owner}:${process.env.BUMP_BRANCH}`,
-              per_page: 100,
-            });
-            if (pulls.length !== 1 || pulls[0].head.sha !== process.env.TRIGGER_SHA) {
-              throw new Error('Synchronized bump pull request head does not match the protected PAT push.');
+            const pollIntervalMs = 2000;
+            const timeoutMs = 60000;
+            const deadline = Date.now() + timeoutMs;
+            let observedSha;
+            // A successful push can precede the PR API's head update.
+            while (true) {
+              const { data: pull } = await github.rest.pulls.get({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                pull_number: Number(process.env.PR_NUMBER),
+              });
+              if (pull.state !== 'open' || pull.head.ref !== process.env.BUMP_BRANCH ||
+                  pull.head.repo?.full_name !== `${context.repo.owner}/${context.repo.repo}`) {
+                throw new Error('Synchronized bump pull request identity or state changed.');
+              }
+              observedSha = pull.head.sha;
+              if (observedSha === process.env.TRIGGER_SHA) {
+                core.notice(`Synchronized bump pull request: ${pull.html_url}`);
+                return;
+              }
+              const remainingMs = deadline - Date.now();
+              if (remainingMs <= 0) {
+                throw new Error(`Timed out waiting for PR #${process.env.PR_NUMBER} head: ` +
+                  `expected ${process.env.TRIGGER_SHA}, observed ${observedSha}.`);
+              }
+              core.info(`Waiting for PR #${process.env.PR_NUMBER} head to synchronize; observed ${observedSha}.`);
+              await new Promise(resolve => setTimeout(resolve, Math.min(pollIntervalMs, remainingMs)));
             }
-            core.notice(`Synchronized bump pull request: ${pulls[0].html_url}`);

--- a/tests/test_bump_publish_retry.py
+++ b/tests/test_bump_publish_retry.py
@@ -1,0 +1,179 @@
+"""Execute the publisher scripts against retry inputs and a simulated GitHub API."""
+
+import json
+import os
+from pathlib import Path
+import shutil
+import subprocess
+import tempfile
+import unittest
+
+from tests.workflow_contract_test_support import load_workflow
+
+POWERSHELL = shutil.which("pwsh") or shutil.which("powershell")
+
+
+def publisher_step(name):
+    steps = load_workflow("bump-download.yml")["jobs"]["publish-bump-branch"]["steps"]
+    return next(step for step in steps if step["name"] == name)
+
+
+class BumpPublisherRetryTests(unittest.TestCase):
+    @unittest.skipUnless(POWERSHELL, "PowerShell required")
+    def test_producer_attempt_validation(self):
+        script = publisher_step("Validate untrusted bump job outputs")["run"]
+        for producer, current, artifact_attempt, accepted in [
+            ("1", "2", "1", True),
+            ("2", "2", "2", True),
+            ("3", "2", "3", False),
+            ("0", "2", "0", False),
+            ("-1", "2", "-1", False),
+            ("01", "2", "01", False),
+            ("1\n", "2", "1\n", False),
+            ("", "2", "", False),
+            ("abc", "2", "abc", False),
+            ("999999999999999999999999", "2", "999999999999999999999999", False),
+            ("1", "2", "2", False),
+        ]:
+            with (
+                self.subTest(producer=producer, artifact_attempt=artifact_attempt),
+                tempfile.TemporaryDirectory() as tmp,
+            ):
+                output = Path(tmp) / "output"
+                source = Path(tmp) / "validate.ps1"
+                source.write_text(script, encoding="utf-8")
+                env = dict(
+                    os.environ,
+                    GITHUB_RUN_ID="123",
+                    GITHUB_RUN_ATTEMPT=current,
+                    GITHUB_OUTPUT=str(output),
+                    UNTRUSTED_GAMEVER="14180",
+                    UNTRUSTED_SOURCE_GAMEVER="14178b",
+                    UNTRUSTED_CONFIG_PATH="configs/14180.yaml",
+                    UNTRUSTED_ARTIFACT_NAME=f"bump-download-candidate-14180-123-{artifact_attempt}",
+                    UNTRUSTED_ARTIFACT_DIGEST="a" * 64,
+                    UNTRUSTED_RUN_ATTEMPT=producer,
+                )
+                result = subprocess.run(
+                    [POWERSHELL, "-NoProfile", "-File", str(source)],
+                    env=env,
+                    capture_output=True,
+                    text=True,
+                    timeout=20,
+                )
+                self.assertEqual(accepted, result.returncode == 0, result.stderr)
+                if accepted:
+                    values = dict(line.split("=", 1) for line in output.read_text(encoding="utf-8-sig").splitlines())
+                    self.assertEqual(producer, values["run_attempt"])
+                    self.assertEqual(env["UNTRUSTED_ARTIFACT_NAME"], values["artifact_name"])
+
+    @unittest.skipUnless(POWERSHELL, "PowerShell required")
+    def test_prepare_receives_producer_attempt(self):
+        step = publisher_step("Revalidate candidate and create direct-child bump commit")
+        # Resolve the step's output bindings, then capture the real command arguments.
+        outputs = {
+            "gamever": "14180",
+            "source_gamever": "14178b",
+            "run_attempt": "1",
+            "artifact_name": "bump-download-candidate-14180-123-1",
+            "artifact_digest": "sha256:" + "a" * 64,
+        }
+        env = dict(os.environ, GITHUB_RUN_ATTEMPT="2", GITHUB_RUN_ID="123")
+        for key, expression in step["env"].items():
+            output_key = expression.removeprefix("${{ steps.validate-inputs.outputs.").removesuffix(" }}")
+            env[key] = outputs[output_key]
+        with tempfile.TemporaryDirectory() as tmp:
+            (Path(tmp) / "publication").mkdir()
+            env.update(GITHUB_WORKSPACE=tmp, GITHUB_OUTPUT=str(Path(tmp) / "output"))
+            source = Path(tmp) / "prepare.ps1"
+            source.write_text(
+                r"""
+function git { $global:LASTEXITCODE = 0 }
+function uv {
+    $args | ConvertTo-Json | Set-Content -LiteralPath (Join-Path $env:GITHUB_WORKSPACE 'arguments.json')
+    '{"commit_sha":"aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"}' |
+        Set-Content -LiteralPath (Join-Path $env:GITHUB_WORKSPACE 'bump-publication-receipt.json')
+    $global:LASTEXITCODE = 0
+}
+"""
+                + step["run"],
+                encoding="utf-8",
+            )
+            subprocess.run(
+                [POWERSHELL, "-NoProfile", "-File", str(source)],
+                env=env,
+                capture_output=True,
+                text=True,
+                check=True,
+                timeout=20,
+            )
+            arguments = json.loads((Path(tmp) / "arguments.json").read_text(encoding="utf-8-sig"))
+            self.assertEqual("1", arguments[arguments.index("--workflow-run-attempt") + 1])
+            self.assertEqual(outputs["artifact_name"], arguments[arguments.index("--actions-artifact-name") + 1])
+
+    @unittest.skipUnless(shutil.which("node"), "Node.js required")
+    def test_pr_head_convergence(self):
+        script = publisher_step("Verify synchronized PR head")["with"]["script"]
+        harness = r"""
+const script = SCRIPT;
+const scenario = process.argv[2];
+let now = 0, calls = 0, sleeps = [];
+Date.now = () => now;
+const wait = (callback, delay) => { sleeps.push(delay); now += delay; callback(); };
+const expected = 'a'.repeat(40), old = 'b'.repeat(40);
+process.env.TRIGGER_SHA = expected;
+process.env.PR_NUMBER = '941';
+process.env.BUMP_BRANCH = 'bump-download/14180';
+const get = async ({pull_number}) => {
+  if (pull_number !== 941) throw new Error('Wrong PR number');
+  calls++;
+  if (scenario === 'api-error') throw new Error('API denied');
+  return {data: {state: scenario === 'closed' ? 'closed' : 'open', html_url: 'https://example.test/941',
+    head: {sha: scenario === 'immediate' || (scenario === 'delayed' && calls >= 3) ? expected : old,
+           ref: scenario === 'wrong-branch' ? 'other' : process.env.BUMP_BRANCH,
+           repo: {full_name: scenario === 'wrong-repo' ? 'other/repo' : 'owner/repo'}}}};
+};
+const github = {rest: {pulls: {get, list() {}}},
+  paginate: async () => [(await get({pull_number: 941})).data]};
+const core = {notice() {}, info() {}};
+const AsyncFunction = Object.getPrototypeOf(async function(){}).constructor;
+(async () => {
+  try {
+    await new AsyncFunction('github', 'context', 'core', 'setTimeout', script)(
+      github, {repo: {owner: 'owner', repo: 'repo'}}, core, wait);
+    console.log(JSON.stringify({ok: true, calls, now, sleeps}));
+  } catch (error) {
+    console.log(JSON.stringify({ok: false, error: error.message, calls, now, sleeps}));
+  }
+})();
+""".replace("SCRIPT", json.dumps(script))
+        with tempfile.TemporaryDirectory() as tmp:
+            source = Path(tmp) / "poll.cjs"
+            source.write_text(harness, encoding="utf-8")
+            for scenario in ("immediate", "delayed", "timeout", "api-error", "closed", "wrong-branch", "wrong-repo"):
+                with self.subTest(scenario=scenario):
+                    result = subprocess.run(
+                        ["node", str(source), scenario], capture_output=True, text=True, check=True, timeout=10
+                    )
+                    observed = json.loads(result.stdout)
+                    self.assertEqual(scenario in ("immediate", "delayed"), observed["ok"], observed)
+                    if scenario == "immediate":
+                        self.assertEqual(1, observed["calls"])
+                        self.assertEqual([], observed["sleeps"])
+                    elif scenario == "delayed":
+                        self.assertEqual(3, observed["calls"])
+                        self.assertEqual(4000, observed["now"])
+                    elif scenario == "timeout":
+                        self.assertEqual(60000, observed["now"])
+                        self.assertIn("a" * 40, observed["error"])
+                        self.assertIn("b" * 40, observed["error"])
+                    elif scenario == "api-error":
+                        self.assertEqual("API denied", observed["error"])
+                        self.assertEqual(1, observed["calls"])
+                    else:
+                        self.assertIn("identity or state changed", observed["error"])
+                        self.assertEqual(1, observed["calls"])
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
﻿## Summary

A failed-only rerun reused the successful bump job's artifact but validated it against the publisher's newer attempt. Preserve attempt-stamped names and propagate the validated producer attempt through both artifact-name validation and candidate manifest verification.

After the protected synchronization push, query the created PR by number every 2 seconds for up to approximately 60 seconds until its head matches the trigger SHA. Keep PR identity/state checks and report expected/observed SHA on timeout.

Partial-publication recovery remains outside this repair: existing branch/tag/PR guards still fail closed. This does not make retries after publication side effects resumable.

## Validation

- `uv run python -m unittest tests.test_bump_publish_retry tests.test_bump_download` — 51 tests passed, including producer-attempt reuse/rejection, prepare argument propagation, delayed PR convergence, timeout, and identity/API failures.
- `actionlint .github/workflows/bump-download.yml` — passed.
- `uv run python format_repo_files.py --check` — passed.
- Ruff check/format check for the added test and `git diff --check` — passed.
- Local script tests used Windows PowerShell and Node.js with a simulated GitHub API; hosted PowerShell 7 and live API behavior remain for CI/runtime verification.
- Repository PR validation is delegated to trusted `source-artifact-required` / `pr-validate` CI; no hosted CI result is claimed here.

Closes #940
