### PR TITLE
feat(release): Add rebuild drift diagnostics and failure artifacts

### DIFF
--- a/.github/workflows/build-on-self-runner.yml
+++ b/.github/workflows/build-on-self-runner.yml
@@ -287,6 +287,8 @@ jobs:
           "RELEASE_REBUILD_VERIFICATION=$verification" | Out-File $env:GITHUB_ENV -Encoding utf8 -Append
           "ACTUAL_ARTIFACT_ROOT=$($document.actual_artifact_root)" | Out-File $env:GITHUB_ENV -Encoding utf8 -Append
           "FORCE_ALL_EXECUTION_REPORT=$($document.execution_report)" | Out-File $env:GITHUB_ENV -Encoding utf8 -Append
+          $diagnostics = Join-Path $env:RUNNER_TEMP "release-rebuild-diagnostics\${{ github.run_id }}-${{ github.run_attempt }}-$env:GAMEVER"
+          "RELEASE_REBUILD_DIAGNOSTICS=$diagnostics" | Out-File $env:GITHUB_ENV -Encoding utf8 -Append
       - name: Analyze every producer group with force-all and rename
         id: analyze
         shell: pwsh
@@ -309,8 +311,18 @@ jobs:
           uv run python release_artifact_rebuild.py verify `
             --repo-root "${{ github.workspace }}" `
             --preparation "$env:RELEASE_REBUILD_PREPARATION" `
-            --output "$env:RELEASE_REBUILD_VERIFICATION"
+            --output "$env:RELEASE_REBUILD_VERIFICATION" `
+            --diagnostics-dir "$env:RELEASE_REBUILD_DIAGNOSTICS"
           if ($LASTEXITCODE -ne 0) { throw "Fresh release artifacts differ from Git truth." }
+      - name: Upload release rebuild verification failure evidence
+        if: ${{ failure() && steps.verify-artifact-rebuild.outcome == 'failure' }}
+        uses: actions/upload-artifact@v4
+        with:
+          name: release-rebuild-diagnostics-${{ env.GAMEVER }}-${{ github.run_id }}-${{ github.run_attempt }}
+          path: ${{ env.RELEASE_REBUILD_DIAGNOSTICS }}
+          if-no-files-found: warn
+          include-hidden-files: true
+          retention-days: 30
       - name: Prepare local-only BinSync candidate without remote writes
         id: binsync-prepare
         shell: pwsh

--- a/artifact_diagnostics.py
+++ b/artifact_diagnostics.py
@@ -1,0 +1,76 @@
+"""Bounded, best-effort byte diagnostics shared by artifact verifiers."""
+
+from __future__ import annotations
+
+import difflib
+import hashlib
+from itertools import islice
+from pathlib import Path
+
+from gamesymbol_snapshot_lib.paths import is_reparse_point
+
+
+MAX_DIFF_LINES = 40
+MAX_DIFF_CHARACTERS = 16000
+MAX_TEXT_BYTES = 1024 * 1024
+MAX_LOG_CHARACTERS = 64000
+
+
+def read_artifact_bytes(path: Path) -> tuple[bytes | None, str | None]:
+    """Never follow links, and preserve read errors as diagnostic facts."""
+    try:
+        for component in (path, *path.parents):
+            if is_reparse_point(component):
+                return None, f"unreadable: link/reparse point: {component}"
+        return path.read_bytes(), None
+    except FileNotFoundError:
+        return None, None
+    except OSError as exc:
+        return None, f"unreadable: {exc}"
+
+
+def content_diff(
+    label: str,
+    expected: bytes | None,
+    actual: bytes | None,
+    *,
+    expected_error: str | None = None,
+    actual_error: str | None = None,
+    max_diff_lines: int = MAX_DIFF_LINES,
+) -> str:
+    def describe(raw: bytes | None, error: str | None) -> str:
+        if error:
+            return error
+        if raw is None:
+            return "missing"
+        return f"size={len(raw)} sha256=sha256:{hashlib.sha256(raw).hexdigest()}"
+
+    facts = (
+        f"\n  artifact: {label}"
+        f"\n  expected: {describe(expected, expected_error)}"
+        f"\n  actual:   {describe(actual, actual_error)}"
+    )
+    if expected_error or actual_error:
+        return facts[:MAX_DIFF_CHARACTERS]
+    if max(len(expected or b""), len(actual or b"")) > MAX_TEXT_BYTES:
+        return facts + "\n  content diff omitted: text size limit exceeded"
+    if b"\0" in (expected or b"") or b"\0" in (actual or b""):
+        return facts + "\n  content diff unavailable: binary data"
+    try:
+        expected_lines = (expected or b"").decode("utf-8").splitlines()
+        actual_lines = (actual or b"").decode("utf-8").splitlines()
+    except UnicodeDecodeError:
+        return facts + "\n  content diff unavailable: not UTF-8"
+    if expected_lines == actual_lines:
+        if expected != actual:
+            return facts + "\n  bytes differ only in line endings/final newline or file presence"
+        return facts
+    lines = list(
+        islice(
+            difflib.unified_diff(expected_lines, actual_lines, fromfile="expected", tofile="actual", lineterm=""),
+            max_diff_lines + 1,
+        )
+    )
+    rendered = facts + "\n  content diff (expected -> actual):\n    " + "\n    ".join(lines[:max_diff_lines])
+    truncated = len(lines) > max_diff_lines or len(rendered) > MAX_DIFF_CHARACTERS
+    return rendered[:MAX_DIFF_CHARACTERS] + ("\n  ... (content diff truncated)" if truncated else "")

