### PR TITLE
docs(pages): document pinned archive delivery and failure modes

### DIFF
--- a/memory/lessons/Pinned historical Pages archive and regression prevention (issue 958).md
+++ b/memory/lessons/Pinned historical Pages archive and regression prevention (issue 958).md
@@ -1,0 +1,50 @@
+---
+title: Pinned historical Pages archive and regression prevention (issue 958)
+type: lesson
+permalink: cs2-vibesignatures/lessons/pinned-historical-pages-archive-and-regression-prevention-issue-958
+tags:
+- pages
+- legacy-archive
+- deploy-pages
+- regression-prevention
+- issue-958
+---
+
+
+# 固定历史 Pages 归档与防回归（issue 958）
+
+## 触发信号
+
+- 线上 `gamesymbols/index.json` 只剩最近版本，历史版本消失，旧内容寻址 URL（如 `14178b.3b967f18c5ebd488afb824915cc903d6d36c67c0145e485db3c1ec027a8e8ff1.json`）返回 404。
+- 有一次“切换数据来源”的改动：Pages 构建从“合并 `pages-snapshots` 分支”改为“只读新格式 Release manifest”，但迁移遗漏了历史数据来源。
+- 需要在不依赖旧 Release API/附件可用性的前提下恢复历史 gamesymbols 与历史 gamedata。
+
+## 根因 / 约束
+
+- 单一数据来源切换会静默丢掉旧来源覆盖的数据集；构建成功不代表数据齐全，索引缺版本不会让构建失败。
+- 历史数据只能一次性离线导入；正常部署不得再下载历史 assets、解压历史 7z 或写归档分支。
+- Git 归档字节必须跨平台稳定：Windows 检出会把 LF 改写成 CRLF，导致哈希与清单不一致，且同提交的 `checkout --force` 会因 stat 缓存不重写文件。
+- 部署用浅检出（`fetch-depth: 1`），没有完整历史，因此不能做祖先校验，只能校验 checkout 目标 SHA 与实际逐文件 inventory。
+- 手动触发部署时，部署代码取自 Release 的 `source_sha`；重跑旧 Release 只会运行旧代码，不会加载新脚本。
+
+## 正确做法
+
+- 把历史 gamesymbols 与历史 gamedata 一次性固化到 `pages-snapshots` 的一个新提交，并在主分支用受版本控制清单 `pages/legacy-inputs.json` 固定 `archiveCommit` + 完整 inventory + 每版 `selected` + `excluded[]` + `importProvenance`；原 asset 映射与排除原因另存 `pages/legacy-gamedata-sources.json`。
+- 部署两个接入点：build job 在 Release hydration 成功后、Vite build 前补历史 gamedata；archive job 在写最终 verification manifest 前合并历史 gamesymbols。两者只读消费同一固定提交，任一历史输入缺失或损坏即中止 upload/deploy。
+- 归档分支根 `.gitattributes` 标注 `gamesymbols/**` 与 `gamedata/**` 为 `text eol=lf`；核验用 git blob SHA-1（`blob <len>\0<data>`），而非工作树字节。
+- 数据归属有分歧时不静默选取：记录选择依据与双方哈希（`importProvenance.gamedataSource.differences`），人工审定后再固定。
+- 需要“用新代码重部署旧 Release 数据”时，用 `workflow_dispatch` 的 `deployment_sha`（必须是 `main` 祖先）选择部署代码，`source_sha` 保持原 Release 来源用于验证；不要修改旧 Release、移动 tag 或重跑旧 Release 期待新代码。
+- 归档提交必须远端可达后才能启用引用它的清单/workflow；发布只用 fast-forward，绝不重写已发布归档历史。
+
+## 验证方式
+
+- 双运行时清单校验：Python 用 `object_pairs_hook` 拒绝重复键，Node 用“重编码为 canonical JSON 后与原文逐字节相等”；两者对同一组 fixture 语义一致。**不要**用正则/splice 构造重复键样例（canonical 会排序 key，容易构造出一个恰好合法的清单）。
+- 合并后逐项断言结果目录包含清单内全部历史文件的 path/size/sha256；不要依赖 CDN 校验兜底——旧文件若未复制，最终 manifest 也可能不含它。
+- 幂等：重复执行补数据与合并，最终资产字节一致；已存在整版本记 `skipped_existing`，不比较不覆盖。
+- 端到端：真实 Release hydration → 补历史 gamedata → build → 合并历史 gamesymbols → `verify:gamesymbols` / `verify:gamedata` → 上线后核对两个索引、已知旧 URL 与最终 CDN 字节校验。
+- 上线后确认版本集合等于“本次有效新 Release 集合 ∪ 对应固定历史集合”，总数为动态值，不写死具体版本或总数。
+
+## 适用范围
+
+- Pages 静态数据（gamesymbols/gamedata）的历史恢复与固定归档维护。
+- 任何“切换数据来源后必须保底旧集合”的迁移；固定清单 + fail-closed 校验 + 只读消费的防回归思路可复用到其他清单驱动的部署。

