### PR TITLE
feat(pages): deploy updated code against an existing Release

### DIFF
--- a/.github/workflows/deploy-pages.yml
+++ b/.github/workflows/deploy-pages.yml
@@ -20,6 +20,10 @@ on:
         description: Verified Release manifest SHA-256
         required: true
         type: string
+      deployment_sha:
+        description: Deployment code commit that must be in main history; defaults to the Release source commit
+        required: false
+        type: string
 permissions: {}
 concurrency:
   group: deploy-pages
@@ -27,11 +31,15 @@ concurrency:
 jobs:
   resolve-release:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     outputs:
       release_id: ${{ steps.identity.outputs.release_id }}
       release_tag: ${{ steps.identity.outputs.release_tag }}
       source_sha: ${{ steps.identity.outputs.source_sha }}
       manifest_sha256: ${{ steps.identity.outputs.manifest_sha256 }}
+      deployment_sha: ${{ steps.deployment.outputs.deployment_sha }}
+      deployment_override: ${{ steps.deployment.outputs.deployment_override }}
     steps:
       - name: Resolve immutable published Release identity
         id: identity
@@ -71,6 +79,49 @@ jobs:
           "release_tag=$releaseTag" | Out-File $env:GITHUB_OUTPUT -Encoding utf8 -Append
           "source_sha=$sourceSha" | Out-File $env:GITHUB_OUTPUT -Encoding utf8 -Append
           "manifest_sha256=$manifestDigest" | Out-File $env:GITHUB_OUTPUT -Encoding utf8 -Append
+      - name: Checkout deployment code helper
+        if: ${{ github.event_name != 'workflow_dispatch' || inputs.deployment_sha == '' }}
+        uses: actions/checkout@v5
+        with:
+          ref: main
+          fetch-depth: 1
+          sparse-checkout: |
+            /pages_deployment_sha.py
+          sparse-checkout-cone-mode: false
+          persist-credentials: false
+      - name: Checkout trusted main history for the deployment commit
+        if: ${{ github.event_name == 'workflow_dispatch' && inputs.deployment_sha != '' }}
+        uses: actions/checkout@v5
+        with:
+          ref: main
+          fetch-depth: 0
+          sparse-checkout: |
+            /pages_deployment_sha.py
+          sparse-checkout-cone-mode: false
+          persist-credentials: false
+      - name: Resolve deployment code commit
+        id: deployment
+        shell: bash
+        env:
+          SOURCE_SHA: ${{ steps.identity.outputs.source_sha }}
+          REQUESTED_DEPLOYMENT_SHA: ${{ inputs.deployment_sha }}
+        run: |
+          set -euo pipefail
+          python3 pages_deployment_sha.py \
+            --source-sha "$SOURCE_SHA" \
+            --requested-sha "$REQUESTED_DEPLOYMENT_SHA" \
+            --repository-root "$GITHUB_WORKSPACE" \
+            --main-ref HEAD \
+            --github-output "$GITHUB_OUTPUT"
+      - name: Record deployment code and Release source SHAs
+        shell: bash
+        run: |
+          {
+            echo "### Deploy Pages resolution"
+            echo "- Release source SHA (data origin): \`${{ steps.identity.outputs.source_sha }}\`"
+            echo "- Deployment code SHA: \`${{ steps.deployment.outputs.deployment_sha }}\`"
+            echo "- Deployment commit override: \`${{ steps.deployment.outputs.deployment_override }}\`"
+          } >> "$GITHUB_STEP_SUMMARY"
   build:
     needs: resolve-release
     runs-on: ubuntu-latest
@@ -82,7 +133,7 @@ jobs:
     steps:
       - uses: actions/checkout@v5
         with:
-          ref: ${{ needs.resolve-release.outputs.source_sha }}
+          ref: ${{ needs.resolve-release.outputs.deployment_sha }}
           persist-credentials: false
       - uses: astral-sh/setup-uv@v9.0.0
       - uses: actions/setup-node@v5
@@ -183,7 +234,7 @@ jobs:
     steps:
       - uses: actions/checkout@v5
         with:
-          ref: ${{ needs.resolve-release.outputs.source_sha }}
+          ref: ${{ needs.resolve-release.outputs.deployment_sha }}
           persist-credentials: false
       - uses: actions/setup-node@v5
         with:

--- a/pages/README.md
+++ b/pages/README.md
@@ -32,6 +32,10 @@ Historical versions without compatible Releases are restored from a pinned `page
 
 The Vite build validates each staged schema-5 snapshot and emits index schema v4. Every symbol and gamedata response remains content-addressed, and after deployment the workflow fetches the public Pages responses and recomputes their bytes so CDN delivery is checked against the exact build.
 
+### Re-deploying an existing Release with updated deployment code (maintainers only)
+
+An automatic `pages-release-published` deployment checks out and builds the deployment code from the triggering Release's `source_sha`, so re-running an old Release keeps running the old Pages code. A manual `workflow_dispatch` may pass `deployment_sha`: a full commit SHA that must already be in trusted `main` history. Pages code, scripts and the pinned historical manifest then come from that commit, while the Release tag, manifest, SHA256SUMS and assets keep being verified against the unchanged `source_sha`. Both commits are recorded in the run summary. The override fails closed before building when the commit is unknown or is not an ancestor of `main`; leaving `deployment_sha` empty reproduces the automatic behavior.
+
 ### Updating the pinned historical archive (maintainers only)
 
 `pages/legacy_inputs_tool.py` is the maintainer-only offline importer. The deployment workflow never calls its download or extraction commands.

--- a/pages_deployment_sha.py
+++ b/pages_deployment_sha.py
@@ -1,0 +1,97 @@
+#!/usr/bin/env python3
+"""Resolve the Pages deployment code commit and require it to be trusted main history."""
+
+from __future__ import annotations
+
+import argparse
+import os
+import re
+import subprocess
+import sys
+from pathlib import Path
+
+SHA_RE = re.compile(r"^[0-9a-f]{40}$")
+
+
+class PagesDeploymentShaError(Exception):
+    """Raised when the Pages deployment code commit cannot be trusted."""
+
+
+def _run_git(repository_root: Path, *arguments: str) -> subprocess.CompletedProcess:
+    try:
+        return subprocess.run(
+            ["git", "-C", str(repository_root), *arguments],
+            capture_output=True,
+            text=True,
+            check=False,
+        )
+    except OSError as exc:
+        raise PagesDeploymentShaError(f"unable to run git: {exc}") from exc
+
+
+def normalize_sha(value: str, label: str) -> str:
+    normalized = str(value).strip().lower()
+    if not SHA_RE.fullmatch(normalized):
+        raise PagesDeploymentShaError(f"{label} is not a full lowercase commit SHA")
+    return normalized
+
+
+def resolve_deployment_sha(source_sha: str, requested_sha: str | None) -> tuple[str, bool]:
+    """Return the deployment code commit and whether it overrides the Release source commit."""
+    source = normalize_sha(source_sha, "Release source SHA")
+    requested = "" if requested_sha is None else str(requested_sha).strip()
+    if not requested:
+        return source, False
+    return normalize_sha(requested, "deployment code SHA"), True
+
+
+def verify_commit_on_main(repository_root: Path, deployment_sha: str, main_ref: str = "HEAD") -> None:
+    """Require the deployment commit to exist and be an ancestor of the trusted main ref."""
+    root = Path(repository_root)
+    discovered = _run_git(root, "rev-parse", "--is-inside-work-tree")
+    if discovered.returncode or discovered.stdout.strip() != "true":
+        raise PagesDeploymentShaError(f"deployment code checkout is not a git work tree: {root}")
+    if _run_git(root, "cat-file", "-e", f"{deployment_sha}^{{commit}}").returncode:
+        raise PagesDeploymentShaError(
+            f"deployment commit does not exist or is not reachable from main: {deployment_sha}"
+        )
+    if _run_git(root, "rev-parse", "--verify", f"{main_ref}^{{commit}}").returncode:
+        raise PagesDeploymentShaError(f"trusted main ref cannot be resolved: {main_ref}")
+    if _run_git(root, "merge-base", "--is-ancestor", deployment_sha, main_ref).returncode:
+        raise PagesDeploymentShaError(f"deployment commit is not in trusted main history: {deployment_sha}")
+
+
+def _parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--source-sha", required=True)
+    parser.add_argument("--requested-sha", default="")
+    parser.add_argument("--repository-root", default="")
+    parser.add_argument("--main-ref", default="HEAD")
+    parser.add_argument("--github-output", default="")
+    return parser
+
+
+def main(argv=None) -> int:
+    args = _parser().parse_args(argv)
+    try:
+        deployment_sha, override = resolve_deployment_sha(args.source_sha, args.requested_sha)
+        if override:
+            if not args.repository_root:
+                raise PagesDeploymentShaError("a deployment code checkout is required for a deployment SHA override")
+            verify_commit_on_main(Path(args.repository_root), deployment_sha, args.main_ref)
+    except (OSError, PagesDeploymentShaError, ValueError) as exc:
+        print(f"Pages deployment SHA error: {exc}", file=sys.stderr)
+        return 1
+    outputs = {"deployment_sha": deployment_sha, "deployment_override": "true" if override else "false"}
+    output_path = args.github_output or os.environ.get("GITHUB_OUTPUT", "")
+    if output_path:
+        with open(output_path, "a", encoding="utf-8") as handle:
+            for key, value in outputs.items():
+                handle.write(f"{key}={value}\n")
+    for key, value in outputs.items():
+        print(f"{key}={value}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/run_test_suite.py
+++ b/tests/run_test_suite.py
@@ -45,6 +45,7 @@ REDIS_INTEGRATION_PREFIXES = (
 RELEASE_INTEGRATION_MODULES = frozenset(
     {
         "test_legacy_inputs_tool",
+        "test_pages_deployment_sha",
         "test_pages_legacy_input",
         "test_pages_release_input",
         "test_release_bundle",

--- a/tests/test_pages_deployment_sha.py
+++ b/tests/test_pages_deployment_sha.py
@@ -1,0 +1,153 @@
+from __future__ import annotations
+
+import contextlib
+import io
+import subprocess
+import tempfile
+import unittest
+from pathlib import Path
+
+import pages_deployment_sha as pds
+
+SOURCE_SHA = "a" * 40
+
+
+def _git(cwd: Path, *arguments: str) -> str:
+    result = subprocess.run(["git", *arguments], cwd=cwd, capture_output=True, text=True, check=True)
+    return result.stdout.strip()
+
+
+def _commit(repository: Path, relative_path: str, content: str, message: str) -> str:
+    target = repository / relative_path
+    target.parent.mkdir(parents=True, exist_ok=True)
+    target.write_text(content, encoding="utf-8", newline="\n")
+    _git(repository, "add", "--all")
+    _git(repository, "commit", "-q", "-m", message)
+    return _git(repository, "rev-parse", "HEAD")
+
+
+def _repository_with_main_and_unmerged_commits(root: Path) -> dict[str, object]:
+    repository = root / "repository"
+    repository.mkdir()
+    _git(root, "init", "-q", str(repository))
+    _git(repository, "config", "user.name", "test")
+    _git(repository, "config", "user.email", "test@example.invalid")
+    source_sha = _commit(repository, "README.md", "data\n", "source")
+    default_branch = _git(repository, "rev-parse", "--abbrev-ref", "HEAD")
+    deployment_sha = _commit(repository, "code.txt", "deployment\n", "deployment")
+    _git(repository, "checkout", "-q", "-b", "unmerged", source_sha)
+    unmerged_sha = _commit(repository, "side.txt", "side\n", "unmerged")
+    _git(repository, "checkout", "-q", default_branch)
+    return {
+        "repository": repository,
+        "source_sha": source_sha,
+        "deployment_sha": deployment_sha,
+        "unmerged_sha": unmerged_sha,
+    }
+
+
+class ResolveDeploymentShaTests(unittest.TestCase):
+    def test_defaults_to_the_release_source_commit(self) -> None:
+        for requested in (None, "", "   "):
+            with self.subTest(requested=requested):
+                self.assertEqual((SOURCE_SHA, False), pds.resolve_deployment_sha(SOURCE_SHA, requested))
+
+    def test_accepts_an_explicit_uppercase_commit(self) -> None:
+        requested = "B" * 40
+        self.assertEqual((requested.lower(), True), pds.resolve_deployment_sha(SOURCE_SHA, requested))
+
+    def test_rejects_invalid_commits(self) -> None:
+        with self.assertRaises(pds.PagesDeploymentShaError):
+            pds.resolve_deployment_sha("not-a-sha", "")
+        with self.assertRaises(pds.PagesDeploymentShaError):
+            pds.resolve_deployment_sha(SOURCE_SHA, "b" * 39)
+        with self.assertRaises(pds.PagesDeploymentShaError):
+            pds.resolve_deployment_sha(SOURCE_SHA, "z" * 40)
+
+
+class VerifyCommitOnMainTests(unittest.TestCase):
+    def test_accepts_main_history_and_rejects_unmerged_or_unknown_commits(self) -> None:
+        with tempfile.TemporaryDirectory() as temporary:
+            repository_state = _repository_with_main_and_unmerged_commits(Path(temporary))
+            repository = repository_state["repository"]
+            source_sha = repository_state["source_sha"]
+            deployment_sha = repository_state["deployment_sha"]
+            unmerged_sha = repository_state["unmerged_sha"]
+
+            pds.verify_commit_on_main(repository, source_sha)
+            pds.verify_commit_on_main(repository, deployment_sha)
+            self.assertNotEqual(source_sha, deployment_sha)
+
+            with self.assertRaises(pds.PagesDeploymentShaError):
+                pds.verify_commit_on_main(repository, unmerged_sha)
+            with self.assertRaises(pds.PagesDeploymentShaError):
+                pds.verify_commit_on_main(repository, "f" * 40)
+
+    def test_rejects_a_directory_that_is_not_a_git_work_tree(self) -> None:
+        with tempfile.TemporaryDirectory() as temporary:
+            with self.assertRaises(pds.PagesDeploymentShaError):
+                pds.verify_commit_on_main(Path(temporary), SOURCE_SHA)
+
+
+class DeploymentShaCliTests(unittest.TestCase):
+    def test_records_an_override_for_main_history_and_rejects_an_unmerged_commit(self) -> None:
+        with tempfile.TemporaryDirectory() as temporary:
+            root = Path(temporary)
+            repository_state = _repository_with_main_and_unmerged_commits(root)
+            repository = repository_state["repository"]
+            source_sha = repository_state["source_sha"]
+            deployment_sha = repository_state["deployment_sha"]
+            unmerged_sha = repository_state["unmerged_sha"]
+            output_path = root / "github-output.txt"
+
+            with contextlib.redirect_stdout(io.StringIO()):
+                accepted = pds.main(
+                    [
+                        "--source-sha",
+                        source_sha,
+                        "--requested-sha",
+                        deployment_sha,
+                        "--repository-root",
+                        str(repository),
+                        "--github-output",
+                        str(output_path),
+                    ]
+                )
+            self.assertEqual(0, accepted)
+            self.assertEqual(
+                f"deployment_sha={deployment_sha}\ndeployment_override=true\n",
+                output_path.read_text(encoding="utf-8"),
+            )
+
+            with contextlib.redirect_stdout(io.StringIO()), contextlib.redirect_stderr(io.StringIO()):
+                rejected = pds.main(
+                    [
+                        "--source-sha",
+                        source_sha,
+                        "--requested-sha",
+                        unmerged_sha,
+                        "--repository-root",
+                        str(repository),
+                        "--github-output",
+                        str(output_path),
+                    ]
+                )
+            self.assertEqual(1, rejected)
+            self.assertEqual(
+                f"deployment_sha={deployment_sha}\ndeployment_override=true\n",
+                output_path.read_text(encoding="utf-8"),
+            )
+
+    def test_defaults_to_the_source_commit_without_a_checkout(self) -> None:
+        with tempfile.TemporaryDirectory() as temporary:
+            output_path = Path(temporary) / "github-output.txt"
+            with contextlib.redirect_stdout(io.StringIO()):
+                self.assertEqual(0, pds.main(["--source-sha", SOURCE_SHA, "--github-output", str(output_path)]))
+            self.assertEqual(
+                f"deployment_sha={SOURCE_SHA}\ndeployment_override=false\n",
+                output_path.read_text(encoding="utf-8"),
+            )
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

- Add an optional `deployment_sha` input to the manual `Deploy Pages` trigger so a redeploy can build Pages code, scripts and the pinned historical manifest from a commit that is already in trusted `main` history.
- Keep the immutable Release verification chain unchanged: the Release tag, manifest, SHA256SUMS and assets are still validated against that Release's own `source_sha`; `deployment_sha` only selects which trusted code is checked out and built.
- `resolve-release` resolves the deployment commit (defaulting to `source_sha`, preserving automatic `pages-release-published` behavior), fails closed when an override is unknown or not an ancestor of `main`, records both SHAs in the run summary, and the `build`/`archive` jobs check out the resolved commit.
- Sparse checkouts use non-cone mode with a leading-slash pattern; the explicit `filter` input is omitted because it overrides `sparse-checkout`.

This allows redeploying existing game data (e.g. 14181) with the current Pages code without republishing the Release, moving its tag or editing its attachments.

## Test plan

- [x] `uv run python -m unittest tests.test_pages_deployment_sha -v` — 7 new tests
- [x] `uv run python tests/run_test_suite.py release-integration -b` — 54 passed
- [x] `uv run python tests/run_test_suite.py all -b` — 1426 run, 0 failures, 3 skipped
- [x] `uv run python format_repo_files.py --check` — clean
- [x] Real-repo check: `deployment_sha` in `main` accepted, a `pages-snapshots`-only commit rejected
- [x] Local git simulation of the non-cone sparse checkout sequence materializes only `pages_deployment_sha.py` and the ancestry check still works
- [ ] First real run: manual `Deploy Pages` on `main` with `deployment_sha` = the merge commit of this PR, triggering Release 14181 and `source_sha` unchanged