--- a/release_artifact_rebuild.py
+++ b/release_artifact_rebuild.py
@@ -14,7 +14,8 @@ import tempfile
 from pathlib import Path
 
 from binary_lock import BinaryLockError, load_binary_lock_from_revision
-from bin_artifact_contract import ArtifactContractError, build_game_artifact_inventory
+from artifact_diagnostics import MAX_LOG_CHARACTERS, content_diff, read_artifact_bytes
+from bin_artifact_contract import ArtifactContractError, _git_blob_entries, build_game_artifact_inventory
 from gamesymbol_snapshot_lib.config import load_contract
 from gamesymbol_snapshot_lib.errors import SnapshotConfigError, SnapshotMismatchError
 from gamesymbol_snapshot_lib.operations import collect_binary_metadata
@@ -314,9 +315,21 @@ def verify_release_rebuild(*, repo_root: str | Path, preparation: dict | str | P
             for path in set(actual_files) | set(expected_files)
             if actual_files.get(path) != expected_files.get(path)
         )
-        raise ReleaseArtifactRebuildError(
-            "fresh release artifacts differ from immutable Git truth:\n" + "\n".join(f"  {path}" for path in changed)
-        )
+        details = "fresh release artifacts differ from immutable Git truth:\n"
+        for index, path in enumerate(changed):
+            try:
+                expected_raw = _git_blob(repo_root, preparation["source_sha"], path) if path in expected_files else None
+                actual_raw, actual_error = read_artifact_bytes(
+                    Path(preparation["actual_artifact_root"]) / Path(path).relative_to("bin_artifacts")
+                )
+                detail = content_diff(path, expected_raw, actual_raw, actual_error=actual_error)
+            except (OSError, ValueError, ReleaseArtifactRebuildError) as exc:
+                detail = f"\n  {path}: content diagnostics unavailable: {exc}"
+            if len(details) + len(detail) > MAX_LOG_CHARACTERS:
+                details += f"\n  ... (diagnostics truncated; {len(changed) - index} files omitted)"
+                break
+            details += detail
+        raise ReleaseArtifactRebuildError(details)
     if actual.inventory_sha256 != preparation["expected_artifact_inventory_sha256"]:
         raise ReleaseArtifactRebuildError("fresh release aggregate artifact inventory digest mismatch")
     result = {
@@ -352,6 +365,94 @@ def load_release_rebuild_verification(path: str | Path) -> dict:
     return document
 
 
+def collect_failure_diagnostics(*, repo_root: Path, preparation_path: Path, destination: Path, error: str) -> None:
+    """Save original bytes without requiring the failed artifact contract to pass."""
+    repo_root = repo_root.resolve()
+    destination = Path(os.path.abspath(destination))
+    staging = Path(os.path.abspath(preparation_path)).parent
+    if destination == repo_root or repo_root in destination.parents:
+        raise ReleaseArtifactRebuildError("diagnostic destination must be outside the source checkout")
+    if destination == staging or staging in destination.parents:
+        raise ReleaseArtifactRebuildError("diagnostic destination must be outside the rebuild staging tree")
+    for component in (destination, *destination.parents):
+        if is_reparse_point(component):
+            raise ReleaseArtifactRebuildError(f"diagnostic destination contains a link: {component}")
+    destination.mkdir(parents=True, exist_ok=False)
+    _atomic_write(destination / "verification-error.txt", (error + "\n").encode("utf-8"))
+    errors = []
+    metadata = {
+        "source_sha": os.environ.get("SOURCE_SHA"),
+        "game_version": os.environ.get("GAMEVER"),
+        "repository": os.environ.get("GITHUB_REPOSITORY"),
+        "run_id": os.environ.get("GITHUB_RUN_ID"),
+        "run_attempt": os.environ.get("GITHUB_RUN_ATTEMPT"),
+        "collection_errors": errors,
+    }
+
+    def copy_evidence(source: Path, relative: Path) -> None:
+        raw, read_error = read_artifact_bytes(source)
+        if raw is None:
+            errors.append(f"{source}: {read_error or 'missing'}")
+            return
+        try:
+            _atomic_write(destination / relative, raw)
+        except OSError as exc:
+            errors.append(f"{source}: {exc}")
+
+    expected_source = None
+    copy_evidence(preparation_path, Path("release-rebuild-preparation.json"))
+    try:
+        # Load the safe copy; never follow a replaced preparation symlink.
+        preparation = load_release_rebuild_preparation(destination / "release-rebuild-preparation.json")
+        source_sha = preparation["source_sha"]
+        gamever = preparation["game_version"]
+        if not SHA_RE.fullmatch(source_sha) or not re.fullmatch(r"[A-Za-z0-9_.-]+", gamever) or gamever in (".", ".."):
+            raise ReleaseArtifactRebuildError("invalid diagnostic source SHA or GAMEVER")
+        metadata.update(source_sha=source_sha, game_version=gamever)
+        expected_source = (source_sha, gamever)
+        actual_root = staging / "actual-bin-artifacts"
+        if Path(os.path.abspath(preparation["actual_artifact_root"])) != actual_root:
+            raise ReleaseArtifactRebuildError("diagnostic actual root is not preparation-local")
+        copy_evidence(staging / "force-all-execution.json", Path("force-all-execution.json"))
+        # Reject root/ancestor links before walking, and child links before descending.
+        for component in (actual_root, *actual_root.parents):
+            if is_reparse_point(component):
+                raise ReleaseArtifactRebuildError(f"actual root contains a link: {component}")
+        if not actual_root.is_dir():
+            errors.append(f"{actual_root}: missing artifact root")
+        for current, directories, files in os.walk(
+            actual_root, followlinks=False, onerror=lambda exc: errors.append(str(exc))
+        ):
+            current_path = Path(current)
+            for directory in list(directories):
+                if is_reparse_point(current_path / directory):
+                    directories.remove(directory)
+                    errors.append(f"{current_path / directory}: skipped link/reparse point")
+            for filename in files:
+                source = current_path / filename
+                copy_evidence(source, Path("actual/bin_artifacts") / source.relative_to(actual_root))
+    except (OSError, ValueError, KeyError, TypeError, ArtifactContractError, ReleaseArtifactRebuildError) as exc:
+        errors.append(str(exc))
+    if expected_source is not None:
+        source_sha, gamever = expected_source
+        try:
+            prefix = f"bin_artifacts/{gamever}/"
+            for path, raw in _git_blob_entries(repo_root, prefix, source_sha).items():
+                relative = Path(path)
+                if (
+                    not path.startswith(prefix)
+                    or relative.is_absolute()
+                    or ".." in relative.parts
+                    or ":" in path
+                    or "\\" in path
+                ):
+                    raise ReleaseArtifactRebuildError(f"invalid diagnostic Git path: {path}")
+                _atomic_write(destination / "expected" / relative, raw)
+        except (OSError, ValueError, ArtifactContractError, ReleaseArtifactRebuildError) as exc:
+            errors.append(str(exc))
+    _atomic_write(destination / "diagnostics.json", _canonical_json_bytes(metadata))
+
+
 def parse_args(argv=None) -> argparse.Namespace:
     parser = argparse.ArgumentParser(description=__doc__)
     subparsers = parser.add_subparsers(dest="command", required=True)
@@ -365,6 +466,7 @@ def parse_args(argv=None) -> argparse.Namespace:
     verify.add_argument("--repo-root", default=".")
     verify.add_argument("--preparation", required=True)
     verify.add_argument("--output")
+    verify.add_argument("--diagnostics-dir", help="Fresh checkout-external directory for failure evidence")
     return parser.parse_args(argv)
 
 
@@ -383,8 +485,20 @@ def main(argv=None) -> int:
             result = verify_release_rebuild(repo_root=args.repo_root, preparation=args.preparation)
             if args.output:
                 _atomic_write(Path(args.output), _canonical_json_bytes(result))
-    except (OSError, UnicodeError, ReleaseArtifactRebuildError) as exc:
+    except Exception as exc:
+        # The CLI failure boundary also captures malformed or incomplete evidence.
         print(f"Error: {exc}", file=sys.stderr)
+        if args.command == "verify" and args.diagnostics_dir:
+            try:
+                collect_failure_diagnostics(
+                    repo_root=Path(args.repo_root),
+                    preparation_path=Path(args.preparation),
+                    destination=Path(args.diagnostics_dir),
+                    error=f"Error: {exc}",
+                )
+            except Exception as diagnostic_error:
+                # Best-effort evidence must never replace the verification failure.
+                print(f"Failure diagnostics unavailable: {diagnostic_error}", file=sys.stderr)
         return 1
     print(json.dumps(result, ensure_ascii=False, sort_keys=True))
     return 0

--- a/tests/run_test_suite.py
+++ b/tests/run_test_suite.py
@@ -53,6 +53,7 @@ RELEASE_INTEGRATION_MODULES = frozenset(
 )
 UNIT_MODULES = frozenset(
     {
+        "test_artifact_diagnostics",
         "test_agent_runner",
         "test_analysis_config",
         "test_atomic_json_write",
@@ -61,6 +62,7 @@ UNIT_MODULES = frozenset(
         "test_binsync_candidate",
         "test_binsync_publish",
         "test_bump_download",
+        "test_bump_publish_retry",
         "test_cnetworkmessages_dtor_preprocessor",
         "test_copy_depot_bin",
         "test_cs2fow_gamedata",

--- a/tests/test_artifact_diagnostics.py
+++ b/tests/test_artifact_diagnostics.py
@@ -1,0 +1,43 @@
+from __future__ import annotations
+
+import tempfile
+import unittest
+from pathlib import Path
+from unittest.mock import patch
+
+from artifact_diagnostics import content_diff, read_artifact_bytes
+
+
+class ArtifactDiagnosticsTests(unittest.TestCase):
+    def test_text_facts_and_diff(self):
+        result = content_diff("a.yaml", b"value: old\n", b"value: new\n")
+        for expected in ("size=11 sha256=sha256:", "-value: old", "+value: new"):
+            self.assertIn(expected, result)
+
+    def test_missing_binary_and_newline_only(self):
+        self.assertIn("expected: missing", content_diff("a", None, b"new\n"))
+        self.assertIn("+new", content_diff("a", None, b"new\n"))
+        self.assertIn("actual:   missing", content_diff("a", b"old\n", None))
+        self.assertIn("not UTF-8", content_diff("a", b"\xff", b"\xfe"))
+        self.assertIn("binary data", content_diff("a", b"\0a", b"\0b"))
+        self.assertIn("line endings", content_diff("a", b"a\r\n", b"a\n"))
+
+    def test_bounded_diff(self):
+        result = content_diff("a", b"old\n" * 100, b"new\n" * 100, max_diff_lines=5)
+        self.assertIn("truncated", result)
+        self.assertLess(len(result.splitlines()), 15)
+        result = content_diff("a", b"a" * 100000, b"b" * 100000)
+        self.assertLess(len(result), 20000)
+
+    def test_unreadable_file_is_a_diagnostic(self):
+        with tempfile.TemporaryDirectory() as temporary:
+            target = Path(temporary) / "a"
+            target.write_bytes(b"a")
+            with patch.object(Path, "read_bytes", side_effect=PermissionError("denied")):
+                raw, error = read_artifact_bytes(target)
+            self.assertIsNone(raw)
+            self.assertIn("denied", error)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_release_artifact_rebuild.py
+++ b/tests/test_release_artifact_rebuild.py
@@ -1,11 +1,14 @@
 from __future__ import annotations
 
 import json
+import contextlib
+import io
 import shutil
 import subprocess
 import tempfile
 import unittest
 from pathlib import Path
+from unittest.mock import patch
 
 import ida_analyze_bin
 import release_artifact_rebuild as rar
@@ -15,6 +18,142 @@ from tests.gamesymbol_snapshot_test_support import write_binary, write_config, w
 
 
 class ReleaseArtifactRebuildTests(unittest.TestCase):
+    def test_verify_failure_preserves_comparison_evidence(self):
+        for failure in ("drift", "missing", "extra", "invalid", "noncanonical", "report", "checkout"):
+            with self.subTest(failure=failure), tempfile.TemporaryDirectory() as temporary:
+                temp = Path(temporary)
+                root = temp / "repo"
+                root.mkdir()
+                source_sha = self._repository(root)
+                preparation = rar.prepare_release_rebuild(
+                    repo_root=root,
+                    source_sha=source_sha,
+                    game_version="1",
+                    binary_root=root / "bin",
+                    staging_root=temp / "rebuild",
+                )
+                shutil.copytree(root / "bin_artifacts", preparation["actual_artifact_root"], dirs_exist_ok=True)
+                self._write_execution_report(preparation)
+                relative = Path("1/server/A.windows.yaml")
+                expected = (root / "bin_artifacts" / relative).read_bytes()
+                target = Path(preparation["actual_artifact_root"]) / relative
+                if failure == "drift":
+                    target.write_bytes(
+                        canonical_symbol_yaml_bytes({"func_name": "A", "func_rva": "0x20"}, category="func")
+                    )
+                elif failure == "missing":
+                    target.unlink()
+                elif failure == "extra":
+                    target.with_name("extra.yaml").write_bytes(b"extra: true\n")
+                elif failure == "invalid":
+                    target.write_bytes(b"broken: [\n")
+                elif failure == "noncanonical":
+                    target.write_bytes(target.read_bytes() + b" ")
+                elif failure == "checkout":
+                    (root / "bin_artifacts" / relative).write_bytes(b"changed checkout\n")
+                else:
+                    Path(preparation["execution_report"]).unlink()
+                bundle = temp / "diagnostics"
+                error = io.StringIO()
+                with contextlib.redirect_stderr(error):
+                    code = rar.main(
+                        [
+                            "verify",
+                            "--repo-root",
+                            str(root),
+                            "--preparation",
+                            str(temp / "rebuild/release-rebuild-preparation.json"),
+                            "--diagnostics-dir",
+                            str(bundle),
+                            "--output",
+                            str(temp / "verified.json"),
+                        ]
+                    )
+                self.assertEqual(1, code)
+                self.assertFalse((temp / "verified.json").exists())
+                self.assertEqual(expected, (bundle / "expected/bin_artifacts" / relative).read_bytes())
+                self.assertEqual(
+                    b"changed checkout\n" if failure == "checkout" else expected,
+                    (root / "bin_artifacts" / relative).read_bytes(),
+                )
+                if target.exists():
+                    self.assertEqual(target.read_bytes(), (bundle / "actual/bin_artifacts" / relative).read_bytes())
+                else:
+                    self.assertFalse((bundle / "actual/bin_artifacts" / relative).exists())
+                metadata = json.loads((bundle / "diagnostics.json").read_bytes())
+                self.assertEqual(source_sha, metadata["source_sha"])
+                self.assertIn("Error:", (bundle / "verification-error.txt").read_text())
+                if failure == "drift":
+                    self.assertIn("sha256=", error.getvalue())
+                    self.assertIn("-func_rva: '0x10'", error.getvalue())
+                    self.assertIn("+func_rva: '0x20'", error.getvalue())
+                    with patch.object(rar, "MAX_LOG_CHARACTERS", 100):
+                        with self.assertRaisesRegex(rar.ReleaseArtifactRebuildError, "diagnostics truncated") as raised:
+                            rar.verify_release_rebuild(repo_root=root, preparation=preparation)
+                    self.assertLess(len(str(raised.exception)), 200)
+                if failure == "extra":
+                    self.assertEqual(
+                        b"extra: true\n", (bundle / "actual/bin_artifacts/1/server/extra.yaml").read_bytes()
+                    )
+                if failure == "report":
+                    self.assertTrue(metadata["collection_errors"])
+
+    def test_collection_skips_linked_tree_and_retains_other_evidence(self):
+        with tempfile.TemporaryDirectory() as temporary:
+            temp = Path(temporary)
+            root = temp / "repo"
+            root.mkdir()
+            source_sha = self._repository(root)
+            preparation = rar.prepare_release_rebuild(
+                repo_root=root,
+                source_sha=source_sha,
+                game_version="1",
+                binary_root=root / "bin",
+                staging_root=temp / "rebuild",
+            )
+            linked_tree = Path(preparation["actual_artifact_root"]) / "linked"
+            linked_tree.mkdir()
+            (linked_tree / "private.txt").write_text("must not copy")
+            original_check = rar.is_reparse_point
+            with patch.object(
+                rar, "is_reparse_point", side_effect=lambda path: path == linked_tree or original_check(path)
+            ):
+                rar.collect_failure_diagnostics(
+                    repo_root=root,
+                    preparation_path=temp / "rebuild/release-rebuild-preparation.json",
+                    destination=temp / "diagnostics",
+                    error="original",
+                )
+            self.assertFalse((temp / "diagnostics/actual/bin_artifacts/linked/private.txt").exists())
+            self.assertTrue((temp / "diagnostics/expected/bin_artifacts/1/server/A.windows.yaml").is_file())
+            metadata = json.loads((temp / "diagnostics/diagnostics.json").read_bytes())
+            self.assertTrue(any("skipped link" in error for error in metadata["collection_errors"]))
+
+    def test_missing_preparation_still_preserves_original_error(self):
+        with tempfile.TemporaryDirectory() as temporary:
+            temp = Path(temporary)
+            rar.collect_failure_diagnostics(
+                repo_root=temp / "repo",
+                preparation_path=temp / "staging/missing.json",
+                destination=temp / "diagnostics",
+                error="original failure",
+            )
+            self.assertEqual("original failure\n", (temp / "diagnostics/verification-error.txt").read_text())
+            metadata = json.loads((temp / "diagnostics/diagnostics.json").read_bytes())
+            self.assertTrue(metadata["collection_errors"])
+
+    def test_diagnostic_failure_does_not_replace_verification_error(self):
+        error = io.StringIO()
+        with (
+            patch.object(rar, "verify_release_rebuild", side_effect=rar.ReleaseArtifactRebuildError("original")),
+            patch.object(rar, "collect_failure_diagnostics", side_effect=OSError("disk full")),
+            contextlib.redirect_stderr(error),
+        ):
+            code = rar.main(["verify", "--preparation", "missing", "--diagnostics-dir", "unused"])
+        self.assertEqual(1, code)
+        self.assertIn("Error: original", error.getvalue())
+        self.assertIn("disk full", error.getvalue())
+
     def _git(self, root: Path, *arguments: str, input_text: str | None = None) -> str:
         result = subprocess.run(
             ["git", "-C", str(root), *arguments],
@@ -106,6 +245,20 @@ class ReleaseArtifactRebuildTests(unittest.TestCase):
             self.assertEqual(source_sha, result["source_sha"])
             self.assertEqual(1, result["file_count"])
             self.assertEqual(result, rar.load_release_rebuild_verification(verification_path))
+            with contextlib.redirect_stdout(io.StringIO()):
+                code = rar.main(
+                    [
+                        "verify",
+                        "--repo-root",
+                        str(root),
+                        "--preparation",
+                        str(temporary_root / "release-rebuild/release-rebuild-preparation.json"),
+                        "--diagnostics-dir",
+                        str(temporary_root / "diagnostics"),
+                    ]
+                )
+            self.assertEqual(0, code)
+            self.assertFalse((temporary_root / "diagnostics").exists())
 
     def test_verify_rejects_one_byte_drift_and_execution_tamper(self) -> None:
         with tempfile.TemporaryDirectory() as temporary:

--- a/trusted_artifact_pr.py
+++ b/trusted_artifact_pr.py
@@ -4,7 +4,6 @@
 from __future__ import annotations
 
 import argparse
-import difflib
 import hashlib
 import json
 import os
@@ -17,6 +16,7 @@ from pathlib import Path
 
 import yaml
 
+from artifact_diagnostics import content_diff, read_artifact_bytes
 from binary_lock import BinaryLockError, load_binary_lock_from_revision
 from bin_artifact_contract import (
     ArtifactContractError,
@@ -1405,48 +1405,20 @@ def _drift_content_diff(
     actual_root: Path,
     max_diff_lines: int = 40,
 ) -> str:
-    """Render an expected-vs-actual content diff for one drifted artifact.
-
-    The expected side is the source checkout's Git-tracked artifact (bound to the
-    merge tree by the caller's filesystem digest checks); the actual side is the
-    isolated rebuild output. Text artifacts (YAML) get a line diff so a drift
-    failure pinpoints the differing fields without runner access; anything else
-    falls back to size and digest facts.
-    """
+    """Render checkout bytes bound to the merge tree against isolated output."""
     expected_path = repo_root / "bin_artifacts" / gamever / relative
     actual_path = actual_root / gamever / relative
 
-    def _describe(path: Path) -> str:
-        if not path.is_file():
-            return "missing"
-        raw = path.read_bytes()
-        return f"size={len(raw)} sha256={_sha256(raw)}"
-
-    facts = (
-        f"\n  artifact: bin_artifacts/{gamever}/{relative}"
-        f"\n  expected: {_describe(expected_path)}"
-        f"\n  actual:   {_describe(actual_path)}"
+    expected_raw, expected_error = read_artifact_bytes(expected_path)
+    actual_raw, actual_error = read_artifact_bytes(actual_path)
+    return content_diff(
+        f"bin_artifacts/{gamever}/{relative}",
+        expected_raw,
+        actual_raw,
+        expected_error=expected_error,
+        actual_error=actual_error,
+        max_diff_lines=max_diff_lines,
     )
-    try:
-        expected_raw = expected_path.read_bytes()
-        actual_raw = actual_path.read_bytes()
-    except OSError:
-        return facts
-    try:
-        expected_lines = expected_raw.decode("utf-8").splitlines()
-        actual_lines = actual_raw.decode("utf-8").splitlines()
-    except UnicodeDecodeError:
-        return facts
-    diff_lines = list(
-        difflib.unified_diff(expected_lines, actual_lines, fromfile="expected", tofile="actual", lineterm="")
-    )
-    if not diff_lines:
-        return facts
-    shown = diff_lines[:max_diff_lines]
-    suffix = (
-        "" if len(diff_lines) <= max_diff_lines else f"\n  ... ({len(diff_lines) - max_diff_lines} more diff lines)"
-    )
-    return facts + "\n  content diff (expected -> actual):\n    " + "\n    ".join(shown) + suffix
 
 
 def validate_selected_execution_records(report: dict, version: dict, *, drift_context=None) -> None:

--- a/trusted_pr_context.py
+++ b/trusted_pr_context.py
@@ -30,6 +30,7 @@ TRUSTED_FILE_PATHS = (
     ".gitmodules",
     "trusted_pr_context.py",
     "trusted_artifact_pr.py",
+    "artifact_diagnostics.py",
     "new_gamever_artifact.py",
     "gamever_baseline.py",
     "bin_artifact_contract.py",


### PR DESCRIPTION
Release rebuild verification failures currently leave only runner logs, and valid artifact drift does not show the changed YAML fields. This change prints bounded expected/actual byte facts and unified diffs, and uploads a separate diagnostic artifact whenever the release rebuild verification step fails, in both publication modes.

The diagnostic artifact preserves raw rebuilt files, expected Git blobs bound to the preparation's immutable source SHA, preparation/execution evidence, the original verification error, and run metadata. Missing or unreadable evidence is recorded; links are not followed. Names include GAMEVER, run ID and attempt, with 30-day retention. Verification remains failed and publication remains blocked. Analysis failures that skip verification are outside this change.

PR and release verification share the new diff utility, which is included in the trusted-tool inventory. The test-suite registry also includes the existing `test_bump_publish_retry` module, whose missing registration previously prevented suite startup.

## Validation

- Focused diagnostics/rebuild tests: 13 passed.
- Trusted PR/context and release bundle regression tests: 48 passed.
- Unit suite: 1215 passed with `CS2VIBE_STRING_MIN_LENGTH` set to empty in the test process. The first run had two failures caused by the local `.env` value `4`; the clean baseline worktree passed, and clearing that single test-process setting resolved both failures without changing `.env`.
- Repository-contract suite: 84 passed; release-integration suite: 15 passed.
- Repository artifact contract: all 16 GAMEVER inventories and 51,377 tracked artifact files passed.
- `uv run python format_repo_files.py --check`, `actionlint .github/workflows/build-on-self-runner.yml`, and `git diff --cached --check`: passed.
- Repository PR validation remains owned by trusted `source-artifact-required` / `pr-validate` CI.

## Pending CI acceptance

A controlled GitHub Actions verify failure has not been run. Confirm the diagnostic artifact can be downloaded and compared, contains the expected and actual byte trees, and leaves the build failed with publication blocked. Local fixture tests verify evidence collection and nonzero exit behavior, but do not substitute for this upload/download check.

Closes #939