--- a/pages/README.md
+++ b/pages/README.md
@@ -47,6 +47,68 @@ An automatic `pages-release-published` deployment checks out and builds the depl
 
 The recorded checksums prove byte identity of the imported historical assets; they are not build attestations for new-format Releases. The archive commit carries a root `.gitattributes` marking both data subtrees `text eol=lf` so a checkout on any platform yields the exact bytes the manifest pins; without it Windows checkouts would rewrite line endings and fail verification.
 
+The pinned record is spread across two version-controlled files. `pages/legacy-inputs.json` fixes `archiveCommit`, the complete historical inventory, the per-version selected index entries, `excluded[]`, and `importProvenance` (`sourceArchiveCommit`, `importBaseCommit`, `selectedBasis`, the `gamedataSource` selection reason with both-side hashes for every byte difference, and the original Release/asset identities). `pages/legacy-gamedata-sources.json` lists the 14 pinned gamedata Release assets and the 18 excluded pre-canonical versions. Update both whenever the archive changes.
+
+### First enablement and refreshing the pinned archive (maintainers only)
+
+The pinned archive commit must be reachable from `pages-snapshots` before any deployment consumes a manifest that references it:
+
+1. Publish the reviewed archive commit with a fast-forward push; never rewrite published archive history.
+2. Merge the pinned manifest together with the scripts and workflow that consume it.
+3. Trigger `Deploy Pages` from `main`. Either publish a new Release whose `source_sha` contains the change, or dispatch manually with `deployment_sha` set to the `main` commit that contains it — the manual path needs no new Release.
+
+A refresh follows the same order: run the importer, review its diff/inventory/volume report, publish the new archive commit, then update `archiveCommit` together with the inventory, selected entries and provenance in a PR before deploying.
+
+### Local deployment build and failure modes (maintainers only)
+
+Reproduce the deployment chain locally:
+
+```powershell
+# 0. Check out the pinned archive read-only (archiveCommit from pages/legacy-inputs.json)
+git clone --filter=blob:none https://github.com/HLND2T/CS2_VibeSignatures.git pages-snapshots
+git -C pages-snapshots checkout <archiveCommit>
+
+# 1. Hydrate a fresh verified Release staging tree (the output root must not exist yet)
+$env:GH_TOKEN = "<token>"
+uv run python pages_release_input.py `
+  --repository HLND2T/CS2_VibeSignatures `
+  --release-id <id> --release-tag <tag> `
+  --source-sha <sha> --manifest-sha256 <sha256> `
+  --output-root "$env:TEMP\pages-release-input" `
+  --receipt "$env:TEMP\pages-release-input.json"
+
+# 2. Supplement historical gamedata into the staging tree
+uv run python pages_legacy_input.py `
+  --manifest pages\legacy-inputs.json `
+  --archive-root pages-snapshots `
+  --staging "$env:TEMP\pages-release-input" `
+  --receipt "$env:TEMP\pages-legacy-gamedata.json"
+
+# 3. Build, merge historical game symbols, verify
+$env:PAGES_RELEASE_INPUT_ROOT = "$env:TEMP\pages-release-input"
+cd pages
+npm ci
+npm run build
+node mergeLegacyGameSymbols.mjs `
+  --directory dist/gamesymbols `
+  --archive ..\pages-snapshots\gamesymbols `
+  --manifest legacy-inputs.json `
+  --receipt "$env:TEMP\pages-legacy-gamesymbols.json"
+npm run verify:gamesymbols
+npm run verify:gamedata
+```
+
+Repeated runs must produce byte-identical assets; a second `pages_legacy_input.py` run reports versions it already staged as `skipped_existing` without comparing or overwriting them. Every failure is fail-closed and names the input that disagreed:
+
+- `PAGES_RELEASE_INPUT_ROOT is required for Pages development and builds` (`pages/vite.config.ts`) — the staging root is unset or absent.
+- Release hydration rejects a repository outside the allowlist, a Release whose tag/source/manifest SHA disagrees with its manifest, an asset allowlist or `SHA256SUMS` mismatch, or extracted gamedata that differs from the manifest, then removes the staging root it was building.
+- The manifest parser rejects non-canonical bytes, duplicate JSON keys, unknown or missing fields, unsafe paths, and unsorted inventories.
+- Historical gamedata supplementation aborts on any archive inventory or byte mismatch and removes only the versions it added, leaving existing inputs intact.
+- The game-symbol merge aborts on archive inventory drift, same-path different bytes, a selected body that is not indexable schema 3, or an index entry that disagrees with its body, and leaves the previous valid `dist/gamesymbols` in place.
+- Deploy-time archive verification compares `rev-parse HEAD` with `archiveCommit` and requires the object to exist; it deliberately performs no ancestry check because the deploy checkout is shallow.
+- A Windows checkout that rewrites line endings fails verification. The archive commit marks both data subtrees `text eol=lf`; compare git blob hashes rather than worktree bytes when investigating.
+- Post-deploy CDN verification failing means the public response bytes differ from the built `dist`; the run fails after publishing, and the manifests in that run's verification artifact show which asset disagreed.
+
 For an exact Pages origin:
 
 ```powershell


### PR DESCRIPTION
## Summary

Completes the #958 delivery docs (TODO 7):

- Point at the two version-controlled provenance files: `pages/legacy-inputs.json` (`archiveCommit`, full inventory, per-version `selected`, `excluded[]`, `importProvenance`) and `pages/legacy-gamedata-sources.json` (14 pinned gamedata assets, 18 excluded pre-canonical versions).
- Add the first-enablement and pinned-archive refresh order: the archive commit must be reachable first, then merge the manifest plus the scripts/workflow that consume it, then trigger `Deploy Pages` from `main` via a new Release whose `source_sha` contains the change or a manual `deployment_sha`.
- Add a local deployment build walkthrough and the fail-closed failure modes for Release hydration, manifest parsing, historical gamedata supplementation, game-symbol merge, pinned archive verification, Windows line endings and post-deploy CDN verification.
- Add a memory lesson following the trigger / root-cause / practice / verification / scope template, recording the data-source migration omission, archive byte constraints and regression-prevention checks.

## Pinned archive volumes (commit `87856ad9`, `pages-snapshots`)

| Subtree | Files | Bytes |
|---|---|---|
| `gamesymbols/` | 113 | 197.14 MiB |
| `gamedata/` | 260 | 3.41 MiB |
| total | 373 | ~200.55 MiB |

## Verification

- `uv run python format_repo_files.py --check` — clean
- Docs-only plus a memory note; no code, script or workflow behaviour changed.

## Rollback

Revert this commit. It only affects documentation and memory notes, so rollback has no deployment impact.